### PR TITLE
refactor: revisit parsing

### DIFF
--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -50,9 +50,9 @@ impl Parse for Contract {
         let args = Punctuated::<ContractArg, Token![,]>::parse_terminated(input)?;
 
         let mut last_arg_order: Option<ArgOrder> = None;
-        let mut binds_pattern: Option<Pat> = None;
         let mut requires: Vec<Condition> = vec![];
         let mut maintains: Vec<Condition> = vec![];
+        let mut binds_pattern: Option<Pat> = None;
         let mut ensures_exprs: Vec<Condition> = vec![];
 
         for arg in args {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -47,7 +47,7 @@ pub struct ConditionClosure {
 
 impl Parse for Contract {
     fn parse(input: ParseStream) -> Result<Self> {
-        let items = Punctuated::<ContractArg, Token![,]>::parse_terminated(input)?;
+        let args = Punctuated::<ContractArg, Token![,]>::parse_terminated(input)?;
 
         let mut last_arg_order: Option<ArgOrder> = None;
         let mut binds_pattern: Option<Pat> = None;
@@ -55,7 +55,7 @@ impl Parse for Contract {
         let mut maintains: Vec<Condition> = vec![];
         let mut ensures_exprs: Vec<Condition> = vec![];
 
-        for arg in items {
+        for arg in args {
             let current_arg_order = arg.get_order();
             if let Some(last_order) = last_arg_order {
                 if current_arg_order < last_order {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -147,6 +147,13 @@ impl TryFrom<ContractArgs> for Contract {
     }
 }
 
+impl Parse for Contract {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let args = input.parse::<ContractArgs>()?;
+        Contract::try_from(args)
+    }
+}
+
 /// A container for all parsed arguments from the `#[contract]` attribute.
 pub struct ContractArgs {
     pub items: Vec<ContractArg>,

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -21,6 +21,13 @@ pub struct Contract {
     pub ensures: Vec<ConditionClosure>,
 }
 
+impl Parse for Contract {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let args = input.parse::<ContractArgs>()?;
+        Contract::try_from(args)
+    }
+}
+
 /// A condition represented by a `bool`-valued expression.
 #[derive(Debug)]
 pub struct Condition {
@@ -144,13 +151,6 @@ impl TryFrom<ContractArgs> for Contract {
             maintains,
             ensures,
         })
-    }
-}
-
-impl Parse for Contract {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let args = input.parse::<ContractArgs>()?;
-        Contract::try_from(args)
     }
 }
 
@@ -292,8 +292,8 @@ fn parse_cfg_attribute(attrs: &[Attribute]) -> Result<Option<Meta>> {
     Ok(cfg_attrs.pop())
 }
 
-// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
-// as if they were built-in Rust keywords during parsing.
+/// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
+/// as if they were built-in Rust keywords during parsing.
 mod kw {
     syn::custom_keyword!(requires);
     syn::custom_keyword!(maintains);

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -155,7 +155,7 @@ impl TryFrom<ContractArgs> for Contract {
 }
 
 /// A container for all parsed arguments from the `#[contract]` attribute.
-pub struct ContractArgs {
+struct ContractArgs {
     pub items: Vec<ContractArg>,
 }
 
@@ -172,7 +172,7 @@ impl Parse for ContractArgs {
 }
 
 /// An intermediate enum to help parse either a condition or a `binds` setting.
-pub enum ContractArg {
+enum ContractArg {
     Requires {
         keyword: kw::requires,
         cfg: Option<Meta>,

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -3,11 +3,11 @@
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
+    Attribute, Block, Expr, ExprClosure, Ident, ItemFn, Meta, Pat, Token,
     parse::{Parse, ParseStream, Result},
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    Attribute, Block, Expr, ExprClosure, Ident, ItemFn, Meta, Pat, Token,
 };
 
 /// A contract specifies the intended behavior of a function or method.

--- a/crates/anodized-core/src/test.rs
+++ b/crates/anodized-core/src/test.rs
@@ -1,12 +1,6 @@
 use super::*;
 use crate::test_util::assert_contract_eq;
-use quote::quote;
-use syn::{parse_quote, parse2, Result};
-
-fn parse_contract(tokens: proc_macro2::TokenStream) -> Result<Contract> {
-    let args: ContractArgs = parse2(tokens)?;
-    Contract::try_from(args)
-}
+use syn::parse_quote;
 
 #[test]
 fn test_parse_simple_contract() {
@@ -43,21 +37,21 @@ fn test_parse_all_clauses() {
 }
 
 #[test]
+#[should_panic(expected = "parameters are out of order")]
 fn test_parse_out_of_order() {
-    let result = parse_contract(quote! {
+    let _: Contract = parse_quote! {
         ensures: output > x,
         requires: x > 0,
-    });
-    assert!(result.is_err());
+    };
 }
 
 #[test]
+#[should_panic(expected = "multiple `binds` parameters are not allowed")]
 fn test_parse_multiple_binds() {
-    let result = parse_contract(quote! {
+    let _: Contract = parse_quote! {
         binds: y,
         binds: z,
-    });
-    assert!(result.is_err());
+    };
 }
 
 #[test]
@@ -178,44 +172,29 @@ fn test_parse_cfg_attributes() {
 }
 
 #[test]
+#[should_panic(expected = "unsupported attribute; only `cfg` is allowed")]
 fn test_parse_non_cfg_attribute() {
-    let error = parse_contract(quote! {
+    let _: Contract = parse_quote! {
         #[allow(dead_code)]
         requires: x > 0,
-    })
-    .expect_err("parsing should have failed but it succeeded");
-
-    assert_eq!(
-        error.to_string(),
-        "unsupported attribute; only `cfg` is allowed"
-    );
+    };
 }
 
 #[test]
+#[should_panic(expected = "multiple `cfg` attributes are not supported")]
 fn test_parse_multiple_cfg_attributes() {
-    let error = parse_contract(quote! {
+    let _: Contract = parse_quote! {
         #[cfg(test)]
         #[cfg(debug_assertions)]
         requires: x > 0,
-    })
-    .expect_err("parsing should have failed but it succeeded");
-
-    assert_eq!(
-        error.to_string(),
-        "multiple `cfg` attributes are not supported"
-    );
+    };
 }
 
 #[test]
+#[should_panic(expected = "`cfg` attribute is not supported on `binds`")]
 fn test_parse_cfg_on_binds() {
-    let error = parse_contract(quote! {
+    let _: Contract = parse_quote! {
         #[cfg(test)]
         binds: y,
-    })
-    .expect_err("parsing should have failed but it succeeded");
-
-    assert_eq!(
-        error.to_string(),
-        "`cfg` attribute is not supported on `binds`"
-    );
+    };
 }

--- a/crates/anodized-core/src/test.rs
+++ b/crates/anodized-core/src/test.rs
@@ -68,7 +68,10 @@ fn test_parse_array_of_conditions() {
     };
 
     let expected = Contract {
-        requires: vec![parse_quote! { x >= 0 }, parse_quote! { y.len() < 10 }],
+        requires: vec![
+            parse_quote! { x >= 0 },
+            parse_quote! { y.len() < 10 },
+        ],
         maintains: vec![],
         ensures: vec![
             parse_quote! { |output| output != x },
@@ -205,7 +208,7 @@ fn test_parse_cfg_on_binds() {
 }
 
 #[test]
-fn test_parse_basic_enum() {
+fn test_parse_macro_in_condition() {
     let contract: Contract = parse_quote! {
         requires: matches!(self.state, State::Idle),
         maintains: matches!(self.state, State::Idle | State::Running | State::Finished),
@@ -224,28 +227,13 @@ fn test_parse_basic_enum() {
 }
 
 #[test]
-fn test_parse_basic_function() {
-    let contract: Contract = parse_quote! {
-        requires: divisor != 0,
-        ensures: output < dividend,
-    };
-
-    let expected = Contract {
-        requires: vec![parse_quote! { divisor != 0 }],
-        maintains: vec![],
-        ensures: vec![parse_quote! { |output| output < dividend }],
-    };
-
-    assert_contract_eq(&contract, &expected);
-}
-
-#[test]
-fn test_parse_default_output_pattern() {
+fn test_parse_binds_pattern() {
     let contract: Contract = parse_quote! {
         binds: (a, b),
         ensures: [
             a <= b,
             (a, b) == pair || (b, a) == pair,
+            |(a, b)| (a, b) == pair || (b, a) == pair,
         ],
     };
 
@@ -255,22 +243,8 @@ fn test_parse_default_output_pattern() {
         ensures: vec![
             parse_quote! { |(a, b)| a <= b },
             parse_quote! { |(a, b)| (a, b) == pair || (b, a) == pair },
+            parse_quote! { |(a, b)| (a, b) == pair || (b, a) == pair },
         ],
-    };
-
-    assert_contract_eq(&contract, &expected);
-}
-
-#[test]
-fn test_parse_method_with_invariant() {
-    let contract: Contract = parse_quote! {
-        maintains: self.count <= self.capacity,
-    };
-
-    let expected = Contract {
-        requires: vec![],
-        maintains: vec![parse_quote! { self.count <= self.capacity }],
-        ensures: vec![],
     };
 
     assert_contract_eq(&contract, &expected);
@@ -282,8 +256,8 @@ fn test_parse_multiple_conditions() {
         requires: [
             self.initialized,
             !self.locked,
-            index < self.items.len(),
         ],
+        requires: index < self.items.len(),
         maintains: self.items.len() <= self.items.capacity(),
     };
 
@@ -295,27 +269,6 @@ fn test_parse_multiple_conditions() {
         ],
         maintains: vec![parse_quote! { self.items.len() <= self.items.capacity() }],
         ensures: vec![],
-    };
-
-    assert_contract_eq(&contract, &expected);
-}
-
-#[test]
-fn test_parse_pattern_in_closure() {
-    let contract: Contract = parse_quote! {
-        ensures: [
-            |(a, b)| a <= b,
-            |(a, b)| (a, b) == pair || (b, a) == pair,
-        ],
-    };
-
-    let expected = Contract {
-        requires: vec![],
-        maintains: vec![],
-        ensures: vec![
-            parse_quote! { |(a, b)| a <= b },
-            parse_quote! { |(a, b)| (a, b) == pair || (b, a) == pair },
-        ],
     };
 
     assert_contract_eq(&contract, &expected);

--- a/crates/anodized-core/src/test.rs
+++ b/crates/anodized-core/src/test.rs
@@ -9,7 +9,7 @@ fn parse_contract(tokens: proc_macro2::TokenStream) -> Result<Contract> {
 }
 
 #[test]
-fn test_parse_simple_contract() -> Result<()> {
+fn test_parse_simple_contract() {
     let contract: Contract = parse_quote! {
         requires: x > 0,
         ensures: output > x,
@@ -22,12 +22,10 @@ fn test_parse_simple_contract() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_all_clauses() -> Result<()> {
+fn test_parse_all_clauses() {
     let contract: Contract = parse_quote! {
         requires: x > 0,
         maintains: y.is_valid(),
@@ -42,8 +40,6 @@ fn test_parse_all_clauses() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
@@ -69,7 +65,7 @@ fn test_parse_multiple_binds() -> Result<()> {
 }
 
 #[test]
-fn test_parse_array_of_conditions() -> Result<()> {
+fn test_parse_array_of_conditions() {
     let contract: Contract = parse_quote! {
         requires: [
             x > 0,
@@ -91,12 +87,10 @@ fn test_parse_array_of_conditions() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_ensures_with_closure() -> Result<()> {
+fn test_parse_ensures_with_closure() {
     let contract: Contract = parse_quote! {
         ensures: |result| result.is_ok(),
     };
@@ -108,12 +102,10 @@ fn test_parse_ensures_with_closure() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_multiple_clauses_of_same_flavor() -> Result<()> {
+fn test_parse_multiple_clauses_of_same_flavor() {
     let contract: Contract = parse_quote! {
         requires: x > 0,
         requires: y > 0,
@@ -131,12 +123,10 @@ fn test_parse_multiple_clauses_of_same_flavor() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_mixed_single_and_array_clauses() -> Result<()> {
+fn test_parse_mixed_single_and_array_clauses() {
     let contract: Contract = parse_quote! {
         requires: x > 0,
         requires: [
@@ -165,12 +155,10 @@ fn test_parse_mixed_single_and_array_clauses() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_cfg_attributes() -> Result<()> {
+fn test_parse_cfg_attributes() {
     let contract: Contract = parse_quote! {
         #[cfg(test)]
         requires: x > 0,
@@ -191,8 +179,6 @@ fn test_parse_cfg_attributes() -> Result<()> {
     };
 
     assert_contract_eq(&contract, &expected);
-
-    Ok(())
 }
 
 #[test]

--- a/crates/anodized-core/src/test.rs
+++ b/crates/anodized-core/src/test.rs
@@ -43,25 +43,21 @@ fn test_parse_all_clauses() {
 }
 
 #[test]
-fn test_parse_out_of_order() -> Result<()> {
+fn test_parse_out_of_order() {
     let result = parse_contract(quote! {
         ensures: output > x,
         requires: x > 0,
     });
     assert!(result.is_err());
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_multiple_binds() -> Result<()> {
+fn test_parse_multiple_binds() {
     let result = parse_contract(quote! {
         binds: y,
         binds: z,
     });
     assert!(result.is_err());
-
-    Ok(())
 }
 
 #[test]
@@ -182,7 +178,7 @@ fn test_parse_cfg_attributes() {
 }
 
 #[test]
-fn test_parse_non_cfg_attribute() -> Result<()> {
+fn test_parse_non_cfg_attribute() {
     let error = parse_contract(quote! {
         #[allow(dead_code)]
         requires: x > 0,
@@ -193,12 +189,10 @@ fn test_parse_non_cfg_attribute() -> Result<()> {
         error.to_string(),
         "unsupported attribute; only `cfg` is allowed"
     );
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_multiple_cfg_attributes() -> Result<()> {
+fn test_parse_multiple_cfg_attributes() {
     let error = parse_contract(quote! {
         #[cfg(test)]
         #[cfg(debug_assertions)]
@@ -210,12 +204,10 @@ fn test_parse_multiple_cfg_attributes() -> Result<()> {
         error.to_string(),
         "multiple `cfg` attributes are not supported"
     );
-
-    Ok(())
 }
 
 #[test]
-fn test_parse_cfg_on_binds() -> Result<()> {
+fn test_parse_cfg_on_binds() {
     let error = parse_contract(quote! {
         #[cfg(test)]
         binds: y,
@@ -226,6 +218,4 @@ fn test_parse_cfg_on_binds() -> Result<()> {
         error.to_string(),
         "`cfg` attribute is not supported on `binds`"
     );
-
-    Ok(())
 }

--- a/crates/anodized-core/src/test.rs
+++ b/crates/anodized-core/src/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::test_util::assert_contract_eq;
 use quote::quote;
-use syn::{parse_quote, parse2};
+use syn::{parse_quote, parse2, Result};
 
 fn parse_contract(tokens: proc_macro2::TokenStream) -> Result<Contract> {
     let args: ContractArgs = parse2(tokens)?;
@@ -10,10 +10,10 @@ fn parse_contract(tokens: proc_macro2::TokenStream) -> Result<Contract> {
 
 #[test]
 fn test_parse_simple_contract() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         requires: x > 0,
         ensures: output > x,
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![parse_quote! { x > 0 }],
@@ -28,12 +28,12 @@ fn test_parse_simple_contract() -> Result<()> {
 
 #[test]
 fn test_parse_all_clauses() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         requires: x > 0,
         maintains: y.is_valid(),
         binds: z,
         ensures: z > x,
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![parse_quote! { x > 0 }],
@@ -70,7 +70,7 @@ fn test_parse_multiple_binds() -> Result<()> {
 
 #[test]
 fn test_parse_array_of_conditions() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         requires: [
             x > 0,
             y > 0,
@@ -79,7 +79,7 @@ fn test_parse_array_of_conditions() -> Result<()> {
             output > x,
             |output| output > y,
         ],
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![parse_quote! { x > 0 }, parse_quote! { y > 0 }],
@@ -97,9 +97,9 @@ fn test_parse_array_of_conditions() -> Result<()> {
 
 #[test]
 fn test_parse_ensures_with_closure() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         ensures: |result| result.is_ok(),
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![],
@@ -114,12 +114,12 @@ fn test_parse_ensures_with_closure() -> Result<()> {
 
 #[test]
 fn test_parse_multiple_clauses_of_same_flavor() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         requires: x > 0,
         requires: y > 0,
         ensures: output > x,
         ensures: |output| output > y,
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![parse_quote! { x > 0 }, parse_quote! { y > 0 }],
@@ -137,7 +137,7 @@ fn test_parse_multiple_clauses_of_same_flavor() -> Result<()> {
 
 #[test]
 fn test_parse_mixed_single_and_array_clauses() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         requires: x > 0,
         requires: [
             y > 1,
@@ -148,7 +148,7 @@ fn test_parse_mixed_single_and_array_clauses() -> Result<()> {
             |output| output > z,
         ],
         ensures: output > x,
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![
@@ -171,12 +171,12 @@ fn test_parse_mixed_single_and_array_clauses() -> Result<()> {
 
 #[test]
 fn test_parse_cfg_attributes() -> Result<()> {
-    let contract = parse_contract(quote! {
+    let contract: Contract = parse_quote! {
         #[cfg(test)]
         requires: x > 0,
         #[cfg(not(debug_assertions))]
         ensures: output > x,
-    })?;
+    };
 
     let expected = Contract {
         requires: vec![Condition {

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{ItemFn, parse_macro_input};
 
-use anodized_core::{Contract, ContractArgs, instrument_function_body};
+use anodized_core::{Contract, instrument_function_body};
 
 /// The main procedural macro for defining contracts on functions.
 ///
@@ -13,14 +13,9 @@ use anodized_core::{Contract, ContractArgs, instrument_function_body};
 #[proc_macro_attribute]
 pub fn contract(args: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the contract arguments from the attribute, e.g., `requires: x > 0, ...`
-    let contract_args = parse_macro_input!(args as ContractArgs);
+    let contract = parse_macro_input!(args as Contract);
     // Parse the function to which the attribute is attached.
     let mut func = parse_macro_input!(input as ItemFn);
-
-    let contract = match Contract::try_from(contract_args) {
-        Ok(contract) => contract,
-        Err(e) => return e.to_compile_error().into(),
-    };
 
     // Generate the new, instrumented function body.
     let new_body = match instrument_function_body(&contract, &func) {


### PR DESCRIPTION
- Implement `Parse` directly for `Contract`.
- Hide internal details like `ContractArg`.
- Simplify and extend unit tests.