### PR TITLE
fix: replace invalid keyword in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/mkovaxx/anodized"
 description = "An ecosystem for correct Rust based on lightweight specification annotations"
 categories = ["development-tools", "development-tools::procedural-macro-helpers"]
-keywords = ["correctness", "design-by-contract", "fuzzing", "property-based-testing", "verification"]
+keywords = ["correctness", "design-by-contract", "fuzzing", "testing", "verification"]
 
 [workspace.dependencies]
 anodized-core = { version = "0.2.0", path = "crates/anodized-core" }


### PR DESCRIPTION
Replace 'property-based-testing' with 'testing' as crates.io doesn't allow keywords longer than 20 characters.