### PR TITLE
fix: enable docs.rs documentation generation

### DIFF
--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -1,5 +1,6 @@
-#![cfg(not(doctest))]
-#![doc = include_str!("../README.md")]
+//! Core interoperability for the Anodized correctness ecosystem.
+//!
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -1,5 +1,6 @@
-#![cfg(not(doctest))]
-#![doc = include_str!("../../../README.md")]
+//! Pragmatic specification annotations for Rust.
+//!
+#![cfg_attr(not(doctest), doc = include_str!("../../../README.md"))]
 
 use proc_macro::TokenStream;
 use quote::ToTokens;


### PR DESCRIPTION
Replace `#![cfg(not(doctest))]` with `#![cfg_attr(not(doctest), ...)]` to allow docs.rs to build documentation while still preventing README code examples from being run as doctests.

This fixes the issue where documentation wasn't appearing on docs.rs for `anodized-core`.