### PR TITLE
Change `clones:` to `captures:` with move semantics

### DIFF
--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -29,6 +29,7 @@ The `#[spec]` attribute's parameters follow a specific grammar, which is formall
 ```ebnf
 params = [ requires_params ]
        , [ maintains_params ]
+       , [ captures_param ]
        (* not a typo: at most one `binds` *)
        , [ binds_param ]
        , [ ensures_params ];
@@ -39,11 +40,16 @@ ensures_params   = { ensures_param };
 
 requires_param  = [ cfg_attr ] , `requires:` , conditions, `,`;
 maintains_param = [ cfg_attr ] , `maintains:` , conditions, `,`;
+captures_param  = `captures:` , captures, `,`;
 binds_param     = `binds:` , pattern, `,`;
 ensures_param   = [ cfg_attr ] , `ensures:` , post_conds, `,`;
 
 conditions = expr | condition_list;
 condition_list = `[` , expr , { `,` , expr } , [ `,` ] , `]`;
+
+captures = capture_expr | capture_list;
+capture_list = `[` , capture_expr , { `,` , capture_expr } , [ `,` ] , `]`;
+capture_expr = expr | (expr , `as` , ident);
 
 post_conds = post_cond_expr | post_cond_list;
 post_cond_list = `[` , post_cond_expr , { `,` , post_cond_expr } , [ `,` ] , `]`;

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -29,8 +29,9 @@ The `#[spec]` attribute's parameters follow a specific grammar, which is formall
 ```ebnf
 params = [ requires_params ]
        , [ maintains_params ]
+       (* not a typo: at most one `captures:` *)
        , [ captures_param ]
-       (* not a typo: at most one `binds` *)
+       (* not a typo: at most one `binds:` *)
        , [ binds_param ]
        , [ ensures_params ];
 
@@ -62,8 +63,8 @@ cfg_attr = `#[cfg(` , settings , `)]`;
 
 - The last `,` is optional.
 - The `params` rule defines a sequence of optional parameter groups that must appear in the specified order.
-- `expr` refers to a Rust [`expression`](https://doc.rust-lang.org/reference/expressions.html); type checking will fail if it does not evaluate to `bool`.
-- `closure` refers to a Rust [`closure expression`](https://doc.rust-lang.org/reference/expressions/closure-expr.html); type checking will fail if it does not take the function's return value as an argument and evaluate to `bool`.
+- `expr` refers to a Rust [`expression`](https://doc.rust-lang.org/reference/expressions.html); type checking will fail if a condition does not evaluate to `bool`.
+- `closure` refers to a Rust [`closure expression`](https://doc.rust-lang.org/reference/expressions/closure-expr.html); type checking will fail if a closure used as a condition does not take the function's return value as an argument and evaluate to `bool`.
 - `pattern` refers to any valid Rust [`pattern`](https://doc.rust-lang.org/reference/patterns.html); type checking will fail if its type does not match the function's return value.
 - `settings` is the content of the [`cfg`](https://doc.rust-lang.org/reference/conditional-compilation.html) attribute (e.g. `test`, `debug_assertions`).
 
@@ -77,6 +78,7 @@ Given an original function like this:
 #[spec(
     requires: <PRECONDITION>,
     maintains: <INVARIANT>,
+    captures: <CAPTURE_EXPR> as <ALIAS>,
     ensures: <POSTCONDITION_CLOSURE>,
 )]
 fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
@@ -92,12 +94,15 @@ fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
     assert!(<PRECONDITION>, "Precondition failed: <PRECONDITION>");
     assert!(<INVARIANT>, "Pre-invariant failed: <INVARIANT>");
 
-    // 2. The original function body is executed
-    let __anodized_output = {
+    // 2. Values are captured and the original function body is executed
+    // Note: captures and body execution happen in a single tuple assignment
+    // to ensure captured values aren't accessible to the function body
+    let (<ALIAS>, __anodized_output) = (<CAPTURE_EXPR>, {
         <BODY>
-    };
+    });
 
     // 3. Invariants and postconditions are checked
+    // The captured value is available to postconditions
     assert!(<INVARIANT>, "Post-invariant failed: <INVARIANT>");
     assert!((<POSTCONDITION_CLOSURE>)(__anodized_output),
         "Postcondition failed: <POSTCONDITION_CLOSURE>");

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -112,4 +112,6 @@ fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
 }
 ```
 
-This transformation happens hygienically, meaning the `__anodized_output` variable will not conflict with any existing variables in your code. Any `#[cfg]` attributes on conditions are respected, and the corresponding `assert!` will be wrapped in an `if cfg!(...)` block, ensuring that expensive checks can be conditionally compiled. In release builds, this entire instrumentation is disabled, resulting in zero performance overhead.
+Note that the `__anodized_output` will be in scope for the postconditions, but referring to it is not recommended.
+
+Any `#[cfg]` attributes on conditions are respected, and the corresponding `assert!` will be wrapped in an `if cfg!(...)` block, ensuring that expensive checks can be conditionally compiled. In release builds, this entire instrumentation is disabled, resulting in zero performance overhead.

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -243,13 +243,13 @@ impl Parse for SpecArg {
             let keyword = input.parse::<kw::captures>()?;
             input.parse::<Token![:]>()?;
 
-            // Parse an expression and interpret as binding(s)
+            // Parse an expression and interpret as capture(s)
             let expr: Expr = input.parse()?;
 
             let bindings = match expr {
-                // Array: interpret as list of bindings
+                // Array: interpret as list of captures
                 Expr::Array(array) => interpret_array_as_captures(array)?,
-                // Single expression: interpret as single binding
+                // Single expression: interpret as single capture
                 _ => vec![interpret_expr_as_capture(expr)?],
             };
 

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -438,7 +438,7 @@ pub fn instrument_fn_body(spec: &Spec, original_body: &Block, is_async: bool) ->
     // Chain capture expressions with body expression
     let capture_exprs = spec.captures.iter().map(|cb| {
         let expr = &cb.expr;
-        quote! { (#expr).clone() }
+        quote! { #expr }
     });
 
     let body_expr = if is_async {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -104,7 +104,7 @@ impl Parse for Spec {
                 }
                 SpecArg::Captures {
                     keyword,
-                    captures: bindings,
+                    captures: caps,
                 } => {
                     if !captures.is_empty() {
                         return Err(syn::Error::new(
@@ -112,7 +112,7 @@ impl Parse for Spec {
                             "at most one `captures` parameter is allowed; to capture multiple values, use a list: `captures: [expr1, expr2, ...]`",
                         ));
                     }
-                    captures.extend(bindings);
+                    captures.extend(caps);
                 }
                 SpecArg::Binds { keyword, pattern } => {
                     if binds_pattern.is_some() {

--- a/crates/anodized-core/src/test_instrument_fn.rs
+++ b/crates/anodized-core/src/test_instrument_fn.rs
@@ -446,7 +446,7 @@ fn test_instrument_with_complex_mixed_conditions() {
 }
 
 #[test]
-fn test_instrument_with_clones() {
+fn test_instrument_with_captures() {
     let spec: Spec = parse_quote! {
         requires: CONDITION_1,
         captures: [

--- a/crates/anodized-core/src/test_instrument_fn.rs
+++ b/crates/anodized-core/src/test_instrument_fn.rs
@@ -464,7 +464,7 @@ fn test_instrument_with_captures() {
     let expected: Block = parse_quote! {
         {
             assert!(CONDITION_1, "Precondition failed: {}", "CONDITION_1");
-            let (ALIAS_1, ALIAS_2, __anodized_output) = ((EXPR_1).clone(), (EXPR_2).clone(), #body);
+            let (ALIAS_1, ALIAS_2, __anodized_output) = (EXPR_1, EXPR_2, #body);
             assert!(
                 (|output| CONDITION_2)(__anodized_output),
                 "Postcondition failed: {}", "| output | CONDITION_2"

--- a/crates/anodized-core/src/test_instrument_fn.rs
+++ b/crates/anodized-core/src/test_instrument_fn.rs
@@ -449,7 +449,7 @@ fn test_instrument_with_complex_mixed_conditions() {
 fn test_instrument_with_clones() {
     let spec: Spec = parse_quote! {
         requires: CONDITION_1,
-        clones: [
+        captures: [
             EXPR_1 as ALIAS_1,
             EXPR_2 as ALIAS_2,
         ],

--- a/crates/anodized-core/src/test_parse_spec.rs
+++ b/crates/anodized-core/src/test_parse_spec.rs
@@ -492,7 +492,7 @@ fn test_parse_captures_array_with_complex_expr_no_alias() {
 
 #[test]
 #[should_panic(expected = "`cfg` attribute is not supported on `captures`")]
-fn test_parse_cfg_on_clones() {
+fn test_parse_cfg_on_captures() {
     let _: Spec = parse_quote! {
         #[cfg(test)]
         captures: value as old_value,

--- a/crates/anodized-core/src/test_parse_spec.rs
+++ b/crates/anodized-core/src/test_parse_spec.rs
@@ -59,12 +59,12 @@ fn test_parse_multiple_binds() {
 
 #[test]
 #[should_panic(
-    expected = "at most one `clones` parameter is allowed; to clone multiple values, use a list"
+    expected = "at most one `captures` parameter is allowed; to capture multiple values, use a list"
 )]
 fn test_parse_multiple_clones() {
     let _: Spec = parse_quote! {
-        clones: value,
-        clones: count as old_count,
+        captures: value,
+        captures: count as old_count,
     };
 }
 
@@ -319,7 +319,7 @@ fn test_parse_rename_return_value() {
 #[test]
 fn test_parse_clones_simple_identifier() {
     let spec: Spec = parse_quote! {
-        clones: count,
+        captures: count,
         ensures: output == old_count + 1,
     };
 
@@ -339,7 +339,7 @@ fn test_parse_clones_simple_identifier() {
 #[test]
 fn test_parse_clones_identifier_with_alias() {
     let spec: Spec = parse_quote! {
-        clones: value as prev_value,
+        captures: value as prev_value,
         ensures: output > prev_value,
     };
 
@@ -359,7 +359,7 @@ fn test_parse_clones_identifier_with_alias() {
 #[test]
 fn test_parse_clones_array() {
     let spec: Spec = parse_quote! {
-        clones: [
+        captures: [
             count,
             index as old_index,
             value as old_value,
@@ -403,7 +403,7 @@ fn test_parse_clones_with_all_clauses() {
     let spec: Spec = parse_quote! {
         requires: x > 0,
         maintains: self.is_valid(),
-        clones: value as old_val,
+        captures: value as old_val,
         binds: result,
         ensures: result > old_val,
     };
@@ -425,7 +425,7 @@ fn test_parse_clones_with_all_clauses() {
 #[should_panic(expected = "parameters are out of order")]
 fn test_parse_clones_out_of_order() {
     let _: Spec = parse_quote! {
-        clones: value,
+        captures: value,
         maintains: self.is_valid(),
     };
 }
@@ -433,7 +433,7 @@ fn test_parse_clones_out_of_order() {
 #[test]
 fn test_parse_clones_array_expression() {
     let spec: Spec = parse_quote! {
-        clones: [a, b, c] as slice,
+        captures: [a, b, c] as slice,
         ensures: slice.len() == 3,
     };
 
@@ -454,7 +454,7 @@ fn test_parse_clones_array_expression() {
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
 fn test_parse_clones_complex_expr_without_alias() {
     let _: Spec = parse_quote! {
-        clones: self.items.len(),
+        captures: self.items.len(),
         ensures: output > 0,
     };
 }
@@ -463,7 +463,7 @@ fn test_parse_clones_complex_expr_without_alias() {
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
 fn test_parse_clones_method_call_without_alias() {
     let _: Spec = parse_quote! {
-        clones: foo.bar(),
+        captures: foo.bar(),
         ensures: output > 0,
     };
 }
@@ -472,7 +472,7 @@ fn test_parse_clones_method_call_without_alias() {
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
 fn test_parse_clones_binary_expr_without_alias() {
     let _: Spec = parse_quote! {
-        clones: a + b,
+        captures: a + b,
         ensures: output > 0,
     };
 }
@@ -481,7 +481,7 @@ fn test_parse_clones_binary_expr_without_alias() {
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
 fn test_parse_clones_array_with_complex_expr_no_alias() {
     let _: Spec = parse_quote! {
-        clones: [
+        captures: [
             count,
             // This should fail - complex expression needs explicit alias
             self.items.len(),
@@ -491,11 +491,11 @@ fn test_parse_clones_array_with_complex_expr_no_alias() {
 }
 
 #[test]
-#[should_panic(expected = "`cfg` attribute is not supported on `clones`")]
+#[should_panic(expected = "`cfg` attribute is not supported on `captures`")]
 fn test_parse_cfg_on_clones() {
     let _: Spec = parse_quote! {
         #[cfg(test)]
-        clones: value as old_value,
+        captures: value as old_value,
         ensures: output > old_value,
     };
 }
@@ -503,7 +503,7 @@ fn test_parse_cfg_on_clones() {
 #[test]
 fn test_parse_clones_edge_case_cast_expr() {
     let spec: Spec = parse_quote! {
-        clones: r as u8 as old_red,
+        captures: r as u8 as old_red,
     };
 
     let expected = Spec {
@@ -522,7 +522,7 @@ fn test_parse_clones_edge_case_cast_expr() {
 #[test]
 fn test_parse_clones_edge_case_array_of_cast_exprs() {
     let spec: Spec = parse_quote! {
-        clones: [
+        captures: [
             r as u8,
             g as u8,
             b as u8,
@@ -551,7 +551,7 @@ fn test_parse_clones_edge_case_array_of_cast_exprs() {
 #[test]
 fn test_parse_clones_edge_case_list_of_cast_exprs() {
     let spec: Spec = parse_quote! {
-        clones: [
+        captures: [
             r as u8 as old_red,
             g as u8 as old_green,
             b as u8 as old_blue,

--- a/crates/anodized-core/src/test_parse_spec.rs
+++ b/crates/anodized-core/src/test_parse_spec.rs
@@ -61,7 +61,7 @@ fn test_parse_multiple_binds() {
 #[should_panic(
     expected = "at most one `captures` parameter is allowed; to capture multiple values, use a list"
 )]
-fn test_parse_multiple_clones() {
+fn test_parse_multiple_captures() {
     let _: Spec = parse_quote! {
         captures: value,
         captures: count as old_count,
@@ -317,7 +317,7 @@ fn test_parse_rename_return_value() {
 }
 
 #[test]
-fn test_parse_clones_simple_identifier() {
+fn test_parse_captures_simple_identifier() {
     let spec: Spec = parse_quote! {
         captures: count,
         ensures: output == old_count + 1,
@@ -337,7 +337,7 @@ fn test_parse_clones_simple_identifier() {
 }
 
 #[test]
-fn test_parse_clones_identifier_with_alias() {
+fn test_parse_captures_identifier_with_alias() {
     let spec: Spec = parse_quote! {
         captures: value as prev_value,
         ensures: output > prev_value,
@@ -357,7 +357,7 @@ fn test_parse_clones_identifier_with_alias() {
 }
 
 #[test]
-fn test_parse_clones_array() {
+fn test_parse_captures_array() {
     let spec: Spec = parse_quote! {
         captures: [
             count,
@@ -399,7 +399,7 @@ fn test_parse_clones_array() {
 }
 
 #[test]
-fn test_parse_clones_with_all_clauses() {
+fn test_parse_captures_with_all_clauses() {
     let spec: Spec = parse_quote! {
         requires: x > 0,
         maintains: self.is_valid(),
@@ -423,7 +423,7 @@ fn test_parse_clones_with_all_clauses() {
 
 #[test]
 #[should_panic(expected = "parameters are out of order")]
-fn test_parse_clones_out_of_order() {
+fn test_parse_captures_out_of_order() {
     let _: Spec = parse_quote! {
         captures: value,
         maintains: self.is_valid(),
@@ -431,7 +431,7 @@ fn test_parse_clones_out_of_order() {
 }
 
 #[test]
-fn test_parse_clones_array_expression() {
+fn test_parse_captures_array_expression() {
     let spec: Spec = parse_quote! {
         captures: [a, b, c] as slice,
         ensures: slice.len() == 3,
@@ -452,7 +452,7 @@ fn test_parse_clones_array_expression() {
 
 #[test]
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
-fn test_parse_clones_complex_expr_without_alias() {
+fn test_parse_captures_complex_expr_without_alias() {
     let _: Spec = parse_quote! {
         captures: self.items.len(),
         ensures: output > 0,
@@ -461,7 +461,7 @@ fn test_parse_clones_complex_expr_without_alias() {
 
 #[test]
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
-fn test_parse_clones_method_call_without_alias() {
+fn test_parse_captures_method_call_without_alias() {
     let _: Spec = parse_quote! {
         captures: foo.bar(),
         ensures: output > 0,
@@ -470,7 +470,7 @@ fn test_parse_clones_method_call_without_alias() {
 
 #[test]
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
-fn test_parse_clones_binary_expr_without_alias() {
+fn test_parse_captures_binary_expr_without_alias() {
     let _: Spec = parse_quote! {
         captures: a + b,
         ensures: output > 0,
@@ -479,7 +479,7 @@ fn test_parse_clones_binary_expr_without_alias() {
 
 #[test]
 #[should_panic(expected = "complex expressions require an explicit alias using `as`")]
-fn test_parse_clones_array_with_complex_expr_no_alias() {
+fn test_parse_captures_array_with_complex_expr_no_alias() {
     let _: Spec = parse_quote! {
         captures: [
             count,
@@ -501,7 +501,7 @@ fn test_parse_cfg_on_clones() {
 }
 
 #[test]
-fn test_parse_clones_edge_case_cast_expr() {
+fn test_parse_captures_edge_case_cast_expr() {
     let spec: Spec = parse_quote! {
         captures: r as u8 as old_red,
     };
@@ -520,7 +520,7 @@ fn test_parse_clones_edge_case_cast_expr() {
 }
 
 #[test]
-fn test_parse_clones_edge_case_array_of_cast_exprs() {
+fn test_parse_captures_edge_case_array_of_cast_exprs() {
     let spec: Spec = parse_quote! {
         captures: [
             r as u8,
@@ -549,7 +549,7 @@ fn test_parse_clones_edge_case_array_of_cast_exprs() {
 }
 
 #[test]
-fn test_parse_clones_edge_case_list_of_cast_exprs() {
+fn test_parse_captures_edge_case_list_of_cast_exprs() {
     let spec: Spec = parse_quote! {
         captures: [
             r as u8 as old_red,

--- a/crates/anodized-core/src/test_parse_spec.rs
+++ b/crates/anodized-core/src/test_parse_spec.rs
@@ -13,7 +13,7 @@ fn test_parse_simple_spec() {
     let expected = Spec {
         requires: vec![parse_quote! { is_valid(x) }],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![parse_quote! { |output| output > x }],
     };
 
@@ -32,7 +32,7 @@ fn test_parse_all_clauses() {
     let expected = Spec {
         requires: vec![parse_quote! { x > 0 && x.is_power_of_two() }],
         maintains: vec![parse_quote! { self.is_valid() }],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![parse_quote! { |z| z >= x }],
     };
 
@@ -84,7 +84,7 @@ fn test_parse_array_of_conditions() {
     let expected = Spec {
         requires: vec![parse_quote! { x >= 0 }, parse_quote! { y.len() < 10 }],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |output| output != x },
             parse_quote! { |output| output.is_some() },
@@ -103,7 +103,7 @@ fn test_parse_ensures_with_closure() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |result| result.is_ok() || result.unwrap_err().kind() == ErrorKind::NotFound },
         ],
@@ -127,7 +127,7 @@ fn test_parse_multiple_clauses_of_same_flavor() {
             parse_quote! { y.is_ascii() },
         ],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |output| output < x },
             parse_quote! { |output| output.len() >= y.len() },
@@ -159,7 +159,7 @@ fn test_parse_mixed_single_and_array_clauses() {
             parse_quote! { z.is_empty() || z.contains("foo") },
         ],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |output| output != y },
             parse_quote! { |output| output.starts_with(z) },
@@ -185,7 +185,7 @@ fn test_parse_cfg_attributes() {
             cfg: Some(parse_quote! { test }),
         }],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![ConditionClosure {
             closure: parse_quote! { |output| output < x },
             cfg: Some(parse_quote! { not(debug_assertions) }),
@@ -236,7 +236,7 @@ fn test_parse_macro_in_condition() {
         maintains: vec![
             parse_quote! { matches!(self.state, State::Idle | State::Running | State::Finished) },
         ],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![parse_quote! { |output| matches!(self.state, State::Running) }],
     };
 
@@ -257,7 +257,7 @@ fn test_parse_binds_pattern() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |(a, b)| a <= b },
             parse_quote! { |(a, b)| (a, b) == pair || (b, a) == pair },
@@ -286,7 +286,7 @@ fn test_parse_multiple_conditions() {
             parse_quote! { index < self.items.len() },
         ],
         maintains: vec![parse_quote! { self.items.len() <= self.items.capacity() }],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![],
     };
 
@@ -306,7 +306,7 @@ fn test_parse_rename_return_value() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![],
+        captures: vec![],
         ensures: vec![
             parse_quote! { |result| result > output },
             parse_quote! { |val| val % 2 == 0 },
@@ -326,7 +326,7 @@ fn test_parse_clones_simple_identifier() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! { count },
             alias: parse_quote! { old_count },
         }],
@@ -346,7 +346,7 @@ fn test_parse_clones_identifier_with_alias() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! { value },
             alias: parse_quote! { prev_value },
         }],
@@ -374,16 +374,16 @@ fn test_parse_clones_array() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![
-            CloneBinding {
+        captures: vec![
+            Capture {
                 expr: parse_quote! { count },
                 alias: parse_quote! { old_count },
             },
-            CloneBinding {
+            Capture {
                 expr: parse_quote! { index },
                 alias: parse_quote! { old_index },
             },
-            CloneBinding {
+            Capture {
                 expr: parse_quote! { value },
                 alias: parse_quote! { old_value },
             },
@@ -411,7 +411,7 @@ fn test_parse_clones_with_all_clauses() {
     let expected = Spec {
         requires: vec![parse_quote! { x > 0 }],
         maintains: vec![parse_quote! { self.is_valid() }],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! { value },
             alias: parse_quote! { old_val },
         }],
@@ -440,7 +440,7 @@ fn test_parse_clones_array_expression() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! { [a, b, c] },
             alias: parse_quote! { slice },
         }],
@@ -509,7 +509,7 @@ fn test_parse_clones_edge_case_cast_expr() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! { r as u8 },
             alias: parse_quote! { old_red },
         }],
@@ -532,7 +532,7 @@ fn test_parse_clones_edge_case_array_of_cast_exprs() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![CloneBinding {
+        captures: vec![Capture {
             expr: parse_quote! {
                 [
                     r as u8,
@@ -561,16 +561,16 @@ fn test_parse_clones_edge_case_list_of_cast_exprs() {
     let expected = Spec {
         requires: vec![],
         maintains: vec![],
-        clones: vec![
-            CloneBinding {
+        captures: vec![
+            Capture {
                 expr: parse_quote! { r as u8 },
                 alias: parse_quote! { old_red },
             },
-            CloneBinding {
+            Capture {
                 expr: parse_quote! { g as u8 },
                 alias: parse_quote! { old_green },
             },
-            CloneBinding {
+            Capture {
                 expr: parse_quote! { b as u8 },
                 alias: parse_quote! { old_blue },
             },

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -34,14 +34,14 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
     let Spec {
         requires: left_requires,
         maintains: left_maintains,
-        captures: left_clones,
+        captures: left_captures,
         ensures: left_ensures,
     } = left;
 
     let Spec {
         requires: right_requires,
         maintains: right_maintains,
-        captures: right_clones,
+        captures: right_captures,
         ensures: right_ensures,
     } = right;
 
@@ -58,9 +58,9 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
         &assert_condition_eq,
     );
     assert_slice_eq(
-        left_clones,
-        right_clones,
-        "clones",
+        left_captures,
+        right_captures,
+        "captures",
         &assert_clone_binding_eq,
     );
     assert_slice_eq(

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -61,7 +61,7 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
         left_captures,
         right_captures,
         "captures",
-        &assert_clone_binding_eq,
+        &assert_capture_eq,
     );
     assert_slice_eq(
         left_ensures,
@@ -146,7 +146,7 @@ fn assert_condition_closure_eq(
     );
 }
 
-fn assert_clone_binding_eq(left: &Capture, right: &Capture, msg_prefix: &str) {
+fn assert_capture_eq(left: &Capture, right: &Capture, msg_prefix: &str) {
     // Destructure to ensure we handle all fields
     let Capture {
         expr: left_expr,

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,4 +1,4 @@
-use crate::{CloneBinding, Condition, ConditionClosure, Spec};
+use crate::{Capture, Condition, ConditionClosure, Spec};
 use quote::ToTokens;
 use syn::{
     Block,
@@ -34,14 +34,14 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
     let Spec {
         requires: left_requires,
         maintains: left_maintains,
-        clones: left_clones,
+        captures: left_clones,
         ensures: left_ensures,
     } = left;
 
     let Spec {
         requires: right_requires,
         maintains: right_maintains,
-        clones: right_clones,
+        captures: right_clones,
         ensures: right_ensures,
     } = right;
 
@@ -146,14 +146,14 @@ fn assert_condition_closure_eq(
     );
 }
 
-fn assert_clone_binding_eq(left: &CloneBinding, right: &CloneBinding, msg_prefix: &str) {
+fn assert_clone_binding_eq(left: &Capture, right: &Capture, msg_prefix: &str) {
     // Destructure to ensure we handle all fields
-    let CloneBinding {
+    let Capture {
         expr: left_expr,
         alias: left_alias,
     } = left;
 
-    let CloneBinding {
+    let Capture {
         expr: right_expr,
         alias: right_alias,
     } = right;

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -161,8 +161,8 @@ fn add_item<T: Clone + Eq>(items: &mut Vec<T>, item: T) { todo!() }
 
 - **Simple identifiers** get an automatic `old_` prefix, i.e. `x` becomes `old_x`.
 - **Complex expressions** require an explicit alias using `as`, i.e. `self.items.len() as orig_len`.
-- **No automatic cloning**: Values are captured as-is. For `Copy` types this is automatic, but for other types you must explicitly use `.clone()`, `.to_owned()`, or other appropriate methods.
-- Captures happen **after** preconditions are checked but **before** the function body executes.
+- **No automatic cloning**: Each captured expression is **moved**. For a `Copy` type, a copy is made implicitly. For a non-`Copy` type, you must explicitly use `.clone()`, `.to_owned()`, or another appropriate method.
+- Capturing happens **after** preconditions are checked but **before** the function body executes.
 - The captured values are **only** available to postconditions, not to preconditions or the function body itself.
 
 ### `binds`: Bind the Return Value

--- a/crates/anodized/tests/block_expressions.rs
+++ b/crates/anodized/tests/block_expressions.rs
@@ -10,7 +10,7 @@ use anodized::spec;
         let length = vec.len();
         length < 100
     },
-    clones: {
+    captures: {
         let snapshot = vec.clone();
         snapshot.len()
     } as old_len,

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -3,7 +3,7 @@ use anodized::spec;
 // Test simple identifier capturing with auto-generated alias
 #[spec(
     captures: count,
-    ensures: old_count <= count,
+    ensures: old_count <= output,
 )]
 fn increment_counter(count: u32) -> u32 {
     count + 1
@@ -124,7 +124,8 @@ fn test_capture_postcondition_failure() {
         ensures: value == old_value + 10,
     )]
     fn bad_increment(value: i32) -> i32 {
-        value + 5 // Wrong! Should add 10
+        // Wrong! Should add 10
+        value + 5
     }
 
     bad_increment(5);
@@ -149,7 +150,8 @@ fn test_precondition_runs_before_captures() {
     }
 
     let mut test = TestStruct { counter: 100 };
-    test.increment(); // Should panic on precondition, not reach captures
+    // Should panic on precondition, not reach captures
+    test.increment();
 }
 
 #[test]

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -1,6 +1,6 @@
 use anodized::spec;
 
-// Test simple identifier cloning with auto-generated alias
+// Test simple identifier capturing with auto-generated alias
 #[spec(
     captures: count,
     ensures: old_count <= count,
@@ -67,13 +67,13 @@ impl Container {
 }
 
 #[test]
-fn test_simple_clone_with_auto_alias() {
+fn test_simple_capture_with_auto_alias() {
     assert_eq!(increment_counter(5), 6);
     assert_eq!(increment_counter(0), 1);
 }
 
 #[test]
-fn test_clone_with_explicit_alias() {
+fn test_capture_with_explicit_alias() {
     let mut container = Container::new();
     container.value = 10;
     container.add_to_value(5);
@@ -81,7 +81,7 @@ fn test_clone_with_explicit_alias() {
 }
 
 #[test]
-fn test_multiple_clones() {
+fn test_multiple_captures() {
     let mut container = Container::new();
 
     // Add items up to capacity
@@ -98,7 +98,7 @@ fn test_multiple_clones() {
 }
 
 #[test]
-fn test_clones_with_preconditions() {
+fn test_captures_with_preconditions() {
     let mut container = Container::new();
     container.counter = 50;
 
@@ -108,7 +108,7 @@ fn test_clones_with_preconditions() {
 
 #[test]
 #[should_panic(expected = "Postcondition failed")]
-fn test_clone_postcondition_failure() {
+fn test_capture_postcondition_failure() {
     #[spec(
         captures: value as old_value,
         ensures: value == old_value + 10,
@@ -122,7 +122,7 @@ fn test_clone_postcondition_failure() {
 
 #[test]
 #[should_panic(expected = "Precondition failed")]
-fn test_precondition_runs_before_clones() {
+fn test_precondition_runs_before_captures() {
     struct TestStruct {
         counter: u32,
     }
@@ -139,5 +139,5 @@ fn test_precondition_runs_before_clones() {
     }
 
     let mut test = TestStruct { counter: 100 };
-    test.increment(); // Should panic on precondition, not reach clones
+    test.increment(); // Should panic on precondition, not reach captures
 }

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -157,11 +157,11 @@ fn test_explicit_clone_for_non_copy_types() {
     let mut container = Container::new();
     container.items.push("first".to_string());
     container.items.push("second".to_string());
-    
+
     // Should not push
     container.maybe_push("third".to_string(), false);
     assert_eq!(container.items.len(), 2);
-    
+
     // Should push
     container.maybe_push("third".to_string(), true);
     assert_eq!(container.items.len(), 3);

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -40,6 +40,16 @@ impl Container {
     }
 
     #[spec(
+        captures: self.items.clone() as original_items,
+        ensures: self.items.len() == original_items.len() || self.items.len() == original_items.len() + 1,
+    )]
+    fn maybe_push(&mut self, item: String, should_push: bool) {
+        if should_push {
+            self.items.push(item);
+        }
+    }
+
+    #[spec(
         captures: [
             self.items.len() as original_len,
             self.capacity as original_cap,
@@ -140,4 +150,19 @@ fn test_precondition_runs_before_captures() {
 
     let mut test = TestStruct { counter: 100 };
     test.increment(); // Should panic on precondition, not reach captures
+}
+
+#[test]
+fn test_explicit_clone_for_non_copy_types() {
+    let mut container = Container::new();
+    container.items.push("first".to_string());
+    container.items.push("second".to_string());
+    
+    // Should not push
+    container.maybe_push("third".to_string(), false);
+    assert_eq!(container.items.len(), 2);
+    
+    // Should push
+    container.maybe_push("third".to_string(), true);
+    assert_eq!(container.items.len(), 3);
 }

--- a/crates/anodized/tests/clones_feature.rs
+++ b/crates/anodized/tests/clones_feature.rs
@@ -2,7 +2,7 @@ use anodized::spec;
 
 // Test simple identifier cloning with auto-generated alias
 #[spec(
-    clones: count,
+    captures: count,
     ensures: old_count <= count,
 )]
 fn increment_counter(count: u32) -> u32 {
@@ -32,7 +32,7 @@ impl Container {
     }
 
     #[spec(
-        clones: self.value as initial_value,
+        captures: self.value as initial_value,
         ensures: self.value == initial_value + amount,
     )]
     fn add_to_value(&mut self, amount: i32) {
@@ -40,7 +40,7 @@ impl Container {
     }
 
     #[spec(
-        clones: [
+        captures: [
             self.items.len() as original_len,
             self.capacity as original_cap,
         ],
@@ -58,7 +58,7 @@ impl Container {
 
     #[spec(
         requires: self.is_valid(),
-        clones: self.counter as old_counter,
+        captures: self.counter as old_counter,
         ensures: self.counter == old_counter + 1,
     )]
     fn increment_if_valid(&mut self) {
@@ -110,7 +110,7 @@ fn test_clones_with_preconditions() {
 #[should_panic(expected = "Postcondition failed")]
 fn test_clone_postcondition_failure() {
     #[spec(
-        clones: value as old_value,
+        captures: value as old_value,
         ensures: value == old_value + 10,
     )]
     fn bad_increment(value: i32) -> i32 {
@@ -130,7 +130,7 @@ fn test_precondition_runs_before_clones() {
     impl TestStruct {
         #[spec(
             requires: self.counter < 100,
-            clones: self.counter as old_counter,
+            captures: self.counter as old_counter,
             ensures: self.counter == old_counter + 1,
         )]
         fn increment(&mut self) {

--- a/crates/anodized/tests/compile-fail/captures_scope_isolation.rs
+++ b/crates/anodized/tests/compile-fail/captures_scope_isolation.rs
@@ -14,7 +14,7 @@ use anodized::spec;
     ],
 )]
 fn test_captures_not_in_body(x: i32, y: i32) -> i32 {
-    // Clone aliases should not be accessible in function body
+    // Capture aliases should not be accessible in function body
     let a = old_x; // Should be an error: `old_x` must not be in scope.
     let b = old_y; // Should be an error: `old_y` must not be in scope.
     x + y

--- a/crates/anodized/tests/compile-fail/captures_scope_isolation.rs
+++ b/crates/anodized/tests/compile-fail/captures_scope_isolation.rs
@@ -1,6 +1,6 @@
 use anodized::spec;
 
-// This test verifies that clone aliases are not accessible in the function body
+// This test verifies that capture aliases are not accessible in the function body
 // or in requires/maintains conditions
 
 #[spec(
@@ -13,7 +13,7 @@ use anodized::spec;
         old_y == 10, // OK: aliases are available in ensures
     ],
 )]
-fn test_clones_not_in_body(x: i32, y: i32) -> i32 {
+fn test_captures_not_in_body(x: i32, y: i32) -> i32 {
     // Clone aliases should not be accessible in function body
     let a = old_x; // Should be an error: `old_x` must not be in scope.
     let b = old_y; // Should be an error: `old_y` must not be in scope.
@@ -28,7 +28,7 @@ fn test_clones_not_in_body(x: i32, y: i32) -> i32 {
         x as old_x,
     ],
 )]
-fn test_clones_not_in_requires(x: i32) {
+fn test_captures_not_in_requires(x: i32) {
     // Function body
 }
 
@@ -40,7 +40,7 @@ fn test_clones_not_in_requires(x: i32) {
         x as old_x,
     ],
 )]
-fn test_clones_not_in_maintains(x: i32) {
+fn test_captures_not_in_maintains(x: i32) {
     // Function body
 }
 

--- a/crates/anodized/tests/compile-fail/captures_scope_isolation.stderr
+++ b/crates/anodized/tests/compile-fail/captures_scope_isolation.stderr
@@ -1,23 +1,23 @@
 error[E0425]: cannot find value `old_x` in this scope
-  --> tests/compile-fail/clones_scope_isolation.rs:18:13
+  --> tests/compile-fail/captures_scope_isolation.rs:18:13
    |
 18 |     let a = old_x; // Should be an error: `old_x` must not be in scope.
    |             ^^^^^ not found in this scope
 
 error[E0425]: cannot find value `old_y` in this scope
-  --> tests/compile-fail/clones_scope_isolation.rs:19:13
+  --> tests/compile-fail/captures_scope_isolation.rs:19:13
    |
 19 |     let b = old_y; // Should be an error: `old_y` must not be in scope.
    |             ^^^^^ not found in this scope
 
 error[E0425]: cannot find value `old_x` in this scope
-  --> tests/compile-fail/clones_scope_isolation.rs:25:9
+  --> tests/compile-fail/captures_scope_isolation.rs:25:9
    |
 25 |         old_x > 0, // Should be an error: `old_x` must not be in scope.
    |         ^^^^^ not found in this scope
 
 error[E0425]: cannot find value `old_x` in this scope
-  --> tests/compile-fail/clones_scope_isolation.rs:37:9
+  --> tests/compile-fail/captures_scope_isolation.rs:37:9
    |
 37 |         old_x > 0, // Should be an error: `old_x` must not be in scope.
    |         ^^^^^ not found in this scope

--- a/crates/anodized/tests/compile-fail/clones_scope_isolation.rs
+++ b/crates/anodized/tests/compile-fail/clones_scope_isolation.rs
@@ -4,7 +4,7 @@ use anodized::spec;
 // or in requires/maintains conditions
 
 #[spec(
-    clones: [
+    captures: [
         x as old_x,
         y as old_y,
     ],
@@ -24,7 +24,7 @@ fn test_clones_not_in_body(x: i32, y: i32) -> i32 {
     requires: [
         old_x > 0, // Should be an error: `old_x` must not be in scope.
     ],
-    clones: [
+    captures: [
         x as old_x,
     ],
 )]
@@ -36,7 +36,7 @@ fn test_clones_not_in_requires(x: i32) {
     maintains: [
         old_x > 0, // Should be an error: `old_x` must not be in scope.
     ],
-    clones: [
+    captures: [
         x as old_x,
     ],
 )]

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -10,8 +10,8 @@ use anodized::spec;
         log.push("maintains2") == (),
     ],
     captures: [
-        log.push("clone1") as _clone1,
-        log.push("clone2") as _clone2,
+        log.push("captures1") as _alias1,
+        log.push("captures2") as _alias2,
     ],
     ensures: [
         log.push("ensures1") == (),
@@ -35,8 +35,8 @@ fn test_execution_order() {
             "requires2",
             "maintains1",
             "maintains2",
-            "clone1",
-            "clone2",
+            "captures1",
+            "captures2",
             "body",
             "maintains1",
             "maintains2",

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -9,7 +9,7 @@ use anodized::spec;
         log.push("maintains1") == (),
         log.push("maintains2") == (),
     ],
-    clones: [
+    captures: [
         log.push("clone1") as _clone1,
         log.push("clone2") as _clone2,
     ],


### PR DESCRIPTION
## Refactor: `clones` to `captures` with move semantics

- Renamed parameter from `clones:` to `captures:` for better clarity
- Changed semantics: Removed automatic `.clone()` insertion, making cloning explicit
- Renamed types: `CloneBinding` to `Capture` throughout codebase

## Implementation Changes

- Updated parser to recognize `captures` keyword
- Modified code generation to move captured expressions (no automatic `.clone()`)
- Simplified `SpecArg` enum structure for cleaner parsing logic

## Test Updates

- Renamed test files: `clones_feature.rs` to `captures_feature.rs`, etc.
- Updated test function names to use "captures" terminology
- Added explicit `.clone()` calls where needed for non-Copy types
- Added new test for explicit cloning behavior

## Documentation Updates

- Updated main README with new `captures:` syntax and semantics
- Added note about explicit cloning requirement for non-Copy types
- Updated core crate EBNF grammar to include `captures` parameter
- Added instrumentation example showing how captures work
- Clarified that captured values are only available to postconditions

## Benefits

- More explicit: Users see exactly when cloning occurs
- Greater flexibility: Users can choose `.clone()`, `.to_owned()`, or other methods
- Rust philosophy: Aligns with "no hidden costs" principle
