### PR TITLE
feat: `backend-no-panic`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Run tests for backend `${{ matrix.backend }}`
+  test-anodized-core:
+    name: Test anodized-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Unit test anodized-core
+        run: cargo test -p anodized-core --lib --no-fail-fast
+
+  test-anodized:
+    name: Test anodized with backend `${{ matrix.backend }}`
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,9 +41,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Unit test anodized-core
-        run: cargo test -p anodized-core --lib --no-fail-fast
 
       - name: Integration test anodized with backend `${{ matrix.backend }}`
         run: cargo test -p anodized --tests --no-fail-fast --features "${{ matrix.features }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
             features: ""
           - backend: no-checks
             features: "backend-no-checks"
+          - backend: no-panic
+            features: "backend-no-panic"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cargo test backend `${{ matrix.backend }}`
-        run: cargo test --no-fail-fast --features "${{ matrix.features }}"
+      - name: Unit test anodized-core
+        run: cargo test -p anodized-core --lib --no-fail-fast
+
+      - name: Integration test anodized with backend `${{ matrix.backend }}`
+        run: cargo test -p anodized --tests --no-fail-fast --features "${{ matrix.features }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Integration test anodized with backend `${{ matrix.backend }}`
-        run: cargo test -p anodized --tests --no-fail-fast --features "backend-${{ matrix.features }}"
+        run: cargo test -p anodized --tests --no-fail-fast --features "backend-${{ matrix.backend }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - backend: default
-            features: ""
-          - backend: no-checks
-            features: "backend-no-checks"
-          - backend: no-panic
-            features: "backend-no-panic"
+          - backend: check-and-panic
+          - backend: check-and-print
+          - backend: no-check
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,4 +40,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Integration test anodized with backend `${{ matrix.backend }}`
-        run: cargo test -p anodized --tests --no-fail-fast --features "${{ matrix.features }}"
+        run: cargo test -p anodized --tests --no-fail-fast --features "backend-${{ matrix.features }}"

--- a/crates/anodized-core/src/backend/function/mod.rs
+++ b/crates/anodized-core/src/backend/function/mod.rs
@@ -18,128 +18,120 @@ impl Backend {
         };
 
         // Generate the new, instrumented function body.
-        let disable_runtime_checks = self.disable_runtime_checks;
-        let new_body = instrument_fn_body(
-            &spec,
-            &func.block,
-            is_async,
-            &return_type,
-            disable_runtime_checks,
-        )?;
+        let new_body = self.instrument_fn_body(&spec, &func.block, is_async, &return_type)?;
 
         // Replace the old function body with the new one.
         *func.block = new_body;
 
         Ok(func)
     }
-}
 
-/// Takes the spec and the original body and returns a new instrumented function body.
-fn instrument_fn_body(
-    spec: &Spec,
-    original_body: &Block,
-    is_async: bool,
-    return_type: &syn::Type,
-    disable_runtime_checks: bool,
-) -> Result<Block> {
-    // The identifier for the return value binding.
-    let output_ident = Ident::new("__anodized_output", Span::mixed_site());
+    fn instrument_fn_body(
+        self,
+        spec: &Spec,
+        original_body: &Block,
+        is_async: bool,
+        return_type: &syn::Type,
+    ) -> Result<Block> {
+        // The identifier for the return value binding.
+        let output_ident = Ident::new("__anodized_output", Span::mixed_site());
 
-    // --- Generate Precondition Checks ---
-    let guard_assert = |assert_stmt: TokenStream2, cfg: Option<&Meta>| {
-        if disable_runtime_checks {
-            quote! { if false { #assert_stmt } }
-        } else if let Some(cfg) = cfg {
-            quote! { if cfg!(#cfg) { #assert_stmt } }
+        // --- Generate Precondition Checks ---
+        let guard_assert = |assert_stmt: TokenStream2, cfg: Option<&Meta>| {
+            if self.disable_runtime_checks {
+                quote! { if false { #assert_stmt } }
+            } else if let Some(cfg) = cfg {
+                quote! { if cfg!(#cfg) { #assert_stmt } }
+            } else {
+                assert_stmt
+            }
+        };
+
+        let preconditions = spec
+            .requires
+            .iter()
+            .map(|condition| {
+                let expr = &condition.expr;
+                let expr_str = expr.to_token_stream().to_string();
+                let assert = quote! { assert!(#expr, "Precondition failed: {}", #expr_str); };
+                guard_assert(assert, condition.cfg.as_ref())
+            })
+            .chain(spec.maintains.iter().map(|condition| {
+                let expr = &condition.expr;
+                let expr_str = expr.to_token_stream().to_string();
+                let assert = quote! { assert!(#expr, "Pre-invariant failed: {}", #expr_str); };
+                guard_assert(assert, condition.cfg.as_ref())
+            }));
+
+        // --- Generate Combined Body and Capture Statement ---
+        // Capture values and execute body in a single tuple assignment
+        // This ensures captured values aren't accessible to the body itself
+
+        // Chain capture aliases with output binding
+        let aliases = spec
+            .captures
+            .iter()
+            .map(|cb| &cb.alias)
+            .chain(std::iter::once(&output_ident));
+
+        // Chain capture expressions with body expression
+        let capture_exprs = spec.captures.iter().map(|cb| {
+            let expr = &cb.expr;
+            quote! { #expr }
+        });
+
+        // Chain underscore types with return type for tuple type annotation
+        let types = spec
+            .captures
+            .iter()
+            .map(|_| quote! { _ })
+            .chain(std::iter::once(quote! { #return_type }));
+
+        let body_expr = if is_async {
+            quote! { (async || #original_body)().await }
         } else {
-            assert_stmt
-        }
-    };
+            quote! { (|| #original_body)() }
+        };
 
-    let preconditions = spec
-        .requires
-        .iter()
-        .map(|condition| {
-            let expr = &condition.expr;
-            let expr_str = expr.to_token_stream().to_string();
-            let assert = quote! { assert!(#expr, "Precondition failed: {}", #expr_str); };
-            guard_assert(assert, condition.cfg.as_ref())
+        let exprs = capture_exprs.chain(std::iter::once(body_expr));
+
+        // Build tuple assignment with type annotation on the tuple
+        let body_and_captures = quote! {
+            let (#(#aliases),*): (#(#types),*) = (#(#exprs),*);
+        };
+
+        // --- Generate Postcondition Checks ---
+        let postconditions = spec
+            .maintains
+            .iter()
+            .map(|condition| {
+                let expr = &condition.expr;
+                let expr_str = expr.to_token_stream().to_string();
+                let assert = quote! { assert!(#expr, "Post-invariant failed: {}", #expr_str); };
+                guard_assert(assert, condition.cfg.as_ref())
+            })
+            .chain(spec.ensures.iter().map(|postcondition| {
+                let closure = annotate_postcondition_closure_argument(
+                    postcondition.closure.clone(),
+                    return_type.clone(),
+                );
+                let closure_str = postcondition.closure.to_token_stream().to_string();
+
+                let assert = quote! {
+                    assert!((#closure)(&#output_ident), "Postcondition failed: {}", #closure_str);
+                };
+                guard_assert(assert, postcondition.cfg.as_ref())
+            }));
+
+        Ok(parse_quote! {
+            {
+                #(#preconditions)*
+                #body_and_captures
+                #(#postconditions)*
+                #output_ident
+            }
         })
-        .chain(spec.maintains.iter().map(|condition| {
-            let expr = &condition.expr;
-            let expr_str = expr.to_token_stream().to_string();
-            let assert = quote! { assert!(#expr, "Pre-invariant failed: {}", #expr_str); };
-            guard_assert(assert, condition.cfg.as_ref())
-        }));
-
-    // --- Generate Combined Body and Capture Statement ---
-    // Capture values and execute body in a single tuple assignment
-    // This ensures captured values aren't accessible to the body itself
-
-    // Chain capture aliases with output binding
-    let aliases = spec
-        .captures
-        .iter()
-        .map(|cb| &cb.alias)
-        .chain(std::iter::once(&output_ident));
-
-    // Chain capture expressions with body expression
-    let capture_exprs = spec.captures.iter().map(|cb| {
-        let expr = &cb.expr;
-        quote! { #expr }
-    });
-
-    // Chain underscore types with return type for tuple type annotation
-    let types = spec
-        .captures
-        .iter()
-        .map(|_| quote! { _ })
-        .chain(std::iter::once(quote! { #return_type }));
-
-    let body_expr = if is_async {
-        quote! { (async || #original_body)().await }
-    } else {
-        quote! { (|| #original_body)() }
-    };
-
-    let exprs = capture_exprs.chain(std::iter::once(body_expr));
-
-    // Build tuple assignment with type annotation on the tuple
-    let body_and_captures = quote! {
-        let (#(#aliases),*): (#(#types),*) = (#(#exprs),*);
-    };
-
-    // --- Generate Postcondition Checks ---
-    let postconditions = spec
-        .maintains
-        .iter()
-        .map(|condition| {
-            let expr = &condition.expr;
-            let expr_str = expr.to_token_stream().to_string();
-            let assert = quote! { assert!(#expr, "Post-invariant failed: {}", #expr_str); };
-            guard_assert(assert, condition.cfg.as_ref())
-        })
-        .chain(spec.ensures.iter().map(|postcondition| {
-            let closure = annotate_postcondition_closure_argument(
-                postcondition.closure.clone(),
-                return_type.clone(),
-            );
-            let closure_str = postcondition.closure.to_token_stream().to_string();
-
-            let assert = quote! {
-                assert!((#closure)(&#output_ident), "Postcondition failed: {}", #closure_str);
-            };
-            guard_assert(assert, postcondition.cfg.as_ref())
-        }));
-
-    Ok(parse_quote! {
-        {
-            #(#preconditions)*
-            #body_and_captures
-            #(#postconditions)*
-            #output_ident
-        }
-    })
+    }
 }
 
 fn annotate_postcondition_closure_argument(

--- a/crates/anodized-core/src/backend/function/mod.rs
+++ b/crates/anodized-core/src/backend/function/mod.rs
@@ -17,7 +17,7 @@ pub fn instrument_fn(backend: Backend, spec: Spec, mut func: ItemFn) -> syn::Res
     };
 
     // Generate the new, instrumented function body.
-    let disable_runtime_checks = backend != Backend::Default;
+    let disable_runtime_checks = backend.disable_runtime_checks;
     let new_body = instrument_fn_body(
         &spec,
         &func.block,
@@ -29,9 +29,7 @@ pub fn instrument_fn(backend: Backend, spec: Spec, mut func: ItemFn) -> syn::Res
     // Replace the old function body with the new one.
     *func.block = new_body;
 
-    match backend {
-        Backend::Default | Backend::NoChecks => Ok(func),
-    }
+    Ok(func)
 }
 
 /// Takes the spec and the original body and returns a new instrumented function body.

--- a/crates/anodized-core/src/backend/function/tests.rs
+++ b/crates/anodized-core/src/backend/function/tests.rs
@@ -32,7 +32,9 @@ fn simple_requires() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -55,7 +57,9 @@ fn requires_disable_runtime_checks() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, true).unwrap();
+    let observed = Backend::NO_CHECKS
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -77,7 +81,9 @@ fn simple_maintains() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -98,7 +104,9 @@ fn simple_ensures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -122,7 +130,9 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -145,7 +155,9 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -169,7 +181,9 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -195,7 +209,9 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -221,7 +237,9 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -251,7 +269,9 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -273,7 +293,9 @@ fn binds_parameter() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -302,7 +324,9 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -339,7 +363,9 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -376,7 +402,9 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -428,7 +456,9 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -459,6 +489,8 @@ fn captures() {
         }
     };
 
-    let observed = instrument_fn_body(&spec, &body, is_async, &ret_type, false).unwrap();
+    let observed = Backend::DEFAULT
+        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/backend/function/tests.rs
+++ b/crates/anodized-core/src/backend/function/tests.rs
@@ -32,7 +32,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -57,7 +57,7 @@ fn requires_disable_runtime_checks() {
         }
     };
 
-    let observed = Backend::NO_CHECKS
+    let observed = Backend::NO_CHECK
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -82,7 +82,7 @@ fn requires_no_panic_backend() {
         }
     };
 
-    let observed = Backend::NO_PANIC
+    let observed = Backend::CHECK_AND_PRINT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -106,7 +106,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -129,7 +129,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -155,7 +155,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -180,7 +180,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -206,7 +206,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -234,7 +234,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -262,7 +262,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -294,7 +294,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -318,7 +318,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -349,7 +349,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -388,7 +388,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -427,7 +427,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -481,7 +481,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -514,7 +514,7 @@ fn captures() {
         }
     };
 
-    let observed = Backend::DEFAULT
+    let observed = Backend::CHECK_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -1,39 +1,71 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Meta;
 pub mod function;
 
 pub struct Backend {
-    pub disable_runtime_checks: bool,
-    pub build_check: fn(&TokenStream, &str, &TokenStream) -> TokenStream,
+    pub build_check: fn(Option<&Meta>, &TokenStream, &str, &TokenStream) -> TokenStream,
 }
 
 impl Backend {
     pub const CHECK_AND_PANIC: Backend = Backend {
-        disable_runtime_checks: false,
         build_check: build_assert,
     };
 
     pub const CHECK_AND_PRINT: Backend = Backend {
-        disable_runtime_checks: false,
         build_check: build_eprint,
     };
 
     pub const NO_CHECK: Backend = Backend {
-        disable_runtime_checks: true,
-        build_check: build_assert,
+        build_check: build_inert,
     };
 }
 
-fn build_assert(expr: &TokenStream, message: &str, repr: &TokenStream) -> TokenStream {
+fn build_assert(
+    cfg: Option<&Meta>,
+    expr: &TokenStream,
+    message: &str,
+    repr: &TokenStream,
+) -> TokenStream {
     let repr_str = repr.to_string();
-    quote! { assert!(#expr, #message, #repr_str); }
+    let check = quote! { assert!(#expr, #message, #repr_str); };
+    guard_check(cfg, check)
 }
 
-fn build_eprint(expr: &TokenStream, message: &str, repr: &TokenStream) -> TokenStream {
+fn build_eprint(
+    cfg: Option<&Meta>,
+    expr: &TokenStream,
+    message: &str,
+    repr: &TokenStream,
+) -> TokenStream {
     let repr_str = repr.to_string();
-    quote! {
+    let check = quote! {
         if !(#expr) {
             eprintln!(#message, #repr_str);
         }
+    };
+    guard_check(cfg, check)
+}
+
+fn build_inert(
+    // The check will not be present at runtime regardless of the `#[cfg]` setting.
+    _cfg: Option<&Meta>,
+    expr: &TokenStream,
+    message: &str,
+    repr: &TokenStream,
+) -> TokenStream {
+    let repr_str = repr.to_string();
+    quote! {
+        if false {
+            assert!(#expr, #message, #repr_str);
+        }
+    }
+}
+
+fn guard_check(cfg: Option<&Meta>, check: TokenStream) -> TokenStream {
+    if let Some(cfg) = cfg {
+        quote! { if cfg!(#cfg) { #check } }
+    } else {
+        check
     }
 }

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -2,7 +2,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 pub mod function;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Backend {
     pub disable_runtime_checks: bool,
     pub build_check: fn(&TokenStream, &str, &TokenStream) -> TokenStream,

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -8,19 +8,19 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub const DEFAULT: Backend = Backend {
+    pub const CHECK_AND_PANIC: Backend = Backend {
         disable_runtime_checks: false,
         build_check: build_assert,
     };
 
-    pub const NO_CHECKS: Backend = Backend {
-        disable_runtime_checks: true,
-        build_check: build_assert,
-    };
-
-    pub const NO_PANIC: Backend = Backend {
+    pub const CHECK_AND_PRINT: Backend = Backend {
         disable_runtime_checks: false,
         build_check: build_eprint,
+    };
+
+    pub const NO_CHECK: Backend = Backend {
+        disable_runtime_checks: true,
+        build_check: build_assert,
     };
 }
 

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -1,16 +1,26 @@
+use proc_macro2::TokenStream;
+use quote::quote;
 pub mod function;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Backend {
     pub disable_runtime_checks: bool,
+    pub build_check: fn(&TokenStream, &str, &TokenStream) -> TokenStream,
 }
 
 impl Backend {
     pub const DEFAULT: Backend = Backend {
         disable_runtime_checks: false,
+        build_check: build_assert,
     };
 
     pub const NO_CHECKS: Backend = Backend {
         disable_runtime_checks: true,
+        build_check: build_assert,
     };
+}
+
+fn build_assert(expr: &TokenStream, message: &str, repr: &TokenStream) -> TokenStream {
+    let repr_str = repr.to_string();
+    quote! { assert!(#expr, #message, #repr_str); }
 }

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -1,9 +1,16 @@
 pub mod function;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Backend {
-    /// Anodized instrumentation with runtime checks.
-    Default,
-    /// Anodized instrumentation with no runtime checks.
-    NoChecks,
+pub struct Backend {
+    pub disable_runtime_checks: bool,
+}
+
+impl Backend {
+    pub const DEFAULT: Backend = Backend {
+        disable_runtime_checks: false,
+    };
+
+    pub const NO_CHECKS: Backend = Backend {
+        disable_runtime_checks: true,
+    };
 }

--- a/crates/anodized-core/src/backend/mod.rs
+++ b/crates/anodized-core/src/backend/mod.rs
@@ -18,9 +18,23 @@ impl Backend {
         disable_runtime_checks: true,
         build_check: build_assert,
     };
+
+    pub const NO_PANIC: Backend = Backend {
+        disable_runtime_checks: false,
+        build_check: build_eprint,
+    };
 }
 
 fn build_assert(expr: &TokenStream, message: &str, repr: &TokenStream) -> TokenStream {
     let repr_str = repr.to_string();
     quote! { assert!(#expr, #message, #repr_str); }
+}
+
+fn build_eprint(expr: &TokenStream, message: &str, repr: &TokenStream) -> TokenStream {
+    let repr_str = repr.to_string();
+    quote! {
+        if !(#expr) {
+            eprintln!(#message, #repr_str);
+        }
+    }
 }

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -14,9 +14,9 @@ license.workspace = true
 proc-macro = true
 
 [features]
-check-and-panic = []
-no-check = []
-check-and-print = []
+backend-check-and-panic = []
+backend-check-and-print = []
+backend-no-check = []
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 
 [features]
 backend-no-checks = []
+backend-no-panic = []
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -14,6 +14,8 @@ license.workspace = true
 proc-macro = true
 
 [features]
+default-features = ["check-and-panic"]
+check-and-panic = []
 backend-no-checks = []
 backend-no-panic = []
 

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -14,10 +14,9 @@ license.workspace = true
 proc-macro = true
 
 [features]
-default-features = ["check-and-panic"]
 check-and-panic = []
-backend-no-checks = []
-backend-no-panic = []
+no-check = []
+check-and-print = []
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -122,16 +122,16 @@ fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 
 Anodized offers multiple backends that control how `#[spec]` annotations expand:
 
-- **default (implicit)**: When no backend feature is selected, Anodized injects runtime `assert!` checks for every `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
-- **`check-and-print`**: Keeps the runtime checks but reports violations with `eprintln!` so execution can continue (useful for experiments or logging).
-- **`no-check`**: Generates the same instrumentation but guards each `assert!` inside `if false { ... }`. This keeps the `#[spec]` syntax- and type-checked while letting the compiler optimize the runtime checks away.
+- **`check-and-panic`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
+- **`check-and-print`**: Reports violations with `eprintln!` so execution can continue (useful for experiments or logging).
+- **`no-check`**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which keeps the `#[spec]` syntax- and type-checked while letting the compiler optimize the runtime checks away.
 
 The backend setting goes in your `Cargo.toml`, for example:
 
 ```toml
 anodized = {
   version = # version
-  features = ["backend-no-check"]
+  features = ["backend-check-and-print"]
 }
 ```
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -123,8 +123,8 @@ fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 Anodized offers multiple backends that control how `#[spec]` annotations expand:
 
 - **`check-and-panic`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
-- **`check-and-print`**: Reports violations with `eprintln!` so execution can continue (useful for experiments or logging).
-- **`no-check`**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which keeps the `#[spec]` syntax- and type-checked while letting the compiler optimize the runtime checks away.
+- **`check-and-print`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
+- **`no-check`**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which lets the compiler optimize the checks away, while keeping the `#[spec]` syntax- and type-checked.
 
 The backend setting goes in your `Cargo.toml`, for example:
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -123,14 +123,15 @@ fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 Anodized offers multiple backends that control how `#[spec]` annotations expand:
 
 - **default (implicit)**: When no backend feature is selected, Anodized injects runtime `assert!` checks for every `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
-- **`backend-no-checks`**: Generates the same instrumentation but guards each `assert!` inside `if false { ... }`. This keeps the `#[spec]` syntax- and type-checked while letting the compiler optimize the runtime checks away.
+- **`check-and-print`**: Keeps the runtime checks but reports violations with `eprintln!` so execution can continue (useful for experiments or logging).
+- **`no-check`**: Generates the same instrumentation but guards each `assert!` inside `if false { ... }`. This keeps the `#[spec]` syntax- and type-checked while letting the compiler optimize the runtime checks away.
 
 The backend setting goes in your `Cargo.toml`, for example:
 
 ```toml
 anodized = {
   version = # version
-  features = ["backend-no-checks"]
+  features = ["no-check"]
 }
 ```
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -131,7 +131,7 @@ The backend setting goes in your `Cargo.toml`, for example:
 ```toml
 anodized = {
   version = # version
-  features = ["no-check"]
+  features = ["backend-no-check"]
 }
 ```
 

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -25,7 +25,10 @@ const BACKEND: Backend = if cfg!(feature = "backend-check-and-panic") {
     Backend::NO_CHECK
 } else {
     panic!(
-        "anodized: you must select a backend feature from `check-and-panic`, `check-and-print`, or `no-check`"
+        r#"anodized: a backend feature must be enabled:
+`backend-check-and-panic`
+`backend-check-and-print`
+`backend-no-check`"#
     )
 };
 

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -9,19 +9,19 @@ use syn::{Item, parse_macro_input};
 use anodized_core::{Spec, backend::Backend};
 
 const _: () = {
-    let count: u32 = cfg!(feature = "check-and-panic") as u32
-        + cfg!(feature = "check-and-print") as u32
-        + cfg!(feature = "no-check") as u32;
+    let count: u32 = cfg!(feature = "backend-check-and-panic") as u32
+        + cfg!(feature = "backend-check-and-print") as u32
+        + cfg!(feature = "backend-no-check") as u32;
     if count > 1 {
         panic!("anodized: backend features are mutually exclusive");
     }
 };
 
-const BACKEND: Backend = if cfg!(feature = "check-and-panic") {
+const BACKEND: Backend = if cfg!(feature = "backend-check-and-panic") {
     Backend::CHECK_AND_PANIC
-} else if cfg!(feature = "check-and-print") {
+} else if cfg!(feature = "backend-check-and-print") {
     Backend::CHECK_AND_PRINT
-} else if cfg!(feature = "no-check") {
+} else if cfg!(feature = "backend-no-check") {
     Backend::NO_CHECK
 } else {
     panic!(

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -9,19 +9,24 @@ use syn::{Item, parse_macro_input};
 use anodized_core::{Spec, backend::Backend};
 
 const _: () = {
-    let count: u32 =
-        cfg!(feature = "backend-no-checks") as u32 + cfg!(feature = "backend-no-panic") as u32;
+    let count: u32 = cfg!(feature = "check-and-panic") as u32
+        + cfg!(feature = "backend-no-checks") as u32
+        + cfg!(feature = "backend-no-panic") as u32;
     if count > 1 {
         panic!("anodized: backend features are mutually exclusive");
     }
 };
 
-const BACKEND: Backend = if cfg!(feature = "backend-no-checks") {
-    Backend::NO_CHECKS
+const BACKEND: Backend = if cfg!(feature = "check-and-panic") {
+    Backend::CHECK_AND_PANIC
+} else if cfg!(feature = "backend-no-checks") {
+    Backend::NO_CHECK
 } else if cfg!(feature = "backend-no-panic") {
-    Backend::NO_PANIC
+    Backend::CHECK_AND_PRINT
 } else {
-    Backend::DEFAULT
+    panic!(
+        "anodized: you must select a feature from `check-and-panic`, `check-and-print`, `no-check`"
+    )
 };
 
 /// The main procedural macro for defining specifications on functions.

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -9,7 +9,8 @@ use syn::{Item, parse_macro_input};
 use anodized_core::{Spec, backend::Backend};
 
 const _: () = {
-    let count: u32 = cfg!(feature = "backend-no-checks") as u32;
+    let count: u32 =
+        cfg!(feature = "backend-no-checks") as u32 + cfg!(feature = "backend-no-panic") as u32;
     if count > 1 {
         panic!("anodized: backend features are mutually exclusive");
     }
@@ -17,6 +18,8 @@ const _: () = {
 
 const BACKEND: Backend = if cfg!(feature = "backend-no-checks") {
     Backend::NO_CHECKS
+} else if cfg!(feature = "backend-no-panic") {
+    Backend::NO_PANIC
 } else {
     Backend::DEFAULT
 };

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -10,8 +10,8 @@ use anodized_core::{Spec, backend::Backend};
 
 const _: () = {
     let count: u32 = cfg!(feature = "check-and-panic") as u32
-        + cfg!(feature = "backend-no-checks") as u32
-        + cfg!(feature = "backend-no-panic") as u32;
+        + cfg!(feature = "check-and-print") as u32
+        + cfg!(feature = "no-check") as u32;
     if count > 1 {
         panic!("anodized: backend features are mutually exclusive");
     }
@@ -19,13 +19,13 @@ const _: () = {
 
 const BACKEND: Backend = if cfg!(feature = "check-and-panic") {
     Backend::CHECK_AND_PANIC
-} else if cfg!(feature = "backend-no-checks") {
-    Backend::NO_CHECK
-} else if cfg!(feature = "backend-no-panic") {
+} else if cfg!(feature = "check-and-print") {
     Backend::CHECK_AND_PRINT
+} else if cfg!(feature = "no-check") {
+    Backend::NO_CHECK
 } else {
     panic!(
-        "anodized: you must select a feature from `check-and-panic`, `check-and-print`, `no-check`"
+        "anodized: you must select a backend feature from `check-and-panic`, `check-and-print`, or `no-check`"
     )
 };
 

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -6,10 +6,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{Item, parse_macro_input};
 
-use anodized_core::{
-    Spec,
-    backend::{Backend, function::instrument_fn},
-};
+use anodized_core::{Spec, backend::Backend};
 
 const _: () = {
     let count: u32 = cfg!(feature = "backend-no-checks") as u32;
@@ -36,7 +33,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let result = match item {
         Item::Fn(func) => {
             let spec = parse_macro_input!(args as Spec);
-            instrument_fn(BACKEND, spec, func)
+            BACKEND.instrument_fn(spec, func)
         }
         unsupported_item => {
             let item_type = item_to_string(&unsupported_item);

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -19,9 +19,9 @@ const _: () = {
 };
 
 const BACKEND: Backend = if cfg!(feature = "backend-no-checks") {
-    Backend::NoChecks
+    Backend::NO_CHECKS
 } else {
-    Backend::Default
+    Backend::DEFAULT
 };
 
 /// The main procedural macro for defining specifications on functions.

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -29,7 +29,7 @@ fn job_start_success() {
     job.start();
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: matches! (self.state, State::Idle)")]
 fn job_start_panics_if_not_idle() {

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -29,7 +29,7 @@ fn job_start_success() {
     job.start();
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Precondition failed: matches! (self.state, State::Idle)")]
 fn job_start_panics_if_not_idle() {

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -29,7 +29,7 @@ fn job_start_success() {
     job.start();
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: matches! (self.state, State::Idle)")]
 fn job_start_panics_if_not_idle() {

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -13,7 +13,7 @@ fn divide_success() {
     checked_divide(10, 2);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: divisor != 0")]
 fn divide_by_zero_panics() {

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -13,7 +13,7 @@ fn divide_success() {
     checked_divide(10, 2);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: divisor != 0")]
 fn divide_by_zero_panics() {

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -13,7 +13,7 @@ fn divide_success() {
     checked_divide(10, 2);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Precondition failed: divisor != 0")]
 fn divide_by_zero_panics() {

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -116,7 +116,7 @@ fn captures_with_preconditions() {
     assert_eq!(container.counter, 51);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed")]
 fn capture_postcondition_failure() {
@@ -133,7 +133,7 @@ fn capture_postcondition_failure() {
     bad_increment(&mut val);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed")]
 fn precondition_runs_before_captures() {

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -116,7 +116,7 @@ fn captures_with_preconditions() {
     assert_eq!(container.counter, 51);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed")]
 fn capture_postcondition_failure() {
@@ -133,7 +133,7 @@ fn capture_postcondition_failure() {
     bad_increment(&mut val);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed")]
 fn precondition_runs_before_captures() {

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -116,7 +116,7 @@ fn captures_with_preconditions() {
     assert_eq!(container.counter, 51);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Postcondition failed")]
 fn capture_postcondition_failure() {
@@ -133,7 +133,7 @@ fn capture_postcondition_failure() {
     bad_increment(&mut val);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Precondition failed")]
 fn precondition_runs_before_captures() {

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     pair
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     pair
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     pair
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -23,7 +23,7 @@ fn func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(feature = "no-check"))]
 #[test]
 fn execution_order() {
     let mut log = Vec::new();
@@ -71,7 +71,7 @@ async fn async_func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(feature = "no-check"))]
 #[test]
 fn async_execution_order() {
     let mut log = Vec::new();

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -50,6 +50,54 @@ fn execution_order() {
 
 #[spec(
     requires: [
+        log.push("requires1") != (),
+        log.push("requires2") != (),
+    ],
+    maintains: [
+        log.push("maintains1") != (),
+        log.push("maintains2") != (),
+    ],
+    captures: [
+        log.push("captures1") as _alias1,
+        log.push("captures2") as _alias2,
+    ],
+    ensures: [
+        log.push("ensures1") != (),
+        log.push("ensures2") != (),
+    ],
+)]
+fn func_all_conditions_fail(log: &mut Vec<&'static str>) {
+    log.push("body");
+    return;
+}
+
+#[cfg(feature = "backend-check-and-print")]
+#[test]
+fn execution_order_print_only() {
+    let mut log = Vec::new();
+    func_all_conditions_fail(&mut log);
+
+    // Verify the exact execution order
+    assert_eq!(
+        log,
+        [
+            "requires1",
+            "requires2",
+            "maintains1",
+            "maintains2",
+            "captures1",
+            "captures2",
+            "body",
+            "maintains1",
+            "maintains2",
+            "ensures1",
+            "ensures2",
+        ]
+    );
+}
+
+#[spec(
+    requires: [
         log.push("requires1") == (),
         log.push("requires2") == (),
     ],

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -23,7 +23,7 @@ fn func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "no-check"))]
+#[cfg(not(feature = "backend-no-check"))]
 #[test]
 fn execution_order() {
     let mut log = Vec::new();
@@ -71,7 +71,7 @@ async fn async_func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "no-check"))]
+#[cfg(not(feature = "backend-no-check"))]
 #[test]
 fn async_execution_order() {
     let mut log = Vec::new();

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     (b, a)
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     (b, a)
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     (b, a)
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -18,7 +18,7 @@ impl Validator {
     }
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.is_valid()")]
 fn violates_post_invariant() {
@@ -27,7 +27,7 @@ fn violates_post_invariant() {
     v.set_validity(false);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.is_valid()")]
 fn violates_pre_invariant() {

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -18,7 +18,7 @@ impl Validator {
     }
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.is_valid()")]
 fn violates_post_invariant() {
@@ -27,7 +27,7 @@ fn violates_post_invariant() {
     v.set_validity(false);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.is_valid()")]
 fn violates_pre_invariant() {

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -18,7 +18,7 @@ impl Validator {
     }
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.is_valid()")]
 fn violates_post_invariant() {
@@ -27,7 +27,7 @@ fn violates_post_invariant() {
     v.set_validity(false);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.is_valid()")]
 fn violates_pre_invariant() {

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -23,7 +23,7 @@ fn increment_success() {
     c.increment();
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.count <= self.capacity")]
 fn increment_violates_invariant() {
@@ -35,7 +35,7 @@ fn increment_violates_invariant() {
     c.increment();
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.count <= self.capacity")]
 fn increment_violates_pre_invariant() {

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -23,7 +23,7 @@ fn increment_success() {
     c.increment();
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.count <= self.capacity")]
 fn increment_violates_invariant() {
@@ -34,7 +34,7 @@ fn increment_violates_invariant() {
     c.increment(); // This will make count 11, violating the invariant on exit.
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.count <= self.capacity")]
 fn increment_violates_pre_invariant() {

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -23,7 +23,7 @@ fn increment_success() {
     c.increment();
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.count <= self.capacity")]
 fn increment_violates_invariant() {
@@ -31,16 +31,18 @@ fn increment_violates_invariant() {
         count: 10,
         capacity: 10,
     };
-    c.increment(); // This will make count 11, violating the invariant on exit.
+    // This will make count 11, violating the invariant on exit.
+    c.increment();
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.count <= self.capacity")]
 fn increment_violates_pre_invariant() {
     let mut c = Counter {
         count: 11,
-        capacity: 10, // count > capacity, violates pre-invariant
+        // count > capacity, violates pre-invariant
+        capacity: 10,
     };
     c.increment();
 }

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -30,7 +30,7 @@ fn get_element_success() {
     buffer.get_element(1);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: ! self.locked")]
 fn get_element_panics_when_locked() {
@@ -42,7 +42,7 @@ fn get_element_panics_when_locked() {
     buffer.get_element(1);
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: index < self.items.len()")]
 fn get_element_panics_on_out_of_bounds() {
@@ -51,5 +51,6 @@ fn get_element_panics_on_out_of_bounds() {
         initialized: true,
         locked: false,
     };
-    buffer.get_element(5); // This will violate the precondition.
+    // This will violate the precondition.
+    buffer.get_element(5);
 }

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -30,7 +30,7 @@ fn get_element_success() {
     buffer.get_element(1);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: ! self.locked")]
 fn get_element_panics_when_locked() {
@@ -42,7 +42,7 @@ fn get_element_panics_when_locked() {
     buffer.get_element(1);
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Precondition failed: index < self.items.len()")]
 fn get_element_panics_on_out_of_bounds() {

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -30,7 +30,7 @@ fn get_element_success() {
     buffer.get_element(1);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Precondition failed: ! self.locked")]
 fn get_element_panics_when_locked() {
@@ -42,7 +42,7 @@ fn get_element_panics_when_locked() {
     buffer.get_element(1);
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Precondition failed: index < self.items.len()")]
 fn get_element_panics_on_out_of_bounds() {

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -33,7 +33,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
+#[cfg(feature = "check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -33,7 +33,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(not(feature = "backend-no-checks"))]
+#[cfg(not(any(feature = "backend-no-checks", feature = "backend-no-panic")))]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -33,7 +33,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(feature = "check-and-panic")]
+#[cfg(feature = "backend-check-and-panic")]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {


### PR DESCRIPTION
- Refactor `Backend` to a data-driven struct with `CHECK_AND_PANIC`, `CHECK_AND_PRINT`, and `NO_CHECK` constants.
- Instrumentation now delegates to per-backend check builders that `assert!` or log with `eprintln!`.
- Rename the public feature flags on the `anodized` proc-macro crate to `backend-check-and-panic`, `backend-check-and-print`, and `backend-no-check`.
- Update docs to describe the new naming and behavior, and update every test’s `cfg` guards accordingly.
- Split the CI workflow into dedicated jobs for `anodized-core` and `anodized`, and exercise the macro crate against all backend variants via a feature matrix using the new names.
