### PR TITLE
docs: `README` Quickstart adjustments

### DIFF
--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -139,7 +139,7 @@ fn main() {
 Your code is automatically instrumented to check the specifications at runtime. A spec violation will cause a panic with a descriptive error message:
 
 ```text
-thread 'main' panicked at 'Precondition failed: whole > 0', src/main.rs:17:5
+thread 'main' panicked at 'Precondition failed: part <= whole', src/main.rs:17:5
 ```
 
 By default, runtime spec-checking is always active (just like Rust's `assert!` macro). For performance-sensitive code, you can use `#[cfg]` attributes to control when checks run (see the [#[cfg] section](#cfg-configure-runtime-checks) below).


### PR DESCRIPTION
Resolves #86 
[Quickstart](https://github.com/mkovaxx/anodized/tree/main/crates/anodized#quickstart):
- Added runtime behavior `1. Add Anodized to your project.`
- Changed error message to include `part <= whole` in `3. Run or test your code as usual.`
