### PR TITLE
Add the ability to pattern match an identifier within a captures expression.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ keywords = ["correctness", "design-by-contract", "fuzzing", "testing", "verifica
 anodized-core = { version = "0.3.0", path = "crates/anodized-core" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits", "full"] }
+syn = { version = "2.0", features = ["extra-traits", "full", "parsing"] }

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,13 +1,17 @@
 use proc_macro2::Span;
 use syn::{
-    Attribute, Expr, Ident, Pat, Token,
+    Attribute, Expr, ExprCast, ExprPath, Ident, Pat, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
+    token,
 };
 
 /// Raw spec arguments, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
 ///
 /// Can represent a well-formed but invalid spec so that e.g. `anodized-fmt` may work with it.
+///
+/// Can also contain representations items which are not strictly top level rust
+/// expressions corresponding to [`syn::Expr`], see [`SpecArgValue`]
 pub struct SpecArgs {
     pub args: Punctuated<SpecArg, Token![,]>,
 }
@@ -36,6 +40,7 @@ impl Parse for SpecArg {
         let colon = input.parse()?;
         let value = match keyword {
             Keyword::Binds => SpecArgValue::parse_pat_or_expr(input)?,
+            Keyword::Captures => SpecArgValue::Captures(input.parse()?),
             _ => SpecArgValue::parse_expr_or_pat(input)?,
         };
 
@@ -49,11 +54,17 @@ impl Parse for SpecArg {
     }
 }
 
-/// Each SpecArg's value needs to be parsed in a way that allows invalid specs.
+/// Each [`SpecArg`]'s value needs to be parsed in a way that allows invalid specs
+/// and non top level rust expressions corresponding to [`syn::Expr`].
+///
+/// Some [SpecArgs](SpecArg) are not full rust expressions and instead components of
+/// expressions such as the match arms of a [`syn::ExprMatch`] in capture lists
+/// or [`syn::Pat`] in binds.
 #[derive(Debug, Clone)]
 pub enum SpecArgValue {
     Expr(Expr),
     Pat(Pat),
+    Captures(CaptureList),
 }
 
 impl SpecArgValue {
@@ -62,6 +73,10 @@ impl SpecArgValue {
         match self {
             Self::Expr(expr) => Ok(expr),
             Self::Pat(pat) => Err(syn::Error::new_spanned(pat, "expected an expression")),
+            Self::Captures(_) => Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "expected an expression, got captures",
+            )),
         }
     }
 
@@ -69,7 +84,23 @@ impl SpecArgValue {
     pub fn try_into_pat(self) -> Result<Pat> {
         match self {
             Self::Pat(pat) => Ok(pat),
-            Self::Expr(expr) => Err(syn::Error::new_spanned(expr, "expected a pattern")),
+            Self::Expr(expr) => Err(syn::Error::new_spanned(
+                expr,
+                "expected a pattern, got an expression",
+            )),
+            Self::Captures(_) => Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "expected a pattern, got captures",
+            )),
+        }
+    }
+
+    /// Return the `CaptureList` or fail.
+    pub fn try_into_captures(self) -> Result<CaptureList> {
+        match self {
+            Self::Captures(list) => Ok(list),
+            Self::Expr(expr) => Err(syn::Error::new_spanned(expr, "expected captures")),
+            Self::Pat(pat) => Err(syn::Error::new_spanned(pat, "expected captures")),
         }
     }
 
@@ -119,6 +150,129 @@ impl SpecArgValue {
             }
             Err(err) => Err(err),
         }
+    }
+}
+
+/// A list of capture expressions, either a single one or an array.
+/// These are not composed of top level [`syn::Expr`] expressions.
+#[derive(Debug, Clone)]
+pub enum CaptureList {
+    Single(CaptureExpr),
+    Array {
+        bracket: token::Bracket,
+        elems: Punctuated<CaptureExpr, Token![,]>,
+    },
+}
+
+impl Parse for CaptureList {
+    fn parse(input: ParseStream) -> Result<Self> {
+        use syn::parse::discouraged::Speculative;
+
+        // For bracketed input, we need to distinguish between:
+        // 1. `[a, b, c]` - an array of capture expressions
+        // 2. `[a, b, c] as slice` - a single capture with an array expr
+        //
+        // If it starts with a bracket, peek ahead to see if there's an `as` after the bracket
+        if input.peek(token::Bracket) {
+            let fork = input.fork();
+            // Try to parse as a single expression with cast (e.g., `[a, b, c] as slice`)
+            if let Ok(capture) = fork.parse::<CaptureExpr>() {
+                // Only use this parse if it's a Cast (has `as` alias) or more complex
+                match &capture {
+                    CaptureExpr::Cast(_) | CaptureExpr::Expr(Expr::Cast(_)) => {
+                        input.advance_to(&fork);
+                        return Ok(CaptureList::Single(capture));
+                    }
+                    _ => {}
+                }
+            }
+            // Otherwise, parse as an array of captures
+            let content;
+            let bracket = syn::bracketed!(content in input);
+            let elems = Punctuated::parse_terminated(&content)?;
+            Ok(CaptureList::Array { bracket, elems })
+        } else {
+            Ok(CaptureList::Single(input.parse()?))
+        }
+    }
+}
+
+/// An expression in a `capture` block which can either be a Cast, Ident, or a cast like pattern
+/// match.
+#[derive(Debug, Clone)]
+pub enum CaptureExpr {
+    Ident(ExprPath),
+    Cast(ExprCast),
+    Pattern(Pat),
+    /// A general expression (for error reporting on complex expressions without alias)
+    Expr(Expr),
+}
+
+impl Parse for CaptureExpr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        use syn::parse::discouraged::Speculative;
+
+        // Try `ident as pattern` syntax first
+        // Parse: identifier, `as` keyword, then a pattern
+        {
+            let fork = input.fork();
+            if let Ok(ident) = fork.parse::<Ident>()
+                && fork.peek(Token![as])
+            {
+                let _: Token![as] = fork.parse().unwrap();
+                // Try to parse the RHS as a pattern
+                if let Ok(pat) = Pat::parse_single(&fork) {
+                    // Only accept if it's a complex pattern (not just an identifier)
+                    // Simple identifiers like `x as alias` should use Cast path
+                    let is_complex_pattern = !matches!(&pat, Pat::Ident(p) if p.subpat.is_none());
+                    if is_complex_pattern {
+                        input.advance_to(&fork);
+                        // Reconstruct as Pat::Ident with subpat
+                        let pat_ident = syn::PatIdent {
+                            attrs: vec![],
+                            by_ref: None,
+                            mutability: None,
+                            ident,
+                            subpat: Some((syn::token::At::default(), Box::new(pat))),
+                        };
+                        return Ok(CaptureExpr::Pattern(Pat::Ident(pat_ident)));
+                    }
+                }
+            }
+        }
+
+        // Try Cast, but only accept if the RHS is a simple identifier.
+        // This handles `expr as alias` syntax for simple aliasing.
+        {
+            let fork = input.fork();
+            if let Ok(cast) = fork.parse::<ExprCast>()
+                && let syn::Type::Path(ref type_path) = *cast.ty
+                    && type_path.qself.is_none()
+                        && type_path.path.leading_colon.is_none()
+                        && type_path.path.segments.len() == 1
+                        && type_path.path.segments[0].arguments.is_none()
+                    {
+                        input.advance_to(&fork);
+                        return Ok(CaptureExpr::Cast(cast));
+                    }
+        }
+
+        // Try ExprPath (e.g., `foo` or `foo::bar`)
+        // Only accept if it's a complete expression (followed by comma or EOF)
+        // Note: Do NOT accept if followed by `[` as that's indexing (e.g., `foo[0]`)
+        {
+            let fork = input.fork();
+            if let Ok(path) = fork.parse::<ExprPath>() {
+                // Check if the path is the complete expression
+                if fork.is_empty() || fork.peek(Token![,]) {
+                    input.advance_to(&fork);
+                    return Ok(CaptureExpr::Ident(path));
+                }
+            }
+        }
+
+        // Fall back to general Expr (will be validated later for alias requirement)
+        Ok(CaptureExpr::Expr(input.parse()?))
     }
 }
 

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -73,8 +73,10 @@ impl Backend {
         let aliases = spec
             .captures
             .iter()
-            .map(|cb| &cb.alias)
-            .chain(std::iter::once(&output_ident));
+            // convert to token stream so that the mismatch
+            // types can be chained
+            .map(|cb| cb.pat.to_token_stream())
+            .chain(std::iter::once(output_ident.to_token_stream()));
 
         // Chain capture expressions with body expression
         let capture_exprs = spec.captures.iter().map(|cb| {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro2::Span;
-use syn::{Expr, Ident, Meta};
+use syn::{Expr, Meta, Pat};
 
 pub mod annotate;
 pub mod instrument;
@@ -69,6 +69,6 @@ pub struct PostCondition {
 pub struct Capture {
     /// The expression to capture.
     pub expr: Expr,
-    /// The identifier to bind the captured value to.
-    pub alias: Ident,
+    /// The pattern to bind the captured value to.
+    pub pat: Pat,
 }

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -126,12 +126,12 @@ fn assert_capture_eq(left: &Capture, right: &Capture, msg_prefix: &str) {
     // Destructure to ensure we handle all fields
     let Capture {
         expr: left_expr,
-        alias: left_alias,
+        pat: left_alias,
     } = left;
 
     let Capture {
         expr: right_expr,
-        alias: right_alias,
+        pat: right_alias,
     } = right;
 
     assert_eq!(

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -248,10 +248,22 @@ use anodized::spec;
     ],
 )]
 fn add_item<T: Clone + Eq>(items: &mut Vec<T>, item: T) { todo!() }
+
+// Pattern matching works on arrays:
+#[spec(
+    captures: arr as [first, second, third],
+    ensures: [
+        first == arr[0],
+        second == arr[1],
+        third == arr[2],
+    ],
+)]
+fn match_array(arr: [i32; 3]) { todo!() }
 ```
 
 - **Simple identifiers** get an automatic `old_` prefix, i.e. `x` becomes `old_x`.
 - **Complex expressions** require an explicit alias using `as`, i.e. `self.items.len() as orig_len`.
+- **Pattern Match Expressions** are also possible with the `ident as pattern` syntax.
 - **No automatic cloning**: Each captured expression is **moved**. For a `Copy` type, a copy is made implicitly. For a non-`Copy` type, you must explicitly use `.clone()`, `.to_owned()`, or another appropriate method.
 - Capturing happens **after** preconditions are checked but **before** the function body executes.
 - The captured values are **only** available to postconditions, not to preconditions or the function body itself.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,3 +18,7 @@ path = "push_checked.rs"
 [[bin]]
 name = "withdraw"
 path = "withdraw.rs"
+
+[[bin]]
+name = "pattern_match"
+path = "pattern_match.rs"

--- a/examples/pattern_match.rs
+++ b/examples/pattern_match.rs
@@ -1,0 +1,70 @@
+use anodized::spec;
+
+#[derive(Debug, Clone, Copy)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[spec(
+    captures: arr as [first, second, third],
+    ensures: [
+        first == arr[0],
+        second == arr[1],
+        third == arr[2],
+    ],
+)]
+fn match_array(arr: [i32; 3]) {
+    println!("Array elements: {}, {}, {}", arr[0], arr[1], arr[2]);
+}
+
+#[spec(
+    captures: tuple as (a, b, c),
+    ensures: [
+        a + b + c == tuple.0 + tuple.1 + tuple.2,
+    ],
+)]
+fn match_tuple(tuple: (i32, i32, i32)) {
+    let (a, b, c) = tuple;
+    println!("Sum: {}, Product: {}", a + b + c, a * b * c);
+}
+
+#[spec(
+    captures: point as Point { x, y },
+    ensures: [
+        x == point.x,
+        y == point.y,
+    ],
+)]
+fn match_struct(point: Point) {
+    println!("Point: ({}, {})", point.x, point.y);
+}
+
+#[spec(
+    captures: [a, b, c] as slice,
+    ensures: [
+        slice[0] == a,
+        slice[1] == b,
+        slice[2] == c,
+    ],
+)]
+fn capture_as_array(a: i32, b: i32, c: i32) {
+    println!("Captured as array: {:?}", [a, b, c]);
+}
+
+fn main() {
+    // Array pattern matching
+    let numbers = [1, 2, 3];
+    match_array(numbers);
+
+    // Tuple pattern matching
+    let coords = (3, 4, 5);
+    match_tuple(coords);
+
+    // Struct pattern matching
+    let point = Point { x: 5, y: -3 };
+    match_struct(point);
+
+    // Array expression captured with alias
+    capture_as_array(10, 20, 30);
+}


### PR DESCRIPTION
Fixes #83 

This is accomplished by modifying the initial parsing step to account
for one more type of non syn::Expr which can be in a capture list.

These are not top level syn::Expr, but instead match arm patterns, "type
casts (which is a bit of a hack)", or expressions in the form of syn::Ident.

We parse captures as their on variant which can later be transformed
into the higher level Captures structure upon parsing the entire Spec.