### PR TITLE
feat: patterns in `captures`

### DIFF
--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,8 +1,10 @@
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream, TokenTree};
+use quote::ToTokens;
 use syn::{
-    Attribute, Expr, Ident, Pat, Token,
+    Attribute, Expr, ExprCast, ExprPath, Ident, Pat, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
+    token,
 };
 
 /// Raw spec arguments, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
@@ -36,6 +38,7 @@ impl Parse for SpecArg {
         let colon = input.parse()?;
         let value = match keyword {
             Keyword::Binds => SpecArgValue::parse_pat_or_expr(input)?,
+            Keyword::Captures => SpecArgValue::Captures(input.parse()?),
             _ => SpecArgValue::parse_expr_or_pat(input)?,
         };
 
@@ -48,12 +51,17 @@ impl Parse for SpecArg {
         })
     }
 }
-
-/// Each SpecArg's value needs to be parsed in a way that allows invalid specs.
+/// Each [`SpecArg`]'s value needs to be parsed in a way that allows invalid specs, e.g.
+/// forms which do not correspond directly to an [`syn::Expr`] in standard Rust.
+///
+/// NOTE:
+/// a [`SpecArgValue`] may hold unrelated syntactic elements such as ['syn::Expr`], [`syn::Pat`],
+/// and even fragments that would never appear as part of a valid Rust program.
 #[derive(Debug, Clone)]
 pub enum SpecArgValue {
     Expr(Expr),
     Pat(Pat),
+    Captures(Captures),
 }
 
 impl SpecArgValue {
@@ -62,6 +70,9 @@ impl SpecArgValue {
         match self {
             Self::Expr(expr) => Ok(expr),
             Self::Pat(pat) => Err(syn::Error::new_spanned(pat, "expected an expression")),
+            Self::Captures(captures) => {
+                Err(syn::Error::new_spanned(captures, "expected an expression"))
+            }
         }
     }
 
@@ -70,6 +81,24 @@ impl SpecArgValue {
         match self {
             Self::Pat(pat) => Ok(pat),
             Self::Expr(expr) => Err(syn::Error::new_spanned(expr, "expected a pattern")),
+            Self::Captures(captures) => {
+                Err(syn::Error::new_spanned(captures, "expected a pattern"))
+            }
+        }
+    }
+
+    /// Return the `CaptureList` or fail.
+    pub fn try_into_captures(self) -> Result<Captures> {
+        match self {
+            Self::Captures(list) => Ok(list),
+            Self::Expr(expr) => Err(syn::Error::new_spanned(
+                expr,
+                "expected captures: expression `as` pattern",
+            )),
+            Self::Pat(pat) => Err(syn::Error::new_spanned(
+                pat,
+                "expected captures: expression `as` pattern",
+            )),
         }
     }
 
@@ -122,6 +151,173 @@ impl SpecArgValue {
     }
 }
 
+/// A group of capture expressions, either a single one or a list.
+/// These are not composed of top level [`syn::Expr`] expressions.
+#[derive(Debug, Clone)]
+pub enum Captures {
+    One(CaptureExpr),
+    Many {
+        bracket: token::Bracket,
+        elems: Punctuated<CaptureExpr, Token![,]>,
+    },
+}
+
+impl Parse for Captures {
+    fn parse(input: ParseStream) -> Result<Self> {
+        use syn::parse::discouraged::Speculative;
+
+        // For bracketed input, we need to distinguish between:
+        // 1. `[a, b, c]` - an array of capture expressions
+        // 2. `[a, b, c] as slice` - a single capture with an array expr
+        //
+        // Multiple captures are in brackets, not followed by `as`
+        if input.peek(token::Bracket) && !input.peek2(Token![as]) {
+            // Parse as an array of captures
+            let content;
+            let bracket = syn::bracketed!(content in input);
+            let elems = Punctuated::parse_terminated(&content)?;
+            Ok(Captures::Many { bracket, elems })
+        } else {
+            // Otherwise parse as one capture
+            Ok(Captures::One(input.parse()?))
+        }
+    }
+}
+
+impl ToTokens for Captures {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::One(capture_expr) => capture_expr.to_tokens(tokens),
+            Self::Many { bracket, elems } => bracket.surround(tokens, |tokens| {
+                elems.to_tokens(tokens);
+            }),
+        }
+    }
+}
+
+/// The form in a `captures` clause: <expression> `as` <pattern>.
+#[derive(Debug, Clone)]
+pub struct CaptureExpr {
+    pub expr: Option<Expr>,
+    pub as_: Option<Token![as]>,
+    pub pat: Option<Pat>,
+}
+
+impl ToTokens for CaptureExpr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(expr) = &self.expr {
+            expr.to_tokens(tokens);
+        }
+        if let Some(as_) = &self.as_ {
+            as_.to_tokens(tokens);
+        }
+        if let Some(pat) = &self.pat {
+            pat.to_tokens(tokens);
+        }
+    }
+}
+
+impl Parse for CaptureExpr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        use syn::parse::discouraged::Speculative;
+
+        // Try `expr as <something>` by splitting at the top-level `as` keyword.
+        {
+            let fork = input.fork();
+            let lhs_ts = take_until_as(&fork)?;
+
+            if fork.peek(Token![as]) {
+                let _: Token![as] = fork.parse()?;
+
+                // Try RHS as a complex pattern (struct, tuple, slice, etc.)
+                if lhs_ts.is_empty() {
+                    // No expr before `as` — incomplete input (e.g. `as Person { name, age }`)
+                    let fork_after_as = fork.fork();
+                    if let Ok(pat) = Pat::parse_single(&fork_after_as) {
+                        let done = fork_after_as.is_empty() || fork_after_as.peek(Token![,]);
+                        if done {
+                            input.advance_to(&fork_after_as);
+                            return Ok(CaptureExpr {
+                                expr: None,
+                                as_: Some(Default::default()),
+                                pat: Some(pat),
+                            });
+                        }
+                    }
+                } else if let Ok(lhs_expr) = syn::parse2::<Expr>(lhs_ts) {
+                    let fork_after_as = fork.fork();
+                    if let Ok(pat) = Pat::parse_single(&fork_after_as) {
+                        let is_complex_pattern =
+                            !matches!(&pat, Pat::Ident(p) if p.subpat.is_none());
+                        let done = fork_after_as.is_empty() || fork_after_as.peek(Token![,]);
+
+                        if is_complex_pattern && done {
+                            input.advance_to(&fork_after_as);
+                            return Ok(CaptureExpr {
+                                expr: Some(lhs_expr),
+                                as_: Some(Default::default()),
+                                pat: Some(pat),
+                            });
+                        }
+                    }
+                }
+
+                // Try as a simple cast/alias (`expr as alias`).
+                // Re-parse the full input as ExprCast since we need syn to build the node.
+                {
+                    let fork_after_as = input.fork();
+                    if let Ok(cast) = fork_after_as.parse::<ExprCast>()
+                        && let syn::Type::Path(ref type_path) = *cast.ty
+                        && type_path.qself.is_none()
+                        && type_path.path.leading_colon.is_none()
+                        && type_path.path.segments.len() == 1
+                        && type_path.path.segments[0].arguments.is_none()
+                    {
+                        let done = fork_after_as.is_empty() || fork_after_as.peek(Token![,]);
+                        if done {
+                            input.advance_to(&fork_after_as);
+                            return Ok(CaptureExpr {
+                                expr: Some(*cast.expr),
+                                as_: Some(cast.as_token),
+                                pat: Some(Pat::Ident(syn::PatIdent {
+                                    attrs: vec![],
+                                    by_ref: None,
+                                    mutability: None,
+                                    ident: type_path.path.segments[0].ident.clone(),
+                                    subpat: None,
+                                })),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Try ExprPath (e.g., `foo` or `foo::bar`)
+        // Only accept if it's a path (optionally followed by a comma)
+        {
+            let fork = input.fork();
+            if let Ok(path) = fork.parse::<ExprPath>()
+                && (fork.is_empty() || fork.peek(Token![,]))
+            {
+                input.advance_to(&fork);
+                return Ok(CaptureExpr {
+                    expr: Some(Expr::Path(path)),
+                    as_: None,
+                    pat: None,
+                });
+            }
+        }
+
+        // Fall back to general Expr (will be validated later for alias requirement)
+        Ok(CaptureExpr {
+            expr: Some(input.parse()?),
+            as_: None,
+            pat: None,
+        })
+    }
+}
+
 /// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
 /// as if they were built-in Rust keywords during parsing.
 pub mod kw {
@@ -166,4 +362,24 @@ impl Keyword {
             (Unknown(ident), span)
         })
     }
+}
+
+/// Consume tokens from the parse stream up to (but not including) a top-level `as` keyword.
+/// Returns the collected tokens. Groups (delimited by `()`, `[]`, `{}`) are consumed atomically,
+/// so any `as` inside them is ignored.
+fn take_until_as(input: ParseStream) -> Result<TokenStream> {
+    input.step(|cursor| {
+        let mut ts = TokenStream::new();
+        let mut c = *cursor;
+
+        while let Some((tt, next)) = c.token_tree() {
+            if matches!(&tt, TokenTree::Ident(id) if id == "as") {
+                break;
+            }
+            ts.extend(std::iter::once(tt));
+            c = next;
+        }
+
+        Ok((ts, c))
+    })
 }

--- a/crates/anodized-core/src/annotate/tests.rs
+++ b/crates/anodized-core/src/annotate/tests.rs
@@ -2,7 +2,7 @@ use crate::test_util::assert_spec_eq;
 
 use super::*;
 use proc_macro2::Span;
-use syn::parse_quote;
+use syn::{parse_quote, parse_str};
 
 #[test]
 fn simple_spec() {
@@ -440,7 +440,7 @@ fn captures_simple_identifier() {
         maintains: vec![],
         captures: vec![Capture {
             expr: parse_quote! { count },
-            alias: parse_quote! { old_count },
+            pat: parse_quote! { old_count },
         }],
         ensures: vec![PostCondition {
             closure: parse_quote! { |output| output == old_count + 1 },
@@ -464,7 +464,7 @@ fn captures_identifier_with_alias() {
         maintains: vec![],
         captures: vec![Capture {
             expr: parse_quote! { value },
-            alias: parse_quote! { prev_value },
+            pat: parse_quote! { prev_value },
         }],
         ensures: vec![PostCondition {
             closure: parse_quote! { |output| output > prev_value },
@@ -497,15 +497,15 @@ fn captures_array() {
         captures: vec![
             Capture {
                 expr: parse_quote! { count },
-                alias: parse_quote! { old_count },
+                pat: parse_quote! { old_count },
             },
             Capture {
                 expr: parse_quote! { index },
-                alias: parse_quote! { old_index },
+                pat: parse_quote! { old_index },
             },
             Capture {
                 expr: parse_quote! { value },
-                alias: parse_quote! { old_value },
+                pat: parse_quote! { old_value },
             },
         ],
         ensures: vec![
@@ -549,7 +549,7 @@ fn captures_with_all_clauses() {
         }],
         captures: vec![Capture {
             expr: parse_quote! { value },
-            alias: parse_quote! { old_val },
+            pat: parse_quote! { old_val },
         }],
         ensures: vec![PostCondition {
             closure: parse_quote! { |result| result > old_val },
@@ -582,7 +582,7 @@ fn captures_array_expression() {
         maintains: vec![],
         captures: vec![Capture {
             expr: parse_quote! { [a, b, c] },
-            alias: parse_quote! { slice },
+            pat: parse_quote! { slice },
         }],
         ensures: vec![PostCondition {
             closure: parse_quote! { |output| slice.len() == 3 },
@@ -635,6 +635,17 @@ fn captures_array_with_complex_expr_no_alias() {
 }
 
 #[test]
+#[should_panic(expected = "complex expressions require an explicit alias using `as`")]
+fn captures_indexing_expr_requires_alias() {
+    // This should fail - `foo[0]` is a complex expression that requires an alias
+    // Previously this was incorrectly parsed as just `foo`, silently capturing the wrong value
+    let _: Spec = parse_quote! {
+        captures: foo[0],
+        ensures: output > 0,
+    };
+}
+
+#[test]
 #[should_panic(expected = "`cfg` attribute is not supported on `captures`")]
 fn cfg_on_captures() {
     let _: Spec = parse_quote! {
@@ -655,7 +666,7 @@ fn captures_edge_case_cast_expr() {
         maintains: vec![],
         captures: vec![Capture {
             expr: parse_quote! { r as u8 },
-            alias: parse_quote! { old_red },
+            pat: parse_quote! { old_red },
         }],
         ensures: vec![],
         span: Span::call_site(),
@@ -685,7 +696,7 @@ fn captures_edge_case_array_of_cast_exprs() {
                     b as u8,
                 ]
             },
-            alias: parse_quote! { r8g8b8 },
+            pat: parse_quote! { r8g8b8 },
         }],
         ensures: vec![],
         span: Span::call_site(),
@@ -710,15 +721,15 @@ fn captures_edge_case_list_of_cast_exprs() {
         captures: vec![
             Capture {
                 expr: parse_quote! { r as u8 },
-                alias: parse_quote! { old_red },
+                pat: parse_quote! { old_red },
             },
             Capture {
                 expr: parse_quote! { g as u8 },
-                alias: parse_quote! { old_green },
+                pat: parse_quote! { old_green },
             },
             Capture {
                 expr: parse_quote! { b as u8 },
-                alias: parse_quote! { old_blue },
+                pat: parse_quote! { old_blue },
             },
         ],
         ensures: vec![],
@@ -726,4 +737,150 @@ fn captures_edge_case_list_of_cast_exprs() {
     };
 
     assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_pattern_matches_slices() {
+    let spec: Spec = parse_quote! {
+        captures: rgb as [r, g, b],
+    };
+
+    let expected = Spec {
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![Capture {
+            expr: parse_quote! { rgb },
+            pat: parse_quote! { [r, g, b] },
+        }],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_pattern_matches_tuples() {
+    let spec: Spec = parse_quote! {
+        captures: point as (x, y, z),
+    };
+
+    let expected = Spec {
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![Capture {
+            expr: parse_quote! { point },
+            pat: parse_quote! { (x, y, z) },
+        }],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_pattern_matches_structs() {
+    let spec: Spec = parse_quote! {
+        captures: person.clone() as Person { name, age },
+    };
+
+    let expected = Spec {
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![Capture {
+            expr: parse_quote! { person.clone() },
+            pat: parse_quote! { Person { name, age } },
+        }],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_pattern_matches_nested() {
+    let spec: Spec = parse_quote! {
+        captures: data.as_ref() as Some((a, b)),
+    };
+
+    let expected = Spec {
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![Capture {
+            expr: parse_quote! { data.as_ref() },
+            pat: parse_quote! { Some((a, b)) },
+        }],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_pattern_with_binding_modifier() {
+    let spec: Spec = parse_quote! {
+        captures: data as Some(inner_tuple @ (a, b)),
+    };
+
+    let expected = Spec {
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![Capture {
+            expr: parse_quote! { data },
+            pat: parse_quote! { Some(inner_tuple @ (a, b)) },
+        }],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn captures_missing_expr_parses_as_spec_args() {
+    let input = "captures: as Person { name, age },";
+    let spec_args: syntax::SpecArgs =
+        parse_str(input).expect("should parse incomplete capture expr for formatting");
+    assert_eq!(spec_args.args.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "capture expression is missing")]
+fn captures_missing_expr_errors_as_spec() {
+    let _: Spec = parse_str("captures: as Person { name, age },").unwrap();
+}
+
+#[test]
+fn captures_expr_as_with_missing_pat_errors() {
+    let capture_expr = syntax::CaptureExpr {
+        expr: Some(parse_quote! { value }),
+        as_: Some(Default::default()),
+        pat: None,
+    };
+    let err = interpret_capture_expr_as_capture(capture_expr).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("missing expected pattern or identifier after `as`"),
+        "{}",
+        err
+    );
+}
+
+#[test]
+fn captures_pat_without_as_errors() {
+    let capture_expr = syntax::CaptureExpr {
+        expr: Some(parse_quote! { value }),
+        as_: None,
+        pat: Some(parse_quote! { old_value }),
+    };
+    let err = interpret_capture_expr_as_capture(capture_expr).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Missing `as` between alias and pattern"),
+        "{}",
+        err
+    );
 }

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -5,7 +5,7 @@ use crate::{Spec, instrument::Backend};
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
-use syn::{Block, Ident, ItemFn, parse::Result, parse_quote};
+use syn::{Block, Ident, ItemFn, Pat, PatIdent, parse::Result, parse_quote};
 
 impl Backend {
     pub fn instrument_fn(&self, spec: Spec, mut func: ItemFn) -> syn::Result<ItemFn> {
@@ -36,7 +36,13 @@ impl Backend {
         let build_check = self.build_check;
 
         // The identifier for the return value binding.
-        let output_ident = Ident::new("__anodized_output", Span::mixed_site());
+        let output_ident = Pat::Ident(PatIdent {
+            attrs: vec![],
+            by_ref: None,
+            mutability: None,
+            ident: Ident::new("__anodized_output", Span::mixed_site()),
+            subpat: None,
+        });
 
         // --- Generate Precondition Checks ---
         let precondition_checks = spec
@@ -73,7 +79,7 @@ impl Backend {
         let aliases = spec
             .captures
             .iter()
-            .map(|cb| &cb.alias)
+            .map(|cb| &cb.pat)
             .chain(std::iter::once(&output_ident));
 
         // Chain capture expressions with body expression

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro2::Span;
-use syn::{Expr, Ident, Meta};
+use syn::{Expr, Meta, Pat};
 
 pub mod annotate;
 pub mod instrument;
@@ -69,6 +69,6 @@ pub struct PostCondition {
 pub struct Capture {
     /// The expression to capture.
     pub expr: Expr,
-    /// The identifier to bind the captured value to.
-    pub alias: Ident,
+    /// The pattern to bind/destructure the captured value.
+    pub pat: Pat,
 }

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -126,12 +126,12 @@ fn assert_capture_eq(left: &Capture, right: &Capture, msg_prefix: &str) {
     // Destructure to ensure we handle all fields
     let Capture {
         expr: left_expr,
-        alias: left_alias,
+        pat: left_alias,
     } = left;
 
     let Capture {
         expr: right_expr,
-        alias: right_alias,
+        pat: right_alias,
     } = right;
 
     assert_eq!(

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -248,11 +248,22 @@ use anodized::spec;
     ],
 )]
 fn add_item<T: Clone + Eq>(items: &mut Vec<T>, item: T) { todo!() }
+
+// A capture may have a pattern to destructure tuples, structs, arrays, and other composite types:
+#[spec(
+    captures: triple as (first, second, third),
+    ensures: [
+        first == triple.0,
+        second == triple.1,
+        third == triple.2,
+    ],
+)]
+fn match_tuple(triple: (bool, char, i32)) { todo!() }
 ```
 
 - **Simple identifiers** get an automatic `old_` prefix, i.e. `x` becomes `old_x`.
 - **Complex expressions** require an explicit alias using `as`, i.e. `self.items.len() as orig_len`.
-- **No automatic cloning**: Each captured expression is **moved**. For a `Copy` type, a copy is made implicitly. For a non-`Copy` type, you must explicitly use `.clone()`, `.to_owned()`, or another appropriate method.
+**Patterns** may be used to destructure the captured value, e.g. `person.clone() as Person { name, age }`.- **No automatic cloning**: Each captured expression is **moved**. For a `Copy` type, a copy is made implicitly. For a non-`Copy` type, you must explicitly use `.clone()`, `.to_owned()`, or another appropriate method.
 - Capturing happens **after** preconditions are checked but **before** the function body executes.
 - The captured values are **only** available to postconditions, not to preconditions or the function body itself.
 

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -171,3 +171,78 @@ fn explicit_clone_for_non_copy_types() {
     container.maybe_push("third".to_string(), true);
     assert_eq!(container.items.len(), 3);
 }
+
+#[derive(Debug, Clone, Copy)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[spec(
+    captures: arr as [first, second, third],
+    ensures: [
+        first == arr[0],
+        second == arr[1],
+        third == arr[2],
+    ],
+)]
+fn match_array(arr: [i32; 3]) {
+    println!("Array elements: {}, {}, {}", arr[0], arr[1], arr[2]);
+}
+
+#[spec(
+    captures: tuple as (a, b, c),
+    ensures: [
+        a + b + c == tuple.0 + tuple.1 + tuple.2,
+    ],
+)]
+fn match_tuple(tuple: (i32, i32, i32)) {
+    let (a, b, c) = tuple;
+    println!("Sum: {}, Product: {}", a + b + c, a * b * c);
+}
+
+#[spec(
+    captures: point as Point { x, y },
+    ensures: [
+        x == point.x,
+        y == point.y,
+    ],
+)]
+fn match_struct(point: Point) {
+    println!("Point: ({}, {})", point.x, point.y);
+}
+
+#[spec(
+    captures: [a, b, c] as slice,
+    ensures: [
+        slice[0] == a,
+        slice[1] == b,
+        slice[2] == c,
+    ],
+)]
+fn capture_as_array(a: i32, b: i32, c: i32) {
+    println!("Captured as array: {:?}", [a, b, c]);
+}
+
+#[test]
+fn match_array_success() {
+    let numbers = [1, 2, 3];
+    match_array(numbers);
+}
+
+#[test]
+fn match_tuple_success() {
+    let coords = (3, 4, 5);
+    match_tuple(coords);
+}
+
+#[test]
+fn match_struct_success() {
+    let point = Point { x: 5, y: -3 };
+    match_struct(point);
+}
+
+#[test]
+fn capture_as_array_success() {
+    capture_as_array(10, 20, 30);
+}


### PR DESCRIPTION
- add `syntax::Captures` to hold a group of capture expressions
- add `SpecArgValue::Captures`
- update `fn` instrumentation with patterns to bind/destructure captured values