### PR TITLE
docs: document `trait` specs feature

### DIFF
--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -67,7 +67,7 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | plain `fn`             | Available   | Pre- and postconditions, invariants. |
 | `fn` inside an `impl`  | Available   | Pre- and postconditions, invariants. |
 | `trait` and its `fn`s  | Available   | Enforces all `impl`s to conform.     |
-| `mod` (child entities) | In Progress | Properties across multiple entities. |
+| `mod`                  | In Progress | Invariants across multiple entities. |
 | `struct`, `enum`       | Planned     | Data invariants.                     |
 | `while`, `loop`, `for` | Planned     | Loop invariants.                     |
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -66,7 +66,8 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | ---------------------- | ----------- | ------------------------------------ |
 | plain `fn`             | Available   | Pre- and postconditions, invariants. |
 | `fn` inside an `impl`  | Available   | Pre- and postconditions, invariants. |
-| `trait` and its `fn`s  | In Progress | Enforces all `impl`s to conform.     |
+| `trait` and its `fn`s  | Available   | Enforces all `impl`s to conform.     |
+| `mod` (child entities) | In Progress | Properties across multiple entities. |
 | `struct`, `enum`       | Planned     | Data invariants.                     |
 | `while`, `loop`, `for` | Planned     | Loop invariants.                     |
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -183,7 +183,7 @@ fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 
 ### Trait Specs
 
-Anodized supports specs on trait methods, which are meant to constrain all implementations.
+Anodized supports specs on trait methods, which automatically constrain all implementations.
 
 Use the following structure:
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -181,6 +181,50 @@ use anodized::spec;
 fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 ```
 
+### Trait Specs
+
+Anodized supports specs on trait methods, which are meant to constrain all implementations.
+
+Use the following structure:
+
+1. Put `#[spec]` on the trait.
+2. Put method-level `#[spec(...)]` on trait methods that define requirements.
+3. Put `#[spec]` on each corresponding trait `impl`.
+
+```rust, no_run
+use anodized::spec;
+
+#[spec]
+trait MonotonicGenerator {
+    fn current(&self) -> i32;
+
+    #[spec(
+        captures: self.current() as old_val,
+        ensures: self.current() > old_val,
+    )]
+    fn update(&mut self);
+}
+
+struct Counter(i32);
+
+#[spec]
+impl MonotonicGenerator for Counter {
+    fn current(&self) -> i32 {
+        self.0
+    }
+
+    fn update(&mut self) {
+        self.0 += 1;
+    }
+}
+```
+
+Important restrictions:
+
+- The trait-level `#[spec]` is an enabler; specification clauses belong on trait methods, not on the trait itself.
+- Do not put `#[spec]` on methods inside a `#[spec]` trait impl. Method specs are defined at the trait declaration.
+- Names prefixed with `__anodized_` are internal and must not be implemented directly.
+
 ### Runtime Behaviors
 
 Anodized offers multiple runtime behaviors that control how `#[spec]` annotations expand to runtime checks:

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -62,14 +62,14 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 
 **`#[spec]` Support**
 
-| Program Element        | Status      | Notes                                |
-| ---------------------- | ----------- | ------------------------------------ |
-| plain `fn`             | Available   | Pre- and postconditions, invariants. |
-| `fn` inside an `impl`  | Available   | Pre- and postconditions, invariants. |
-| `trait` and its `fn`s  | Available   | Enforces all `impl`s to conform.     |
-| `mod`                  | In Progress | Invariants across multiple entities. |
-| `struct`, `enum`       | Planned     | Data invariants.                     |
-| `while`, `loop`, `for` | Planned     | Loop invariants.                     |
+| Program Element        | Status                    | Notes                                |
+| ---------------------- | ------------------------- | ------------------------------------ |
+| plain `fn`             | Available                 | Pre- and postconditions, invariants. |
+| `fn` inside an `impl`  | Available                 | Pre- and postconditions, invariants. |
+| `trait` and its `fn`s  | [Available](#trait-specs) | Enforces all `impl`s to conform.     |
+| `mod`                  | In Progress               | Invariants across multiple entities. |
+| `struct`, `enum`       | Planned                   | Data invariants.                     |
+| `while`, `loop`, `for` | Planned                   | Loop invariants.                     |
 
 **Runtime Behaviors**
 


### PR DESCRIPTION
- Extend and update the `README`s to document `trait`-level specs.