### PR TITLE
fix: evaluate each capture expression in a closure

### DIFF
--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -85,7 +85,8 @@ impl Backend {
         // Chain capture expressions with body expression
         let capture_exprs = spec.captures.iter().map(|cb| {
             let expr = &cb.expr;
-            quote! { #expr }
+            // Evaluate expression in a closure to prevent early return.
+            quote! { (|| #expr)() }
         });
 
         // Chain underscore types with return type for tuple type annotation

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -507,7 +507,7 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             assert!((| | CONDITION_1)(), "Precondition failed: {}", "CONDITION_1");
-            let (ALIAS_1, ALIAS_2, __anodized_output): (_, _, #ret_type) = (EXPR_1, EXPR_2, (|| #body)());
+            let (ALIAS_1, ALIAS_2, __anodized_output): (_, _, #ret_type) = ((| | EXPR_1) (), (| | EXPR_2) (), (|| #body)());
             assert!((|output: &#ret_type| CONDITION_2)(&__anodized_output), "Postcondition failed: {}", "| output | CONDITION_2");
             assert!((|output: &#ret_type| CONDITION_3)(&__anodized_output), "Postcondition failed: {}", "| output | CONDITION_3");
             __anodized_output

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -12,8 +12,8 @@ use anodized::spec;
         return log.push("maintains2") == (),
     ],
     captures: [
-        log.push("captures1") as _alias1,
-        log.push("captures2") as _alias2,
+        { return log.push("captures1"); } as _alias1,
+        { return log.push("captures2"); } as _alias2,
     ],
     ensures: [
         return log.push("ensures1") == (),

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -12,8 +12,8 @@ use anodized::spec;
         return log.push("maintains2") == (),
     ],
     captures: [
-        { return log.push("captures1"); } as _alias1,
-        { return log.push("captures2"); } as _alias2,
+        return log.push("captures1") as _alias1,
+        return log.push("captures2") as _alias2,
     ],
     ensures: [
         return log.push("ensures1") == (),


### PR DESCRIPTION
Guard against early `return` statements that may appear in a capture, by evaluating the captured expression wrapped in a zero-param closure.