### PR TITLE
[anodized-logic] feat: quantifiers `exists` and `forall`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,22 @@ jobs:
 
       - name: Unit and integration test anodized-fmt
         run: cargo test -p anodized-fmt --tests --no-fail-fast
+
+  test-anodized-logic:
+    name: Lint and test anodized-logic
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Lint anodized-logic
+        run: cargo clippy -p anodized-logic --all-targets -- -D warnings
+
+      - name: Integration test anodized-logic
+        run: cargo test -p anodized-logic --tests --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/anodized",
     "crates/anodized-core",
     "crates/anodized-fmt",
+    "crates/anodized-logic",
 ]
 resolver = "2"
 

--- a/crates/anodized-logic/Cargo.toml
+++ b/crates/anodized-logic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anodized-logic"
+description.workspace = true
+
+version.workspace = true
+edition.workspace = true
+readme = "README.md"
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+license.workspace = true
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/crates/anodized-logic/Cargo.toml
+++ b/crates/anodized-logic/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "anodized-logic"
-description.workspace = true
+version = "0.1.0"
+description = "Helps embed non-trivial elements of logic into Rust code"
 
-version.workspace = true
 edition.workspace = true
 readme = "README.md"
 repository.workspace = true

--- a/crates/anodized-logic/README.md
+++ b/crates/anodized-logic/README.md
@@ -1,0 +1,6 @@
+<img width="100" alt="Anodized Logo" src="https://raw.githubusercontent.com/mkovaxx/anodized/main/assets/logo.svg">
+
+# Anodized Logic
+
+Provides helpers to embed non-trivial elements of logic into Rust code, meant to be used in
+[Anodized](https://github.com/mkovaxx/anodized) specifications.

--- a/crates/anodized-logic/src/lib.rs
+++ b/crates/anodized-logic/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod quantifiers;

--- a/crates/anodized-logic/src/quantifiers.rs
+++ b/crates/anodized-logic/src/quantifiers.rs
@@ -1,0 +1,20 @@
+#[allow(private_bounds)]
+pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
+    unimplemented!("Runtime checks are not supported for quantifiers.")
+}
+
+#[allow(private_bounds)]
+pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
+    unimplemented!("Runtime checks are not supported for quantifiers.")
+}
+
+trait Predicate<T> {}
+
+impl<P, T1> Predicate<(T1,)> for P where P: Fn(T1) -> bool {}
+impl<P, T1, T2> Predicate<(T1, T2)> for P where P: Fn(T1, T2) -> bool {}
+impl<P, T1, T2, T3> Predicate<(T1, T2, T3)> for P where P: Fn(T1, T2, T3) -> bool {}
+impl<P, T1, T2, T3, T4> Predicate<(T1, T2, T3, T4)> for P where P: Fn(T1, T2, T3, T4) -> bool {}
+impl<P, T1, T2, T3, T4, T5> Predicate<(T1, T2, T3, T4, T5)> for P where
+    P: Fn(T1, T2, T3, T4, T5) -> bool
+{
+}

--- a/crates/anodized-logic/src/quantifiers.rs
+++ b/crates/anodized-logic/src/quantifiers.rs
@@ -1,10 +1,10 @@
-#[allow(private_bounds)]
-pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
+#[allow(private_bounds, unused_variables)]
+pub fn forall<P: Predicate<T>, T>(predicate: P) -> bool {
     unimplemented!("Runtime checks are not supported for quantifiers.")
 }
 
-#[allow(private_bounds)]
-pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
+#[allow(private_bounds, unused_variables)]
+pub fn exists<P: Predicate<T>, T>(predicate: P) -> bool {
     unimplemented!("Runtime checks are not supported for quantifiers.")
 }
 

--- a/crates/anodized-logic/tests/compile_fail.rs
+++ b/crates/anodized-logic/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_errors() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/crates/anodized-logic/tests/compile_fail/quantifiers.rs
+++ b/crates/anodized-logic/tests/compile_fail/quantifiers.rs
@@ -1,0 +1,21 @@
+use anodized_logic::quantifiers::{exists, forall};
+
+fn main() {
+    // exists over naked expression
+    let _ = exists(1 + 2 == 3);
+
+    // forall over naked expression
+    let _ = forall(1 + 2 == 3);
+
+    // exists over 0-var predicate
+    let _ = exists(|| 1 + 2 == 3);
+
+    // forall over 0-var predicate
+    let _ = forall(|| 1 + 2 == 3);
+
+    // exists over non-bool expression
+    let _ = exists(|i: i32| i + i);
+
+    // forall over non-bool expression
+    let _ = forall(|i: i32| i + i);
+}

--- a/crates/anodized-logic/tests/compile_fail/quantifiers.stderr
+++ b/crates/anodized-logic/tests/compile_fail/quantifiers.stderr
@@ -9,8 +9,8 @@ error[E0277]: the trait bound `bool: quantifiers::Predicate<_>` is not satisfied
 note: required by a bound in `anodized_logic::quantifiers::exists`
  --> src/quantifiers.rs
   |
-  | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
-  |                     ^^^^^^^^^^^^ required by this bound in `exists`
+  | pub fn exists<P: Predicate<T>, T>(predicate: P) -> bool {
+  |                  ^^^^^^^^^^^^ required by this bound in `exists`
 
 error[E0277]: the trait bound `bool: quantifiers::Predicate<_>` is not satisfied
  --> tests/compile_fail/quantifiers.rs:8:20
@@ -23,8 +23,8 @@ error[E0277]: the trait bound `bool: quantifiers::Predicate<_>` is not satisfied
 note: required by a bound in `forall`
  --> src/quantifiers.rs
   |
-  | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
-  |                     ^^^^^^^^^^^^ required by this bound in `forall`
+  | pub fn forall<P: Predicate<T>, T>(predicate: P) -> bool {
+  |                  ^^^^^^^^^^^^ required by this bound in `forall`
 
 error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:11:20: 11:22}: quantifiers::Predicate<_>` is not satisfied
   --> tests/compile_fail/quantifiers.rs:11:20
@@ -38,8 +38,8 @@ error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:1
 note: required by a bound in `anodized_logic::quantifiers::exists`
   --> src/quantifiers.rs
    |
-   | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
-   |                     ^^^^^^^^^^^^ required by this bound in `exists`
+   | pub fn exists<P: Predicate<T>, T>(predicate: P) -> bool {
+   |                  ^^^^^^^^^^^^ required by this bound in `exists`
 
 error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:14:20: 14:22}: quantifiers::Predicate<_>` is not satisfied
   --> tests/compile_fail/quantifiers.rs:14:20
@@ -53,8 +53,8 @@ error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:1
 note: required by a bound in `forall`
   --> src/quantifiers.rs
    |
-   | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
-   |                     ^^^^^^^^^^^^ required by this bound in `forall`
+   | pub fn forall<P: Predicate<T>, T>(predicate: P) -> bool {
+   |                  ^^^^^^^^^^^^ required by this bound in `forall`
 
 error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:17:20: 17:28}: quantifiers::Predicate<_>` is not satisfied
   --> tests/compile_fail/quantifiers.rs:17:20
@@ -68,8 +68,8 @@ error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:1
 note: required by a bound in `anodized_logic::quantifiers::exists`
   --> src/quantifiers.rs
    |
-   | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
-   |                     ^^^^^^^^^^^^ required by this bound in `exists`
+   | pub fn exists<P: Predicate<T>, T>(predicate: P) -> bool {
+   |                  ^^^^^^^^^^^^ required by this bound in `exists`
 
 error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:20:20: 20:28}: quantifiers::Predicate<_>` is not satisfied
   --> tests/compile_fail/quantifiers.rs:20:20
@@ -83,5 +83,5 @@ error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:2
 note: required by a bound in `forall`
   --> src/quantifiers.rs
    |
-   | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
-   |                     ^^^^^^^^^^^^ required by this bound in `forall`
+   | pub fn forall<P: Predicate<T>, T>(predicate: P) -> bool {
+   |                  ^^^^^^^^^^^^ required by this bound in `forall`

--- a/crates/anodized-logic/tests/compile_fail/quantifiers.stderr
+++ b/crates/anodized-logic/tests/compile_fail/quantifiers.stderr
@@ -1,0 +1,87 @@
+error[E0277]: the trait bound `bool: quantifiers::Predicate<_>` is not satisfied
+ --> tests/compile_fail/quantifiers.rs:5:20
+  |
+5 |     let _ = exists(1 + 2 == 3);
+  |             ------ ^^^^^^^^^^ the trait `quantifiers::Predicate<_>` is not implemented for `bool`
+  |             |
+  |             required by a bound introduced by this call
+  |
+note: required by a bound in `anodized_logic::quantifiers::exists`
+ --> src/quantifiers.rs
+  |
+  | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
+  |                     ^^^^^^^^^^^^ required by this bound in `exists`
+
+error[E0277]: the trait bound `bool: quantifiers::Predicate<_>` is not satisfied
+ --> tests/compile_fail/quantifiers.rs:8:20
+  |
+8 |     let _ = forall(1 + 2 == 3);
+  |             ------ ^^^^^^^^^^ the trait `quantifiers::Predicate<_>` is not implemented for `bool`
+  |             |
+  |             required by a bound introduced by this call
+  |
+note: required by a bound in `forall`
+ --> src/quantifiers.rs
+  |
+  | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
+  |                     ^^^^^^^^^^^^ required by this bound in `forall`
+
+error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:11:20: 11:22}: quantifiers::Predicate<_>` is not satisfied
+  --> tests/compile_fail/quantifiers.rs:11:20
+   |
+11 |     let _ = exists(|| 1 + 2 == 3);
+   |             ------ ^^^^^^^^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `quantifiers::Predicate<_>` is not implemented for closure `{closure@$DIR/tests/compile_fail/quantifiers.rs:11:20: 11:22}`
+note: required by a bound in `anodized_logic::quantifiers::exists`
+  --> src/quantifiers.rs
+   |
+   | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
+   |                     ^^^^^^^^^^^^ required by this bound in `exists`
+
+error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:14:20: 14:22}: quantifiers::Predicate<_>` is not satisfied
+  --> tests/compile_fail/quantifiers.rs:14:20
+   |
+14 |     let _ = forall(|| 1 + 2 == 3);
+   |             ------ ^^^^^^^^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `quantifiers::Predicate<_>` is not implemented for closure `{closure@$DIR/tests/compile_fail/quantifiers.rs:14:20: 14:22}`
+note: required by a bound in `forall`
+  --> src/quantifiers.rs
+   |
+   | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
+   |                     ^^^^^^^^^^^^ required by this bound in `forall`
+
+error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:17:20: 17:28}: quantifiers::Predicate<_>` is not satisfied
+  --> tests/compile_fail/quantifiers.rs:17:20
+   |
+17 |     let _ = exists(|i: i32| i + i);
+   |             ------ ^^^^^^^^^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `quantifiers::Predicate<_>` is not implemented for closure `{closure@$DIR/tests/compile_fail/quantifiers.rs:17:20: 17:28}`
+note: required by a bound in `anodized_logic::quantifiers::exists`
+  --> src/quantifiers.rs
+   |
+   | pub fn exists<T, P: Predicate<T>>(_predicate: P) -> bool {
+   |                     ^^^^^^^^^^^^ required by this bound in `exists`
+
+error[E0277]: the trait bound `{closure@$DIR/tests/compile_fail/quantifiers.rs:20:20: 20:28}: quantifiers::Predicate<_>` is not satisfied
+  --> tests/compile_fail/quantifiers.rs:20:20
+   |
+20 |     let _ = forall(|i: i32| i + i);
+   |             ------ ^^^^^^^^^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `quantifiers::Predicate<_>` is not implemented for closure `{closure@$DIR/tests/compile_fail/quantifiers.rs:20:20: 20:28}`
+note: required by a bound in `forall`
+  --> src/quantifiers.rs
+   |
+   | pub fn forall<T, P: Predicate<T>>(_predicate: P) -> bool {
+   |                     ^^^^^^^^^^^^ required by this bound in `forall`

--- a/crates/anodized-logic/tests/quantifiers.rs
+++ b/crates/anodized-logic/tests/quantifiers.rs
@@ -1,0 +1,25 @@
+use anodized_logic::quantifiers::{exists, forall};
+
+#[test]
+#[should_panic(expected = "Runtime checks are not supported for quantifiers.")]
+fn exists_with_1_var() {
+    let _ = exists(|i: i32| i < 42);
+}
+
+#[test]
+#[should_panic(expected = "Runtime checks are not supported for quantifiers.")]
+fn forall_with_1_var() {
+    let _ = forall(|i: i32| i < 42);
+}
+
+#[test]
+#[should_panic(expected = "Runtime checks are not supported for quantifiers.")]
+fn exists_with_5_var() {
+    let _ = exists(|i: i32, j: usize, k: bool, x: f32, y: f32| (i as usize) < j && k == (x != y));
+}
+
+#[test]
+#[should_panic(expected = "Runtime checks are not supported for quantifiers.")]
+fn forall_with_5_var() {
+    let _ = forall(|i: i32, j: usize, k: bool, x: f32, y: f32| (i as usize) < j && k == (x != y));
+}


### PR DESCRIPTION
- add `anodized-logic`
- add support for quantifiers `exists` and `forall`
- include `anodized-logic` tests in CI