### PR TITLE
[anodized] refactor: use `cfg` settings instead of Cargo features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,15 @@ jobs:
         run: cargo test -p anodized-core --lib --no-fail-fast
 
   test-anodized:
-    name: Lint and test anodized with runtime behavior `${{ matrix.runtime }}`
+    name: Lint and test anodized with cfg `${{ matrix.cfg }}`
     runs-on: ubuntu-latest
     needs: fmt
     strategy:
       matrix:
         include:
-          - runtime: check-and-panic
-          - runtime: check-and-print
-          - runtime: no-check
+          - cfg: '--config build.rustflags=["--cfg","anodized_panic"]'
+          - cfg: '--config build.rustflags=["--cfg","anodized_print"]'
+          - cfg: ""
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,11 +63,11 @@ jobs:
         with:
           components: clippy
 
-      - name: Lint anodized with runtime behavior `${{ matrix.runtime }}`
-        run: cargo clippy -p anodized --all-targets --no-default-features --features "runtime-${{ matrix.runtime }}" -- -D warnings
+      - name: Lint anodized with cfg `${{ matrix.cfg }}`
+        run: cargo ${{ matrix.cfg }} clippy -p anodized --all-targets -- -D warnings
 
-      - name: Integration test anodized with runtime behavior `${{ matrix.runtime }}`
-        run: cargo test -p anodized --tests --no-fail-fast --no-default-features --features "runtime-${{ matrix.runtime }}"
+      - name: Integration test anodized with cfg `${{ matrix.cfg }}`
+        run: cargo ${{ matrix.cfg }} test -p anodized --tests --no-fail-fast
 
   test-anodized-fmt:
     name: Lint and test anodized-fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - cfg: '--config build.rustflags=["--cfg","anodized_panic"]'
-          - cfg: '--config build.rustflags=["--cfg","anodized_print"]'
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_panic"]'''
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_print"]'''
           - cfg: ""
     steps:
       - name: Checkout repository

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "rust-analyzer.cargo.features": ["anodized/runtime-check-and-panic"]
+    "rust-analyzer.cargo.cfgs": ["anodized_panic"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **Fixed handling `return` statements in a `fn` body** - Returns no longer bypass runtime checks.
-- **Must explicitly select a `runtime-*` behavior** - See below.
+- **Must explicitly select an `anodized-*` behavior** - See below.
 
 ### Added
 
 - Support for capturing entry-time values via `captures:`.
-- Explicit `runtime-*` behavior settings: `check-and-panic`, `check-and-print`, `no-check`.
+- Explicit behavior settings via cfg: `--cfg anodized_panic`, `--cfg anodized_print`; no-check uses neither cfg.
 
 ## 0.2.1 (2025 Aug 26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **Fixed handling `return` statements in a `fn` body** - Returns no longer bypass runtime checks.
-- **Must explicitly select an `anodized-*` behavior** - See below.
+- **Must explicitly select a `runtime-*` behavior** - See below.
 
 ### Added
 
 - Support for capturing entry-time values via `captures:`.
-- Explicit behavior settings via cfg: `--cfg anodized_panic`, `--cfg anodized_print`; no-check uses neither cfg.
+- Explicit `runtime-*` behavior settings: `check-and-panic`, `check-and-print`, `no-check`.
 
 ## 0.2.1 (2025 Aug 26)
 

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -72,7 +72,7 @@ cfg_attr = `#[cfg(` , settings , `)]`;
 
 ## Runtime Checks
 
-The `#[spec]` macro transforms the function body by injecting runtime checks whose behavior is controlled by `runtime-*` feature settings. This process, known as instrumentation, follows a clear pattern.
+The `#[spec]` macro transforms the function body by injecting runtime checks whose behavior is controlled by compiler cfg settings in `anodized` (for example `anodized_panic` or `anodized_print`). This process, known as instrumentation, follows a clear pattern.
 
 Given an original function like this:
 
@@ -122,4 +122,4 @@ fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
 }
 ```
 
-When a condition has a `#[cfg(...)]` attribute, the corresponding `check!` is wrapped in an `if cfg!(...)` block. This follows standard Rust `#[cfg]` semantics: the check only runs when the configuration predicate is true. The behavior of the `check!` itself is controlled by the global `runtime-*` feature setting.
+When a condition has a `#[cfg(...)]` attribute, the corresponding `check!` is wrapped in an `if cfg!(...)` block. This follows standard Rust `#[cfg]` semantics: the check only runs when the configuration predicate is true. The behavior of the `check!` itself is controlled by the selected `anodized` cfg setting.

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -16,8 +16,8 @@ This crate is the interoperability layer for tools connected to the [Anodized](h
 
 - **If you're looking for blockchain smart contracts...**
 
-  > _"These are not the **contracts** you're looking for."_ 🤖  
-  
+  > _"These are not the **contracts** you're looking for."_ 🤖
+
   But don't leave yet! While Anodized is about Design by Contract (not blockchain), it can still help make your smart contracts more robust through formal specifications.
 
 ---
@@ -70,9 +70,9 @@ cfg_attr = `#[cfg(` , settings , `)]`;
 - `pattern` is an irrefutable Rust [`pattern`](https://doc.rust-lang.org/reference/patterns.html); type checking will fail if its type does not match the function's return value.
 - `settings` is the content of the [`cfg`](https://doc.rust-lang.org/reference/conditional-compilation.html) attribute (e.g. `test`, `debug_assertions`).
 
-## Runtime Checks
+## Instrumentation
 
-The `#[spec]` macro transforms the function body by injecting runtime checks whose behavior is controlled by compiler cfg settings in `anodized` (for example `anodized_panic` or `anodized_print`). This process, known as instrumentation, follows a clear pattern.
+The `#[spec]` macro transforms the function body by injecting code, determined by compiler `cfg` settings (e.g. `anodized_panic`, `anodized_print`). This process, known as instrumentation, follows a clear pattern.
 
 Given an original function like this:
 
@@ -122,4 +122,4 @@ fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
 }
 ```
 
-When a condition has a `#[cfg(...)]` attribute, the corresponding `check!` is wrapped in an `if cfg!(...)` block. This follows standard Rust `#[cfg]` semantics: the check only runs when the configuration predicate is true. The behavior of the `check!` itself is controlled by the selected `anodized` cfg setting.
+When a condition has a `#[cfg(...)]` attribute, the corresponding `check!` is wrapped in an `if cfg!(...)` block. This follows standard Rust `#[cfg]` semantics: the check only runs when the configuration predicate is true. Details of the injected code are determined by `cfg` settings.

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{Spec, instrument::Backend};
+use crate::{
+    Spec,
+    instrument::{Backend, build_assert, build_eprint, build_inert},
+};
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
@@ -33,7 +36,12 @@ impl Backend {
         is_async: bool,
         return_type: &syn::Type,
     ) -> Result<Block> {
-        let build_check = self.build_check;
+        let build_check = match (self.emit_print, self.emit_panic) {
+            (true, true) => build_assert,
+            (true, false) => build_eprint,
+            (false, true) => build_assert,
+            (false, false) => build_inert,
+        };
 
         // The identifier for the return value binding.
         let output_ident = Pat::Ident(PatIdent {

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -32,7 +32,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -57,7 +57,7 @@ fn requires_disable_runtime_checks() {
         }
     };
 
-    let observed = Backend::NO_CHECK
+    let observed = Backend::NOTHING
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -82,7 +82,7 @@ fn requires_no_panic_runtime() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PRINT
+    let observed = Backend::PRINT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -106,7 +106,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -129,7 +129,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -155,7 +155,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -180,7 +180,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -206,7 +206,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -234,7 +234,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -262,7 +262,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -294,7 +294,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -318,7 +318,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -349,7 +349,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -388,7 +388,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -427,7 +427,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -481,7 +481,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -514,7 +514,7 @@ fn captures() {
         }
     };
 
-    let observed = Backend::CHECK_AND_PANIC
+    let observed = Backend::PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -10,23 +10,6 @@ pub struct Backend {
     pub emit_panic: bool,
 }
 
-impl Backend {
-    pub const CHECK_AND_PANIC: Backend = Backend {
-        emit_print: true,
-        emit_panic: true,
-    };
-
-    pub const CHECK_AND_PRINT: Backend = Backend {
-        emit_print: true,
-        emit_panic: false,
-    };
-
-    pub const NO_CHECK: Backend = Backend {
-        emit_print: false,
-        emit_panic: false,
-    };
-}
-
 /// Make an error message to say that some item is unsupported.
 pub fn make_item_error<T: ToTokens>(tokens: &T, item_descr: &str) -> syn::Error {
     let msg = format!(

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -10,6 +10,23 @@ pub struct Backend {
     pub emit_panic: bool,
 }
 
+impl Backend {
+    pub const CHECK_AND_PANIC: Backend = Backend {
+        emit_print: true,
+        emit_panic: true,
+    };
+
+    pub const CHECK_AND_PRINT: Backend = Backend {
+        emit_print: true,
+        emit_panic: false,
+    };
+
+    pub const NO_CHECK: Backend = Backend {
+        emit_print: false,
+        emit_panic: false,
+    };
+}
+
 /// Make an error message to say that some item is unsupported.
 pub fn make_item_error<T: ToTokens>(tokens: &T, item_descr: &str) -> syn::Error {
     let msg = format!(

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -10,20 +10,21 @@ pub struct Backend {
     pub emit_panic: bool,
 }
 
+#[cfg(test)]
 impl Backend {
-    pub const CHECK_AND_PANIC: Backend = Backend {
-        emit_print: true,
-        emit_panic: true,
-    };
-
-    pub const CHECK_AND_PRINT: Backend = Backend {
-        emit_print: true,
-        emit_panic: false,
-    };
-
-    pub const NO_CHECK: Backend = Backend {
+    pub(crate) const NOTHING: Backend = Backend {
         emit_print: false,
         emit_panic: false,
+    };
+
+    pub(crate) const PRINT: Backend = Backend {
+        emit_print: true,
+        emit_panic: false,
+    };
+
+    pub(crate) const PANIC: Backend = Backend {
+        emit_print: true,
+        emit_panic: true,
     };
 }
 

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -6,20 +6,24 @@ pub mod fns;
 pub mod traits;
 
 pub struct Backend {
-    pub build_check: fn(Option<&Meta>, &TokenStream, &str, &TokenStream) -> TokenStream,
+    pub emit_print: bool,
+    pub emit_panic: bool,
 }
 
 impl Backend {
     pub const CHECK_AND_PANIC: Backend = Backend {
-        build_check: build_assert,
+        emit_print: true,
+        emit_panic: true,
     };
 
     pub const CHECK_AND_PRINT: Backend = Backend {
-        build_check: build_eprint,
+        emit_print: true,
+        emit_panic: false,
     };
 
     pub const NO_CHECK: Backend = Backend {
-        build_check: build_inert,
+        emit_print: false,
+        emit_panic: false,
     };
 }
 

--- a/crates/anodized-fmt/tests/fixtures/expected/basic_traits.rs
+++ b/crates/anodized-fmt/tests/fixtures/expected/basic_traits.rs
@@ -66,7 +66,7 @@ fn should_succeed() {
     assert_eq!(test.mul_by(500), 1000);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: x > 0")]
 fn should_fail_add_to() {
@@ -74,7 +74,7 @@ fn should_fail_add_to() {
     assert_eq!(test.add_to(0), 3);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | output | * output > old_val")]
 fn should_fail_negative_mul_by() {

--- a/crates/anodized-fmt/tests/fixtures/expected/with_binds.rs
+++ b/crates/anodized-fmt/tests/fixtures/expected/with_binds.rs
@@ -12,7 +12,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {

--- a/crates/anodized-fmt/tests/fixtures/input/basic_traits.rs
+++ b/crates/anodized-fmt/tests/fixtures/input/basic_traits.rs
@@ -65,7 +65,7 @@ fn should_succeed() {
     assert_eq!(test.mul_by(500), 1000);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: x > 0")]
 fn should_fail_add_to() {
@@ -73,7 +73,7 @@ fn should_fail_add_to() {
     assert_eq!(test.add_to(0), 3);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | output | * output > old_val")]
 fn should_fail_negative_mul_by() {

--- a/crates/anodized-fmt/tests/fixtures/input/with_binds.rs
+++ b/crates/anodized-fmt/tests/fixtures/input/with_binds.rs
@@ -12,7 +12,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -13,13 +13,8 @@ license.workspace = true
 [lib]
 proc-macro = true
 
-[features]
-# Users should explicitly select a runtime feature when using this crate.
-# The default below is for development only:
-# default = ["runtime-check-and-print"]
-runtime-check-and-panic = []
-runtime-check-and-print = []
-runtime-no-check = []
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_panic)", "cfg(anodized_print)"] }
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -71,27 +71,27 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `struct`, `enum`       | Planned                   | Data invariants.                     |
 | `while`, `loop`, `for` | Planned                   | Loop invariants.                     |
 
-**Runtime Behaviors**
+**Backend Settings**
 
-| Behavior               | Status    | A `spec` violation...  |
-| ---------------------- | --------- | ---------------------- |
-| `cfg(anodized_panic)`  | Available | panics                 |
-| `cfg(anodized_print)`  | Available | prints an error        |
-| no cfg selected        | Available | has no runtime effect  |
-| `cfg(anodized_log)`    | Planned   | writes to a log        |
-| `cfg(anodized_trace)`  | Planned   | emits a trace event    |
-| `cfg(anodized_trap)`   | Planned   | breaks into a debugger |
+| `--cfg` setting  | Status    | A `spec` violation...  |
+| ---------------- | --------- | ---------------------- |
+| `anodized_print` | Available | prints an error        |
+| `anodized_panic` | Available | causes a panic         |
+| `anodized_log`   | Planned   | writes to a log        |
+| `anodized_trace` | Planned   | emits a trace event    |
+| `anodized_trap`  | Planned   | breaks into a debugger |
 
 **Analyzer Integrations**
 
-| System  | Status  | Notes                 |
-| ------- | ------- | --------------------- |
-| Aeneas  | Planned | Integrate with Charon |
-| Creusot | Planned |                       |
-| Flux    | Planned |                       |
-| Kani    | Planned |                       |
-| Prusti  | Planned |                       |
-| Verus   | Planned | Emit VIR              |
+| System  | Status      | Notes                 |
+| ------- | ----------- | --------------------- |
+| Aeneas  | Planned     | Integrate with Charon |
+| Creusot | Planned     |                       |
+| Flux    | Planned     |                       |
+| Hax     | In Progress | Uses `hax_lib` macros |
+| Kani    | Planned     |                       |
+| Prusti  | Planned     |                       |
+| Verus   | Planned     | Emit VIR              |
 
 ## Quickstart
 
@@ -108,7 +108,7 @@ Then compile with your desired runtime cfg:
 RUSTFLAGS="--cfg anodized_panic" cargo run
 ```
 
-See the [Runtime Behaviors](#runtime-behaviors) section for other runtime cfg settings.
+See the [Backend Settings](#runtime-settings) section for other configuration options.
 
 **2. Add specifications to your functions.**
 
@@ -231,27 +231,26 @@ Important restrictions:
 - Do not put `#[spec]` on methods inside a `#[spec]` trait impl. Method specs are defined at the trait declaration.
 - Names prefixed with `__anodized_` are internal and must not be implemented directly.
 
-### Runtime Behaviors
+### Backend Settings
 
-Anodized offers multiple runtime behaviors that control how `#[spec]` annotations expand to runtime checks:
+Anodized uses `cfg` settings to control how the backend expands each `#[spec]` into Rust code.
 
-- **`cfg(anodized_panic)`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
-- **`cfg(anodized_print)`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
-- **No cfg selected**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which lets the compiler optimize the checks away, while keeping the `#[spec]` syntax- and type-checked.
+- **`anodized_print`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
+- **`anodized_panic`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
 
-You select the runtime behavior via compiler cfg flags, for example:
+You select the runtime behavior via compiler `cfg` flags, for example:
 
 ```bash
 RUSTFLAGS="--cfg anodized_print" cargo test
 ```
 
-To disable runtime checks completely, run without either cfg flag.
+To disable runtime checks completely, run without any `anodized_*` setting.
 
-Future runtime behaviors (log, trace, breakpoint, etc.) will use the same cfg-based mechanism.
+Future backend settings (log, trace, breakpoint, etc.) will use the same `cfg`-based mechanism.
 
-### `#[cfg]`: Configure Runtime Checks
+### Attribute Support
 
-When `--cfg anodized_panic` or `--cfg anodized_print` is enabled, each condition is checked at runtime, just like Rust's `assert!` macro. You can use the standard `#[cfg]` attribute to select build configurations under which the runtime check is active.
+With `anodized_panic` or `anodized_print`, each condition is checked at runtime. You can use the standard `#[cfg]` attribute to select build configurations under which a condition is checked.
 
 ```rust, no_run
 use anodized::spec;
@@ -268,7 +267,7 @@ use anodized::spec;
 fn perform_complex_operation(input: i32) -> Result<i32, String> { todo!() }
 ```
 
-The `#[cfg]` attribute follows standard Rust semantics: when the configuration predicate is false, the runtime check for the condition is completely omitted. Without a `#[cfg]` attribute, the condition behaves exactly like `assert!`, always checked at runtime.
+The `#[cfg]` attribute follows standard Rust semantics: when the configuration predicate is false, the runtime check for the condition is completely omitted.
 
 **Important:** Anodized guarantees that each condition remains syntactically valid and type-correct regardless of its `#[cfg]` settings. This prevents conditions from becoming invalid between different build configurations, and keeps the entire spec always visible to analysis tools.
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -71,7 +71,7 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `struct`, `enum`       | Planned                   | Data invariants.                     |
 | `while`, `loop`, `for` | Planned                   | Loop invariants.                     |
 
-**Backend Settings**
+**Build Configurations**
 
 | `--cfg` setting  | Status    | A `spec` violation...  |
 | ---------------- | --------- | ---------------------- |
@@ -102,13 +102,13 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 anodized = { version = "0.4.0" }
 ```
 
-Then compile with your desired runtime cfg:
+Then compile with an `anodized_*` build setting:
 
 ```bash
 RUSTFLAGS="--cfg anodized_panic" cargo run
 ```
 
-See the [Backend Settings](#runtime-settings) section for other configuration options.
+See the [Build Configurations](#build-configurations) section for other options.
 
 **2. Add specifications to your functions.**
 
@@ -231,22 +231,22 @@ Important restrictions:
 - Do not put `#[spec]` on methods inside a `#[spec]` trait impl. Method specs are defined at the trait declaration.
 - Names prefixed with `__anodized_` are internal and must not be implemented directly.
 
-### Backend Settings
+### Build Configurations
 
-Anodized uses `cfg` settings to control how the backend expands each `#[spec]` into Rust code.
+Anodized uses `cfg` options to control how each `#[spec]` changes the Rust code.
 
 - **`anodized_print`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
-- **`anodized_panic`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
+- **`anodized_panic`**: Injects an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message.
 
-You select the runtime behavior via compiler `cfg` flags, for example:
+Select the desired options via compiler `cfg` flags, for example:
 
 ```bash
 RUSTFLAGS="--cfg anodized_print" cargo test
 ```
 
-To disable runtime checks completely, run without any `anodized_*` setting.
+To disable runtime checks completely, run without any `anodized_*` options.
 
-Future backend settings (log, trace, breakpoint, etc.) will use the same `cfg`-based mechanism.
+Future options (log, trace, breakpoint, etc.) will use the same `cfg`-based mechanism.
 
 ### Attribute Support
 
@@ -431,7 +431,7 @@ A core design principle of Anodized is that a condition is written as a **standa
 
 The choice of "specification" (or "spec") over "contract" is deliberate. While Design by Contract has a rich history, the term "contract" is now strongly associated with blockchain. This is particularly true in Rust, which has become a leading language for smart contract development.
 
-This naming collision hurts discoverability. Searching for "Rust contract" yields blockchain results, not correctness tools.
+This naming collision hurts discoverability. Searching for "Rust contract" yields many blockchain results, not just correctness tools.
 
 Using "specification" instead:
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -235,8 +235,8 @@ Important restrictions:
 
 Anodized uses `cfg` options to control how each `#[spec]` changes the Rust code.
 
-- **`anodized_print`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
-- **`anodized_panic`**: Injects an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message.
+- **`anodized_print`**: Reports each violation with `eprintln!`, so execution can continue. Useful for experiments, logging, etc.
+- **`anodized_panic`**: Checks each condition via an `assert!`, so a violation panics with a descriptive message.
 
 Select the desired options via compiler `cfg` flags, for example:
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -73,14 +73,14 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 
 **Runtime Behaviors**
 
-| Behavior          | Status    | A `spec` violation...  |
-| ----------------- | --------- | ---------------------- |
-| `check-and-panic` | Available | panics                 |
-| `check-and-print` | Available | prints an error        |
-| `no-check`        | Available | has no runtime effect  |
-| `check-and-log`   | Planned   | writes to a log        |
-| `check-and-trace` | Planned   | emits a trace event    |
-| `check-and-trap`  | Planned   | breaks into a debugger |
+| Behavior               | Status    | A `spec` violation...  |
+| ---------------------- | --------- | ---------------------- |
+| `cfg(anodized_panic)`  | Available | panics                 |
+| `cfg(anodized_print)`  | Available | prints an error        |
+| no cfg selected        | Available | has no runtime effect  |
+| `cfg(anodized_log)`    | Planned   | writes to a log        |
+| `cfg(anodized_trace)`  | Planned   | emits a trace event    |
+| `cfg(anodized_trap)`   | Planned   | breaks into a debugger |
 
 **Analyzer Integrations**
 
@@ -99,10 +99,16 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 
 ```toml
 [dependencies]
-anodized = { version = "0.4.0", features = ["runtime-check-and-panic"] }
+anodized = { version = "0.4.0" }
 ```
 
-See the [Runtime Behaviors](#runtime-behaviors) section for other runtime features.
+Then compile with your desired runtime cfg:
+
+```bash
+RUSTFLAGS="--cfg anodized_panic" cargo run
+```
+
+See the [Runtime Behaviors](#runtime-behaviors) section for other runtime cfg settings.
 
 **2. Add specifications to your functions.**
 
@@ -143,7 +149,7 @@ Your code is automatically instrumented to check the specifications at runtime. 
 thread 'main' panicked at 'Precondition failed: part <= whole', src/main.rs:17:5
 ```
 
-By default, runtime spec-checking is always active (just like Rust's `assert!` macro). For performance-sensitive code, you can use `#[cfg]` attributes to control when checks run (see the [#[cfg] section](#cfg-configure-runtime-checks) below).
+Runtime checks are active when you compile with `--cfg anodized_panic` or `--cfg anodized_print`. You can additionally use `#[cfg]` attributes on individual conditions to control when checks run (see the [#[cfg] section](#cfg-configure-runtime-checks) below).
 
 **Important:** Even when a condition's runtime check is disabled via a `#[cfg]` build setting, the compiler still validates that condition at compile time for syntax errors, unknown identifiers, type mismatches, etc.
 
@@ -229,24 +235,23 @@ Important restrictions:
 
 Anodized offers multiple runtime behaviors that control how `#[spec]` annotations expand to runtime checks:
 
-- **`check-and-panic`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
-- **`check-and-print`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
-- **`no-check`**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which lets the compiler optimize the checks away, while keeping the `#[spec]` syntax- and type-checked.
+- **`cfg(anodized_panic)`**: Inject an `assert!` check for each `requires`, `maintains`, and `ensures` clause. A failing condition panics with a descriptive message, just like the examples above.
+- **`cfg(anodized_print)`**: Reports violations with `eprintln!` so execution can continue. Useful for experiments, logging, etc.
+- **No cfg selected**: Disable checks altogether. Each check is surrounded with an `if false { ... }`, which lets the compiler optimize the checks away, while keeping the `#[spec]` syntax- and type-checked.
 
-The runtime setting goes in your `Cargo.toml`, for example:
+You select the runtime behavior via compiler cfg flags, for example:
 
-```toml
-anodized = {
-  version = # version
-  features = ["runtime-check-and-print"]
-}
+```bash
+RUSTFLAGS="--cfg anodized_print" cargo test
 ```
 
-Future runtime behaviors (log, trace, breakpoint, etc.) will use the same feature-based mechanism.
+To disable runtime checks completely, run without either cfg flag.
+
+Future runtime behaviors (log, trace, breakpoint, etc.) will use the same cfg-based mechanism.
 
 ### `#[cfg]`: Configure Runtime Checks
 
-By default, each condition is checked at runtime, just like Rust's `assert!` macro: it's always active in both debug and release builds. You can use the standard `#[cfg]` attribute to select build configurations under which the runtime check is active.
+When `--cfg anodized_panic` or `--cfg anodized_print` is enabled, each condition is checked at runtime, just like Rust's `assert!` macro. You can use the standard `#[cfg]` attribute to select build configurations under which the runtime check is active.
 
 ```rust, no_run
 use anodized::spec;

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -9,28 +9,9 @@ use anodized_core::{
     instrument::{Backend, make_item_error},
 };
 
-const _: () = {
-    let count: u32 = cfg!(feature = "runtime-check-and-panic") as u32
-        + cfg!(feature = "runtime-check-and-print") as u32
-        + cfg!(feature = "runtime-no-check") as u32;
-    if count > 1 {
-        panic!("anodized: runtime features are mutually exclusive");
-    }
-};
-
-const BACKEND: Backend = if cfg!(feature = "runtime-check-and-panic") {
-    Backend::CHECK_AND_PANIC
-} else if cfg!(feature = "runtime-check-and-print") {
-    Backend::CHECK_AND_PRINT
-} else if cfg!(feature = "runtime-no-check") {
-    Backend::NO_CHECK
-} else {
-    panic!(
-        r#"anodized: a runtime feature must be selected:
-`runtime-check-and-panic`
-`runtime-check-and-print`
-`runtime-no-check`"#
-    )
+const BACKEND: Backend = Backend {
+    emit_print: cfg!(anodized_print),
+    emit_panic: cfg!(anodized_panic),
 };
 
 /// Attaches a specification to a fn, or enables specs inside a trait and its impls.

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -29,7 +29,7 @@ fn job_start_success() {
     job.start();
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: matches! (self.state, State::Idle)")]
 fn job_start_panics_if_not_idle() {

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -13,7 +13,7 @@ fn divide_success() {
     checked_divide(10, 2);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: divisor != 0")]
 fn divide_by_zero_panics() {

--- a/crates/anodized/tests/basic_traits.rs
+++ b/crates/anodized/tests/basic_traits.rs
@@ -66,7 +66,7 @@ fn should_succeed() {
     assert_eq!(test.mul_by(500), 1000);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: x > 0")]
 fn should_fail_add_to() {
@@ -74,7 +74,7 @@ fn should_fail_add_to() {
     assert_eq!(test.add_to(0), 3);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | output | * output > old_val")]
 fn should_fail_negative_mul_by() {

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -116,7 +116,7 @@ fn captures_with_preconditions() {
     assert_eq!(container.counter, 51);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed")]
 fn capture_postcondition_failure() {
@@ -133,7 +133,7 @@ fn capture_postcondition_failure() {
     bad_increment(&mut val);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed")]
 fn precondition_runs_before_captures() {

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     pair
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -25,7 +25,7 @@ fn func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "runtime-no-check"))]
+#[cfg(any(anodized_panic, anodized_print))]
 #[test]
 fn execution_order() {
     let mut log = Vec::new();
@@ -73,7 +73,7 @@ fn func_all_conditions_fail(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(feature = "runtime-check-and-print")]
+#[cfg(anodized_print)]
 #[test]
 fn execution_order_print_only() {
     let mut log = Vec::new();
@@ -121,7 +121,7 @@ async fn async_func(log: &mut Vec<&'static str>) {
     return;
 }
 
-#[cfg(not(feature = "runtime-no-check"))]
+#[cfg(any(anodized_panic, anodized_print))]
 #[test]
 fn async_execution_order() {
     let mut log = Vec::new();

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -12,7 +12,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     (b, a)
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | (a, b) | a <= b")]
 fn sort_fail_postcondition() {

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -18,7 +18,7 @@ impl Validator {
     }
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.is_valid()")]
 fn violates_post_invariant() {
@@ -27,7 +27,7 @@ fn violates_post_invariant() {
     v.set_validity(false);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.is_valid()")]
 fn violates_pre_invariant() {

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -23,7 +23,7 @@ fn increment_success() {
     c.increment();
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Post-invariant failed: self.count <= self.capacity")]
 fn increment_violates_invariant() {
@@ -35,7 +35,7 @@ fn increment_violates_invariant() {
     c.increment();
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Pre-invariant failed: self.count <= self.capacity")]
 fn increment_violates_pre_invariant() {

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -30,7 +30,7 @@ fn get_element_success() {
     buffer.get_element(1);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: ! self.locked")]
 fn get_element_panics_when_locked() {
@@ -42,7 +42,7 @@ fn get_element_panics_when_locked() {
     buffer.get_element(1);
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Precondition failed: index < self.items.len()")]
 fn get_element_panics_on_out_of_bounds() {

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -33,7 +33,7 @@ fn calculate_odd_result(output: i32) -> i32 {
     }
 }
 
-#[cfg(feature = "runtime-check-and-panic")]
+#[cfg(anodized_panic)]
 #[test]
 #[should_panic(expected = "Postcondition failed: | result | * result % 2 == 0")]
 fn rename_panics_if_not_even() {


### PR DESCRIPTION
- move from Cargo features to `cfg` options
- split into orthogonal ON/OFF flags instead of mutually exclusive choices