### PR TITLE
[anodized-core] refactor: make `Backend::instrument_fn` usable with `ItemFn`, `TraitItemFn`, and `ImplItemFn` as well

### DIFF
--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -8,25 +8,25 @@ use crate::{
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
-use syn::{Block, Ident, ItemFn, Pat, PatIdent, parse::Result, parse_quote};
+use syn::{Block, Ident, Pat, PatIdent, Signature, parse::Result, parse_quote};
 
 impl Backend {
-    pub fn instrument_fn(&self, spec: Spec, mut func: ItemFn) -> syn::Result<ItemFn> {
-        let is_async = func.sig.asyncness.is_some();
+    pub fn instrument_fn(&self, spec: Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
+        let is_async = sig.asyncness.is_some();
 
         // Extract the return type from the function signature
-        let return_type = match &func.sig.output {
+        let return_type = match &sig.output {
             syn::ReturnType::Default => syn::parse_quote!(()),
             syn::ReturnType::Type(_, ty) => ty.as_ref().clone(),
         };
 
         // Generate the new, instrumented function body.
-        let new_body = self.instrument_fn_body(&spec, &func.block, is_async, &return_type)?;
+        let new_body = self.instrument_fn_body(&spec, body, is_async, &return_type)?;
 
         // Replace the old function body with the new one.
-        *func.block = new_body;
+        *body = new_body;
 
-        Ok(func)
+        Ok(())
     }
 
     fn instrument_fn_body(

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -1,5 +1,5 @@
 use quote::quote;
-use syn::{FnArg, ImplItem, ItemFn, Pat, TraitItem, parse_quote};
+use syn::{FnArg, ImplItem, Pat, TraitItem, parse_quote};
 
 use crate::{
     Spec,
@@ -42,35 +42,25 @@ impl Backend {
                     let original_ident = func.sig.ident.clone();
                     let mangled_ident = mangle_ident(&original_ident);
 
-                    let mut mangled_fn = func.clone();
+                    let mut wrapper_fn = func.clone();
+                    wrapper_fn.attrs = other_attrs;
+                    let call_args = build_call_args(&func.sig.inputs)?;
+                    let mut wrapper_body: syn::Block = parse_quote!({
+                        Self::#mangled_ident(#(#call_args),*)
+                    });
+                    if let Some(spec_attr) = spec_attr {
+                        let spec = spec_attr.parse_args()?;
+                        self.instrument_fn(spec, &wrapper_fn.sig, &mut wrapper_body)?;
+                    }
+                    wrapper_fn.default = Some(wrapper_body);
+                    wrapper_fn.semi_token = None;
+                    new_trait_items.push(TraitItem::Fn(wrapper_fn));
+
+                    let mut mangled_fn = func;
                     mangled_fn.sig.ident = mangled_ident.clone();
                     mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
                     mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
-
-                    let call_args = build_call_args(&func.sig.inputs)?;
-                    let mut wrapper_block: syn::Block = parse_quote!({
-                        Self::#mangled_ident(#(#call_args),*)
-                    });
-
-                    if let Some(spec_attr) = spec_attr {
-                        let spec = spec_attr.parse_args()?;
-                        let wrapper_item = ItemFn {
-                            attrs: Vec::new(),
-                            vis: syn::Visibility::Inherited,
-                            sig: func.sig.clone(),
-                            block: Box::new(wrapper_block),
-                        };
-                        let instrumented = self.instrument_fn(spec, wrapper_item)?;
-                        wrapper_block = *instrumented.block;
-                    }
-
-                    let mut wrapper_fn = func;
-                    wrapper_fn.attrs = other_attrs;
-                    wrapper_fn.default = Some(wrapper_block);
-                    wrapper_fn.semi_token = None;
-
                     new_trait_items.push(TraitItem::Fn(mangled_fn));
-                    new_trait_items.push(TraitItem::Fn(wrapper_fn));
                 }
                 TraitItem::Const(mut const_item) => {
                     let (spec, attrs) = find_spec_attr(const_item.attrs)?;

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -24,11 +24,11 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
-        Item::Fn(func) => {
+        Item::Fn(mut func) => {
             let spec = parse_macro_input!(args as Spec);
             BACKEND
-                .instrument_fn(spec, func)
-                .map(|tokens| tokens.into_token_stream())
+                .instrument_fn(spec, &func.sig, &mut func.block)
+                .map(|_| func.into_token_stream())
         }
         Item::Trait(the_trait) => {
             let spec = parse_macro_input!(args as Spec);


### PR DESCRIPTION
This makes e.g. `Backend::instrument_trait` internals slightly less awkward.