### PR TITLE
feat: embed `spec` elements as `fn __anodized_*`

### DIFF
--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -3,7 +3,7 @@ mod tests;
 
 use crate::{
     Capture, PostCondition, PreCondition, Spec,
-    instrument::{Backend, build_assert, build_eprint, build_inert},
+    instrument::{Backend, build_assert, build_eprint},
 };
 
 use proc_macro2::Span;
@@ -122,7 +122,7 @@ impl Backend {
             (true, true) => build_assert,
             (true, false) => build_eprint,
             (false, true) => build_assert,
-            (false, false) => build_inert,
+            (false, false) => return Ok(original_body.clone()),
         };
 
         // The identifier for the return value binding.

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -2,13 +2,13 @@
 mod tests;
 
 use crate::{
-    Spec,
+    PostCondition, PreCondition, Spec,
     instrument::{Backend, build_assert, build_eprint, build_inert},
 };
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
-use syn::{Block, Ident, Pat, PatIdent, Signature, parse::Result, parse_quote};
+use syn::{Block, Ident, Pat, PatIdent, Signature, Stmt, parse::Result, parse_quote};
 
 impl Backend {
     pub fn instrument_fn(&self, spec: Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
@@ -27,6 +27,66 @@ impl Backend {
         *body = new_body;
 
         Ok(())
+    }
+
+    fn build_spec_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+        Signature {
+            constness: sig.constness,
+            asyncness: sig.asyncness,
+            unsafety: sig.unsafety,
+            abi: sig.abi.clone(),
+            fn_token: sig.fn_token,
+            ident: syn::Ident::new(&format!("{prefix}{}", sig.ident), sig.ident.span()),
+            generics: sig.generics.clone(),
+            paren_token: sig.paren_token,
+            inputs: sig.inputs.clone(),
+            variadic: sig.variadic.clone(),
+            output: syn::ReturnType::Default,
+        }
+    }
+
+    fn build_precondition_fn_body(conditions: &[PreCondition]) -> Block {
+        let statements = conditions.iter().map(|condition| -> Stmt {
+            let closure = &condition.closure;
+            parse_quote! { let _ = #closure; }
+        });
+        parse_quote! {
+            {
+                #(#statements)*
+            }
+        }
+    }
+
+    fn build_poscondition_fn_body(
+        conditions: &[PostCondition],
+        return_type: &syn::Type,
+    ) -> Result<Block> {
+        let mut statements = vec![];
+        for condition in conditions {
+            let closure = &condition.closure;
+            // TODO: This sort of validation should happen during parsing.
+            let output_binder = match closure.inputs.first() {
+                Some(output_binder) if closure.inputs.len() == 1 => output_binder,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        &closure.inputs,
+                        "Postcondition closure must have exactly one parameter.",
+                    ));
+                }
+            };
+            let statement: Stmt = if let Pat::Type(_) = output_binder {
+                parse_quote! { let _ = #closure; }
+            } else {
+                let body = &closure.body;
+                parse_quote! { let _ = |#output_binder: &#return_type| #body; }
+            };
+            statements.push(statement);
+        }
+        Ok(parse_quote! {
+            {
+                #(#statements)*
+            }
+        })
     }
 
     fn instrument_fn_body(

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -2,13 +2,15 @@
 mod tests;
 
 use crate::{
-    PostCondition, PreCondition, Spec,
+    Capture, PostCondition, PreCondition, Spec,
     instrument::{Backend, build_assert, build_eprint, build_inert},
 };
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
-use syn::{Block, Ident, Pat, PatIdent, Signature, Stmt, parse::Result, parse_quote};
+use syn::{
+    Block, Expr, Ident, Pat, PatIdent, ReturnType, Signature, Stmt, parse::Result, parse_quote,
+};
 
 impl Backend {
     pub fn instrument_fn(&self, spec: Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
@@ -29,14 +31,14 @@ impl Backend {
         Ok(())
     }
 
-    fn build_spec_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+    pub fn build_spec_fn_sig(prefix: &str, sig: &Signature) -> Signature {
         Signature {
             constness: sig.constness,
             asyncness: sig.asyncness,
             unsafety: sig.unsafety,
             abi: sig.abi.clone(),
             fn_token: sig.fn_token,
-            ident: syn::Ident::new(&format!("{prefix}{}", sig.ident), sig.ident.span()),
+            ident: syn::Ident::new(&format!("{prefix}_{}", sig.ident), sig.ident.span()),
             generics: sig.generics.clone(),
             paren_token: sig.paren_token,
             inputs: sig.inputs.clone(),
@@ -45,7 +47,7 @@ impl Backend {
         }
     }
 
-    fn build_precondition_fn_body(conditions: &[PreCondition]) -> Block {
+    pub fn build_precondition_fn_body(conditions: &[PreCondition]) -> Block {
         let statements = conditions.iter().map(|condition| -> Stmt {
             let closure = &condition.closure;
             parse_quote! { let _ = #closure; }
@@ -57,11 +59,20 @@ impl Backend {
         }
     }
 
-    fn build_poscondition_fn_body(
+    pub fn build_poscondition_fn_body(
+        captures: &[Capture],
         conditions: &[PostCondition],
-        return_type: &syn::Type,
+        return_type: &ReturnType,
     ) -> Result<Block> {
+        let aliases = captures.iter().map(|capture| &capture.pat);
+        let capture_exprs = captures.iter().map(|capture| -> Expr {
+            let expr = &capture.expr;
+            // Wrap in closure to guard against `return`.
+            parse_quote! { (|| #expr)() }
+        });
+
         let mut statements = vec![];
+
         for condition in conditions {
             let closure = &condition.closure;
             // TODO: This sort of validation should happen during parsing.
@@ -75,15 +86,26 @@ impl Backend {
                 }
             };
             let statement: Stmt = if let Pat::Type(_) = output_binder {
+                // If the pattern has a type annotation, use as-is.
                 parse_quote! { let _ = #closure; }
             } else {
+                // Otherwise add a type annotation.
                 let body = &closure.body;
-                parse_quote! { let _ = |#output_binder: &#return_type| #body; }
+                match &return_type {
+                    ReturnType::Default => {
+                        parse_quote! { let _ = |#output_binder: &()| #body; }
+                    }
+                    ReturnType::Type(_, ty) => {
+                        parse_quote! { let _ = |#output_binder: &#ty| #body; }
+                    }
+                }
             };
             statements.push(statement);
         }
+
         Ok(parse_quote! {
             {
+                let (#(#aliases),*) = (#(#capture_exprs),*);
                 #(#statements)*
             }
         })

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -86,7 +86,7 @@ impl Backend {
                 }
             };
             let statement: Stmt = if let Pat::Type(_) = output_binder {
-                // If the pattern has a type annotation, use as-is.
+                // If the output binder has a type annotation, use as-is.
                 parse_quote! { let _ = #closure; }
             } else {
                 // Otherwise add a type annotation.

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -2,11 +2,11 @@ use crate::test_util::assert_tokens_eq;
 
 use super::*;
 use proc_macro2::TokenStream;
-use syn::{Block, ItemFn, Type, parse_quote};
+use syn::{Block, ItemFn, ItemTrait, Type, parse_quote};
 
 #[test]
 fn embed_spec_item_fn() {
-    let spec: Spec = parse_quote! {
+    let fn_spec: Spec = parse_quote! {
         requires: COND_1,
         #[cfg(META_1)]
         requires: [COND_2, COND_3],
@@ -26,19 +26,19 @@ fn embed_spec_item_fn() {
         ],
     };
     let item_fn: ItemFn = parse_quote! {
-        fn IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY
         }
     };
 
     let expected: TokenStream = parse_quote! {
-        fn IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY
         }
 
         #[doc(hidden)]
         #[allow(warnings)]
-        fn __anodized_fn_requires_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+        fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
             let _ = | | COND_1;
             let _ = | | COND_2;
             let _ = | | COND_3;
@@ -46,7 +46,7 @@ fn embed_spec_item_fn() {
 
         #[doc(hidden)]
         #[allow(warnings)]
-        fn __anodized_fn_maintains_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+        fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
             let _ = | | COND_4;
             let _ = | | COND_5;
             let _ = | | COND_6;
@@ -54,7 +54,7 @@ fn embed_spec_item_fn() {
 
         #[doc(hidden)]
         #[allow(warnings)]
-        fn __anodized_fn_ensures_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+        fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((| | EXPR_1)(), (| | EXPR_2)());
             let _ = |PAT_1: &RET_TYPE| COND_7;
             let _ = |PAT_1: &RET_TYPE| COND_8;
@@ -62,7 +62,64 @@ fn embed_spec_item_fn() {
         }
     };
 
-    let observed = Backend::NOTHING.instrument_item_fn(spec, item_fn).unwrap();
+    let observed = Backend::NOTHING
+        .instrument_item_fn(fn_spec, item_fn)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
+fn embed_spec_item_trait() {
+    let trait_spec = Spec::empty();
+    let item_trait: ItemTrait = parse_quote! {
+        trait TRAIT {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        trait TRAIT {
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
+            }
+
+            #[doc(hidden)]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let _ = | | COND_1;
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let _ = | | COND_2;
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let () = ();
+                let _ = |PAT_1: &RET_TYPE| COND_3;
+            }
+        }
+    };
+
+    let observed = Backend::NOTHING
+        .instrument_item_trait(trait_spec, item_trait)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -2,7 +2,7 @@ use crate::test_util::assert_tokens_eq;
 
 use super::*;
 use proc_macro2::TokenStream;
-use syn::{Block, ItemFn, ItemTrait, Type, parse_quote};
+use syn::{Block, ItemFn, Type, parse_quote};
 
 #[test]
 fn embed_spec_item_fn() {
@@ -64,61 +64,6 @@ fn embed_spec_item_fn() {
 
     let observed = Backend::NOTHING
         .instrument_item_fn(fn_spec, item_fn)
-        .unwrap();
-    assert_tokens_eq(&observed, &expected);
-}
-
-#[test]
-fn embed_spec_item_trait() {
-    let trait_spec = Spec::empty();
-    let item_trait: ItemTrait = parse_quote! {
-        trait TRAIT {
-            #[spec(
-                requires: COND_1,
-                maintains: COND_2,
-                binds: PAT_1,
-                ensures: COND_3,
-            )]
-            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                BODY
-            }
-        }
-    };
-
-    let expected: TokenStream = parse_quote! {
-        trait TRAIT {
-            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
-            }
-
-            #[doc(hidden)]
-            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                BODY
-            }
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | COND_1;
-            }
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | COND_2;
-            }
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let () = ();
-                let _ = |PAT_1: &RET_TYPE| COND_3;
-            }
-        }
-    };
-
-    let observed = Backend::NOTHING
-        .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -1,7 +1,70 @@
 use crate::test_util::assert_tokens_eq;
 
 use super::*;
-use syn::{Block, Type, parse_quote};
+use proc_macro2::TokenStream;
+use syn::{Block, ItemFn, Type, parse_quote};
+
+#[test]
+fn embed_spec_item_fn() {
+    let spec: Spec = parse_quote! {
+        requires: COND_1,
+        #[cfg(META_1)]
+        requires: [COND_2, COND_3],
+        maintains: [COND_4, COND_5],
+        #[cfg(META_2)]
+        maintains: COND_6,
+        captures: [
+            EXPR_1 as ALIAS_1,
+            EXPR_2 as (ALIAS_2, ALIAS_3),
+        ],
+        binds: PAT_1,
+        ensures: COND_7,
+        #[cfg(META_3)]
+        ensures: [
+            COND_8,
+            |PAT_2: TYPE| COND_9,
+        ],
+    };
+    let item_fn: ItemFn = parse_quote! {
+        fn IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        fn IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
+        }
+
+        #[doc(hidden)]
+        #[allow(warnings)]
+        fn __anodized_fn_requires_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+            let _ = | | COND_1;
+            let _ = | | COND_2;
+            let _ = | | COND_3;
+        }
+
+        #[doc(hidden)]
+        #[allow(warnings)]
+        fn __anodized_fn_maintains_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+            let _ = | | COND_4;
+            let _ = | | COND_5;
+            let _ = | | COND_6;
+        }
+
+        #[doc(hidden)]
+        #[allow(warnings)]
+        fn __anodized_fn_ensures_IDENT(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+            let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((| | EXPR_1)(), (| | EXPR_2)());
+            let _ = |PAT_1: &RET_TYPE| COND_7;
+            let _ = |PAT_1: &RET_TYPE| COND_8;
+            let _ = |PAT_2: TYPE| COND_9;
+        }
+    };
+
+    let observed = Backend::NOTHING.instrument_item_fn(spec, item_fn).unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
 
 fn make_fn_body() -> Block {
     parse_quote! {

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -47,19 +47,10 @@ fn requires_disable_runtime_checks() {
     let ret_type = make_return_type();
     let is_async = false;
 
-    let expected: Block = parse_quote! {
-        {
-            if false {
-                assert!((| | CONDITION_1)(), "Precondition failed: {}", "CONDITION_1");
-            }
-            let (__anodized_output): (#ret_type) = ((|| #body)());
-            __anodized_output
-        }
-    };
-
     let observed = Backend::NOTHING
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
+    let expected: Block = body;
     assert_tokens_eq(&observed, &expected);
 }
 

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -154,21 +154,6 @@ fn build_eprint(
     guard_check(cfg, check)
 }
 
-fn build_inert(
-    // The check will not be present at runtime regardless of the `#[cfg]` setting.
-    _cfg: Option<&Meta>,
-    expr: &TokenStream,
-    message: &str,
-    repr: &TokenStream,
-) -> TokenStream {
-    let repr_str = repr.to_string();
-    quote! {
-        if false {
-            assert!(#expr, #message, #repr_str);
-        }
-    }
-}
-
 fn guard_check(cfg: Option<&Meta>, check: TokenStream) -> TokenStream {
     if let Some(cfg) = cfg {
         quote! { if cfg!(#cfg) { #check } }

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -1,6 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Attribute, Meta};
+use syn::{Attribute, ItemFn, ItemImpl, ItemTrait, Meta};
+
+use crate::Spec;
 
 pub mod fns;
 pub mod traits;
@@ -8,6 +10,31 @@ pub mod traits;
 pub struct Backend {
     pub emit_print: bool,
     pub emit_panic: bool,
+}
+
+impl Backend {
+    pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> syn::Result<TokenStream> {
+        self.instrument_fn(spec, &item_fn.sig, &mut item_fn.block)?;
+        Ok(item_fn.to_token_stream())
+    }
+
+    pub fn instrument_item_trait(
+        &self,
+        spec: Spec,
+        item_trait: ItemTrait,
+    ) -> syn::Result<TokenStream> {
+        let new_trait = self.instrument_trait(spec, item_trait)?;
+        Ok(new_trait.to_token_stream())
+    }
+
+    pub fn instrument_item_trait_impl(
+        &self,
+        spec: Spec,
+        item_impl: ItemImpl,
+    ) -> syn::Result<TokenStream> {
+        let new_trait_impl = self.instrument_trait_impl(spec, item_impl)?;
+        Ok(new_trait_impl.to_token_stream())
+    }
 }
 
 #[cfg(test)]

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -18,7 +18,7 @@ impl Backend {
 
         let attrs: [Attribute; 2] = [
             parse_quote!(#[doc(hidden)]),
-            parse_quote!(#[allow(unused_variables)]),
+            parse_quote!(#[allow(warnings)]),
         ];
 
         // Embed `spec` elements as `__anodized_fn_*` functions.

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Attribute, ItemFn, ItemImpl, ItemTrait, Meta};
+use syn::{Attribute, ItemFn, ItemImpl, ItemTrait, Meta, Result, parse_quote};
 
 use crate::Spec;
 
@@ -13,9 +13,47 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> syn::Result<TokenStream> {
+    pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
+        let mut tokens = TokenStream::new();
+
+        let attrs: [Attribute; 2] = [
+            parse_quote!(#[doc(hidden)]),
+            parse_quote!(#[allow(unused_variables)]),
+        ];
+
+        // Embed `spec` elements as `__anodized_fn_*` functions.
+        let spec_requires_fn = ItemFn {
+            attrs: attrs.to_vec(),
+            vis: syn::Visibility::Inherited,
+            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &item_fn.sig),
+            block: Box::new(Self::build_precondition_fn_body(&spec.requires)),
+        };
+        let spec_maintains_fn = ItemFn {
+            attrs: attrs.to_vec(),
+            vis: syn::Visibility::Inherited,
+            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &item_fn.sig),
+            block: Box::new(Self::build_precondition_fn_body(&spec.maintains)),
+        };
+        let spec_ensures_fn = ItemFn {
+            attrs: attrs.to_vec(),
+            vis: syn::Visibility::Inherited,
+            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+            block: Box::new(Self::build_poscondition_fn_body(
+                &spec.captures,
+                &spec.ensures,
+                &item_fn.sig.output,
+            )?),
+        };
+
+        // Instrument function body.
         self.instrument_fn(spec, &item_fn.sig, &mut item_fn.block)?;
-        Ok(item_fn.to_token_stream())
+
+        item_fn.to_tokens(&mut tokens);
+        spec_requires_fn.to_tokens(&mut tokens);
+        spec_maintains_fn.to_tokens(&mut tokens);
+        spec_ensures_fn.to_tokens(&mut tokens);
+
+        Ok(tokens)
     }
 
     pub fn instrument_item_trait(

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use quote::quote;
 use syn::{Attribute, FnArg, ImplItem, Pat, TraitItem, TraitItemFn, parse_quote};
 

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -1,5 +1,5 @@
 use quote::quote;
-use syn::{FnArg, ImplItem, Pat, TraitItem, parse_quote};
+use syn::{Attribute, FnArg, ImplItem, Pat, TraitItem, TraitItemFn, parse_quote};
 
 use crate::{
     Spec,
@@ -39,8 +39,41 @@ impl Backend {
                     //   not going to work in every situation.
                     func.attrs = other_attrs.clone();
 
-                    let original_ident = func.sig.ident.clone();
-                    let mangled_ident = mangle_ident(&original_ident);
+                    let attrs: [Attribute; 2] = [
+                        parse_quote!(#[doc(hidden)]),
+                        parse_quote!(#[allow(warnings)]),
+                    ];
+
+                    // Embed `spec` elements as `__anodized_fn_*` functions.
+                    let spec_requires_fn = TraitItemFn {
+                        attrs: attrs.to_vec(),
+                        sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
+                        default: Some(Self::build_precondition_fn_body(&spec.requires)),
+                        semi_token: None,
+                    };
+                    new_trait_items.push(TraitItem::Fn(spec_requires_fn));
+
+                    let spec_maintains_fn = TraitItemFn {
+                        attrs: attrs.to_vec(),
+                        sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
+                        default: Some(Self::build_precondition_fn_body(&spec.maintains)),
+                        semi_token: None,
+                    };
+                    new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
+
+                    let spec_ensures_fn = TraitItemFn {
+                        attrs: attrs.to_vec(),
+                        sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
+                        default: Some(Self::build_poscondition_fn_body(
+                            &spec.captures,
+                            &spec.ensures,
+                            &func.sig.output,
+                        )?),
+                        semi_token: None,
+                    };
+                    new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
+
+                    let mangled_ident = mangle_ident(&func.sig.ident);
 
                     let mut wrapper_fn = func.clone();
                     wrapper_fn.attrs = other_attrs;

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -24,6 +24,7 @@ impl Backend {
                 "Unsupported spec element on trait. Try placing it on an item inside the trait",
             ));
         }
+        let _ = move || spec;
 
         let mut new_trait_items = Vec::with_capacity(the_trait.items.len() * 2);
 
@@ -31,13 +32,17 @@ impl Backend {
             match item {
                 TraitItem::Fn(mut func) => {
                     let (spec_attr, other_attrs) = find_spec_attr(func.attrs)?;
-
                     // NOTE: We have no way of knowing which attributes are
                     //   "external" - meant for the interface and belong on the wrapper,
                     //   "internal" - meant for the mangled implementation.
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
                     func.attrs = other_attrs.clone();
+
+                    let fn_spec: Spec = match spec_attr {
+                        Some(spec_attr) => spec_attr.parse_args()?,
+                        None => Spec::empty(),
+                    };
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -48,30 +53,25 @@ impl Backend {
                     let spec_requires_fn = TraitItemFn {
                         attrs: attrs.to_vec(),
                         sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
-                        default: Some(Self::build_precondition_fn_body(&spec.requires)),
+                        default: Some(Self::build_precondition_fn_body(&fn_spec.requires)),
                         semi_token: None,
                     };
-                    new_trait_items.push(TraitItem::Fn(spec_requires_fn));
-
                     let spec_maintains_fn = TraitItemFn {
                         attrs: attrs.to_vec(),
                         sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
-                        default: Some(Self::build_precondition_fn_body(&spec.maintains)),
+                        default: Some(Self::build_precondition_fn_body(&fn_spec.maintains)),
                         semi_token: None,
                     };
-                    new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
-
                     let spec_ensures_fn = TraitItemFn {
                         attrs: attrs.to_vec(),
                         sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
                         default: Some(Self::build_poscondition_fn_body(
-                            &spec.captures,
-                            &spec.ensures,
+                            &fn_spec.captures,
+                            &fn_spec.ensures,
                             &func.sig.output,
                         )?),
                         semi_token: None,
                     };
-                    new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
 
                     let mangled_ident = mangle_ident(&func.sig.ident);
 
@@ -81,10 +81,7 @@ impl Backend {
                     let mut wrapper_body: syn::Block = parse_quote!({
                         Self::#mangled_ident(#(#call_args),*)
                     });
-                    if let Some(spec_attr) = spec_attr {
-                        let spec = spec_attr.parse_args()?;
-                        self.instrument_fn(spec, &wrapper_fn.sig, &mut wrapper_body)?;
-                    }
+                    self.instrument_fn(fn_spec, &wrapper_fn.sig, &mut wrapper_body)?;
                     wrapper_fn.default = Some(wrapper_body);
                     wrapper_fn.semi_token = None;
                     new_trait_items.push(TraitItem::Fn(wrapper_fn));
@@ -94,6 +91,10 @@ impl Backend {
                     mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
                     mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
                     new_trait_items.push(TraitItem::Fn(mangled_fn));
+
+                    new_trait_items.push(TraitItem::Fn(spec_requires_fn));
+                    new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
+                    new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
                 }
                 TraitItem::Const(mut const_item) => {
                     let (spec, attrs) = find_spec_attr(const_item.attrs)?;

--- a/crates/anodized-core/src/instrument/traits/tests.rs
+++ b/crates/anodized-core/src/instrument/traits/tests.rs
@@ -1,0 +1,60 @@
+use crate::test_util::assert_tokens_eq;
+
+use super::*;
+use proc_macro2::TokenStream;
+use syn::{ItemTrait, parse_quote};
+
+#[test]
+fn embed_spec_item_trait() {
+    let trait_spec = Spec::empty();
+    let item_trait: ItemTrait = parse_quote! {
+        trait TRAIT {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        trait TRAIT {
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
+            }
+
+            #[doc(hidden)]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let _ = | | COND_1;
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let _ = | | COND_2;
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+                let () = ();
+                let _ = |PAT_1: &RET_TYPE| COND_3;
+            }
+        }
+    };
+
+    let observed = Backend::NOTHING
+        .instrument_item_trait(trait_spec, item_trait)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -25,6 +25,17 @@ pub struct Spec {
 }
 
 impl Spec {
+    /// Empty spec that contains no elements.
+    pub fn empty() -> Self {
+        Self {
+            requires: vec![],
+            maintains: vec![],
+            captures: vec![],
+            ensures: vec![],
+            span: Span::call_site(),
+        }
+    }
+
     /// Returns `true` if the spec contract is empty (specifies nothing), otherwise returns `false`
     pub fn is_empty(&self) -> bool {
         self.requires.is_empty()

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro::TokenStream;
-use quote::ToTokens;
 use syn::{Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
@@ -24,23 +23,17 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
-        Item::Fn(mut func) => {
+        Item::Fn(func) => {
             let spec = parse_macro_input!(args as Spec);
-            BACKEND
-                .instrument_fn(spec, &func.sig, &mut func.block)
-                .map(|_| func.into_token_stream())
+            BACKEND.instrument_item_fn(spec, func)
         }
         Item::Trait(the_trait) => {
             let spec = parse_macro_input!(args as Spec);
-            BACKEND
-                .instrument_trait(spec, the_trait)
-                .map(|tokens| tokens.into_token_stream())
+            BACKEND.instrument_item_trait(spec, the_trait)
         }
         Item::Impl(the_impl) if the_impl.trait_.is_some() => {
             let spec = parse_macro_input!(args as Spec);
-            BACKEND
-                .instrument_trait_impl(spec, the_impl)
-                .map(|tokens| tokens.into_token_stream())
+            BACKEND.instrument_item_trait_impl(spec, the_impl)
         }
         Item::Impl(ref the_impl) if the_impl.trait_.is_none() => {
             Err(make_item_error(&item, "inherent impl"))

--- a/crates/anodized/tests/async_function.rs
+++ b/crates/anodized/tests/async_function.rs
@@ -4,6 +4,7 @@ use anodized::spec;
     requires: x.is_finite(),
     ensures: output + output == x,
 )]
+#[allow(unused)]
 async fn async_half(x: f32) -> f32 {
     todo!()
 }

--- a/crates/anodized/tests/compile_fail/captures_scope_isolation.rs
+++ b/crates/anodized/tests/compile_fail/captures_scope_isolation.rs
@@ -33,7 +33,7 @@ fn captures_not_in_body(x: i32, y: i32) -> i32 {
     ],
 )]
 fn captures_not_in_requires(x: i32) {
-    // Function body
+    let _ = x;
 }
 
 #[spec(
@@ -46,7 +46,7 @@ fn captures_not_in_requires(x: i32) {
     ],
 )]
 fn captures_not_in_maintains(x: i32) {
-    // Function body
+    let _ = x;
 }
 
 fn main() {}

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -7,6 +7,7 @@ use anodized::spec;
         (*a, *b) == pair || (*b, *a) == pair,
     ],
 )]
+#[allow(unused)]
 fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     // Deliberately wrong implementation to break the spec.
     pair

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -20,6 +20,7 @@ use anodized::spec;
         return log.push("ensures2") == (),
     ],
 )]
+#[allow(unused)]
 fn func(log: &mut Vec<&'static str>) {
     log.push("body");
     return;
@@ -68,6 +69,7 @@ fn execution_order() {
         log.push("ensures2") != (),
     ],
 )]
+#[allow(unused)]
 fn func_all_conditions_fail(log: &mut Vec<&'static str>) {
     log.push("body");
     return;
@@ -116,6 +118,7 @@ fn execution_order_print_only() {
         log.push("ensures2") == (),
     ],
 )]
+#[allow(unused)]
 async fn async_func(log: &mut Vec<&'static str>) {
     log.push("body");
     return;

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -6,6 +6,7 @@ use anodized::spec;
         |(a, b)| (*a, *b) == pair || (*b, *a) == pair,
     ],
 )]
+#[allow(unused)]
 fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
     let (a, b) = pair;
     // Deliberately wrong implementation to break the spec.

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -13,6 +13,7 @@ impl Validator {
     #[spec(
         maintains: self.is_valid(),
     )]
+    #[allow(unused)]
     fn set_validity(&mut self, new_validity: bool) {
         self.valid = new_validity;
     }

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -25,6 +25,7 @@ fn rename_success() {
     binds: result,
     ensures: *result % 2 == 0,
 )]
+#[allow(unused)]
 fn calculate_odd_result(output: i32) -> i32 {
     if output % 2 == 0 {
         output + 1


### PR DESCRIPTION
- When runtime checks are disabled, each original function is unaltered.
- Each `spec` is validated (syntax, scope, types) even with runtime checks disabled.
- Each `spec` is available to downstream `rustc_driver` tools.
- Test `fn` and `trait` instrumentation.