### PR TITLE
feat: `cfg(anodized_discard_specs)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - cfg: ""
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_discard_specs"]'''
           - cfg: '--config ''build.rustflags=["--cfg","anodized_panic"]'''
           - cfg: '--config ''build.rustflags=["--cfg","anodized_print"]'''
-          - cfg: ""
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/crates/anodized-core/src/instrument/data/mod.rs
+++ b/crates/anodized-core/src/instrument/data/mod.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
-use syn::{ItemEnum, ItemStruct, Result, parse_quote};
+use quote::ToTokens;
+use syn::{ItemEnum, ItemImpl, ItemStruct, Result, parse_quote};
 
 use crate::{DataSpec, instrument::Backend};
 
@@ -12,40 +13,54 @@ impl Backend {
         spec: DataSpec,
         item_struct: ItemStruct,
     ) -> Result<TokenStream> {
+        let mut tokens = TokenStream::new();
+
         let ident = &item_struct.ident;
         let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
         let statements = Self::build_precondition_fn_body(&spec.maintains).stmts;
 
-        Ok(parse_quote! {
-            #item_struct
+        item_struct.to_tokens(&mut tokens);
 
-            #[doc(hidden)]
-            #[allow(warnings)]
-            impl #impl_generics #ident #ty_generics #where_clause {
-                fn __anodized_data_maintains(&self) {
-                    #(#statements)*
+        if self.embed_spec {
+            let spec_impl: ItemImpl = parse_quote! {
+                #[doc(hidden)]
+                #[allow(warnings)]
+                impl #impl_generics #ident #ty_generics #where_clause {
+                    fn __anodized_data_maintains(&self) {
+                        #(#statements)*
+                    }
                 }
-            }
-        })
+            };
+            spec_impl.to_tokens(&mut tokens);
+        }
+
+        Ok(tokens)
     }
 
     pub fn instrument_item_enum(&self, spec: DataSpec, item_enum: ItemEnum) -> Result<TokenStream> {
+        let mut tokens = TokenStream::new();
+
         let ident = &item_enum.ident;
         let (impl_generics, ty_generics, where_clause) = item_enum.generics.split_for_impl();
         let statements = Self::build_precondition_fn_body(&spec.maintains).stmts;
 
-        Ok(parse_quote! {
-            #item_enum
+        item_enum.to_tokens(&mut tokens);
 
-            #[doc(hidden)]
-            #[allow(warnings)]
-            impl #impl_generics #ident #ty_generics #where_clause {
-                fn __anodized_data_maintains(&self) {
-                    // Bring all variants into scope for convenience.
-                    use #ident::*;
-                    #(#statements)*
+        if self.embed_spec {
+            let spec_impl: ItemImpl = parse_quote! {
+                #[doc(hidden)]
+                #[allow(warnings)]
+                impl #impl_generics #ident #ty_generics #where_clause {
+                    fn __anodized_data_maintains(&self) {
+                        // Bring all variants into scope for convenience.
+                        use #ident::*;
+                        #(#statements)*
+                    }
                 }
-            }
-        })
+            };
+            spec_impl.to_tokens(&mut tokens);
+        }
+
+        Ok(tokens)
     }
 }

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -13,7 +13,7 @@ use syn::{
 };
 
 impl Backend {
-    pub fn instrument_fn(&self, spec: Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
+    pub fn instrument_fn(&self, spec: &Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
         self.instrument_loops_in_fn_body(body)?;
 
         let is_async = sig.asyncness.is_some();
@@ -25,7 +25,7 @@ impl Backend {
         };
 
         // Generate the new, instrumented function body.
-        let new_body = self.instrument_fn_body(&spec, body, is_async, &return_type)?;
+        let new_body = self.instrument_fn_body(spec, body, is_async, &return_type)?;
 
         // Replace the old function body with the new one.
         *body = new_body;

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -32,10 +32,6 @@ fn embed_spec_item_fn() {
     };
 
     let expected: TokenStream = parse_quote! {
-        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            BODY
-        }
-
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
@@ -59,6 +55,10 @@ fn embed_spec_item_fn() {
             let _ = |PAT_1: &RET_TYPE| COND_7;
             let _ = |PAT_1: &RET_TYPE| COND_8;
             let _ = |PAT_2: TYPE| COND_9;
+        }
+
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
         }
     };
 

--- a/crates/anodized-core/src/instrument/loops/mod.rs
+++ b/crates/anodized-core/src/instrument/loops/mod.rs
@@ -27,28 +27,30 @@ impl Backend {
     }
 
     fn instrument_loop_body(&self, spec: LoopSpec, stmts: &mut Vec<Stmt>) {
-        let maintains_block = Self::build_precondition_fn_body(&spec.maintains);
-        stmts.insert(
-            0,
-            parse_quote! {
-                let __anodized_loop_maintains = #maintains_block;
-            },
-        );
+        if self.embed_spec {
+            let maintains_block = Self::build_precondition_fn_body(&spec.maintains);
+            stmts.insert(
+                0,
+                parse_quote! {
+                    let __anodized_loop_maintains = #maintains_block;
+                },
+            );
 
-        let let_decreases: Option<Stmt> = spec.decreases.map(|loop_variant| {
-            let expr = loop_variant.expr;
-            parse_quote! {
-                let _ = || #expr;
-            }
-        });
-        stmts.insert(
-            1,
-            parse_quote! {
-                let __anodized_loop_decreases = {
-                    #let_decreases
-                };
-            },
-        );
+            let let_decreases: Option<Stmt> = spec.decreases.map(|loop_variant| {
+                let expr = loop_variant.expr;
+                parse_quote! {
+                    let _ = || #expr;
+                }
+            });
+            stmts.insert(
+                1,
+                parse_quote! {
+                    let __anodized_loop_decreases = {
+                        #let_decreases
+                    };
+                },
+            );
+        }
     }
 }
 

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -10,6 +10,7 @@ pub mod loops;
 pub mod traits;
 
 pub struct Backend {
+    pub embed_spec: bool,
     pub emit_print: bool,
     pub emit_panic: bool,
 }
@@ -80,16 +81,19 @@ impl Backend {
 #[cfg(test)]
 impl Backend {
     pub(crate) const NOTHING: Backend = Backend {
+        embed_spec: true,
         emit_print: false,
         emit_panic: false,
     };
 
     pub(crate) const PRINT: Backend = Backend {
+        embed_spec: true,
         emit_print: true,
         emit_panic: false,
     };
 
     pub(crate) const PANIC: Backend = Backend {
+        embed_spec: true,
         emit_print: true,
         emit_panic: true,
     };

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -49,7 +49,7 @@ impl Backend {
         };
 
         // Instrument function body.
-        self.instrument_fn(spec, &item_fn.sig, &mut item_fn.block)?;
+        self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
 
         item_fn.to_tokens(&mut tokens);
         spec_requires_fn.to_tokens(&mut tokens);

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -19,42 +19,44 @@ impl Backend {
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        let attrs: [Attribute; 2] = [
-            parse_quote!(#[doc(hidden)]),
-            parse_quote!(#[allow(warnings)]),
-        ];
+        if self.embed_spec {
+            let attrs: [Attribute; 2] = [
+                parse_quote!(#[doc(hidden)]),
+                parse_quote!(#[allow(warnings)]),
+            ];
 
-        // Embed `spec` elements as `__anodized_fn_*` functions.
-        let spec_requires_fn = ItemFn {
-            attrs: attrs.to_vec(),
-            vis: syn::Visibility::Inherited,
-            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &item_fn.sig),
-            block: Box::new(Self::build_precondition_fn_body(&spec.requires)),
-        };
-        let spec_maintains_fn = ItemFn {
-            attrs: attrs.to_vec(),
-            vis: syn::Visibility::Inherited,
-            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &item_fn.sig),
-            block: Box::new(Self::build_precondition_fn_body(&spec.maintains)),
-        };
-        let spec_ensures_fn = ItemFn {
-            attrs: attrs.to_vec(),
-            vis: syn::Visibility::Inherited,
-            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &item_fn.sig),
-            block: Box::new(Self::build_poscondition_fn_body(
-                &spec.captures,
-                &spec.ensures,
-                &item_fn.sig.output,
-            )?),
-        };
+            // Embed `spec` elements as `__anodized_fn_*` functions.
+            let spec_requires_fn = ItemFn {
+                attrs: attrs.to_vec(),
+                vis: syn::Visibility::Inherited,
+                sig: Self::build_spec_fn_sig("__anodized_fn_requires", &item_fn.sig),
+                block: Box::new(Self::build_precondition_fn_body(&spec.requires)),
+            };
+            let spec_maintains_fn = ItemFn {
+                attrs: attrs.to_vec(),
+                vis: syn::Visibility::Inherited,
+                sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &item_fn.sig),
+                block: Box::new(Self::build_precondition_fn_body(&spec.maintains)),
+            };
+            let spec_ensures_fn = ItemFn {
+                attrs: attrs.to_vec(),
+                vis: syn::Visibility::Inherited,
+                sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+                block: Box::new(Self::build_poscondition_fn_body(
+                    &spec.captures,
+                    &spec.ensures,
+                    &item_fn.sig.output,
+                )?),
+            };
+
+            spec_requires_fn.to_tokens(&mut tokens);
+            spec_maintains_fn.to_tokens(&mut tokens);
+            spec_ensures_fn.to_tokens(&mut tokens);
+        }
 
         // Instrument function body.
         self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
-
         item_fn.to_tokens(&mut tokens);
-        spec_requires_fn.to_tokens(&mut tokens);
-        spec_maintains_fn.to_tokens(&mut tokens);
-        spec_ensures_fn.to_tokens(&mut tokens);
 
         Ok(tokens)
     }

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -49,34 +49,40 @@ impl Backend {
                         None => Spec::empty(),
                     };
 
-                    let attrs: [Attribute; 2] = [
-                        parse_quote!(#[doc(hidden)]),
-                        parse_quote!(#[allow(warnings)]),
-                    ];
+                    if self.embed_spec {
+                        let attrs: [Attribute; 2] = [
+                            parse_quote!(#[doc(hidden)]),
+                            parse_quote!(#[allow(warnings)]),
+                        ];
 
-                    // Embed `spec` elements as `__anodized_fn_*` functions.
-                    let spec_requires_fn = TraitItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
-                        default: Some(Self::build_precondition_fn_body(&fn_spec.requires)),
-                        semi_token: None,
-                    };
-                    let spec_maintains_fn = TraitItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
-                        default: Some(Self::build_precondition_fn_body(&fn_spec.maintains)),
-                        semi_token: None,
-                    };
-                    let spec_ensures_fn = TraitItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
-                        default: Some(Self::build_poscondition_fn_body(
-                            &fn_spec.captures,
-                            &fn_spec.ensures,
-                            &func.sig.output,
-                        )?),
-                        semi_token: None,
-                    };
+                        // Embed `spec` elements as `__anodized_fn_*` functions.
+                        let spec_requires_fn = TraitItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
+                            default: Some(Self::build_precondition_fn_body(&fn_spec.requires)),
+                            semi_token: None,
+                        };
+                        let spec_maintains_fn = TraitItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
+                            default: Some(Self::build_precondition_fn_body(&fn_spec.maintains)),
+                            semi_token: None,
+                        };
+                        let spec_ensures_fn = TraitItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
+                            default: Some(Self::build_poscondition_fn_body(
+                                &fn_spec.captures,
+                                &fn_spec.ensures,
+                                &func.sig.output,
+                            )?),
+                            semi_token: None,
+                        };
+
+                        new_trait_items.push(TraitItem::Fn(spec_requires_fn));
+                        new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
+                        new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
+                    }
 
                     let mangled_ident = mangle_ident(&func.sig.ident);
 
@@ -96,10 +102,6 @@ impl Backend {
                     mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
                     mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
                     new_trait_items.push(TraitItem::Fn(mangled_fn));
-
-                    new_trait_items.push(TraitItem::Fn(spec_requires_fn));
-                    new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
-                    new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
                 }
                 TraitItem::Const(mut const_item) => {
                     let (spec, attrs) = find_spec_attr(const_item.attrs)?;
@@ -178,37 +180,43 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         None => Spec::empty(),
                     };
 
-                    let attrs: [Attribute; 2] = [
-                        parse_quote!(#[doc(hidden)]),
-                        parse_quote!(#[allow(warnings)]),
-                    ];
+                    if self.embed_spec {
+                        let attrs: [Attribute; 2] = [
+                            parse_quote!(#[doc(hidden)]),
+                            parse_quote!(#[allow(warnings)]),
+                        ];
 
-                    // Embed `spec` elements as `__anodized_fn_*` functions.
-                    let spec_requires_fn = ImplItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
-                        block: Self::build_precondition_fn_body(&fn_spec.requires),
-                        vis: Visibility::Inherited,
-                        defaultness: None,
-                    };
-                    let spec_maintains_fn = ImplItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
-                        block: Self::build_precondition_fn_body(&fn_spec.maintains),
-                        vis: Visibility::Inherited,
-                        defaultness: None,
-                    };
-                    let spec_ensures_fn = ImplItemFn {
-                        attrs: attrs.to_vec(),
-                        sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
-                        block: Self::build_poscondition_fn_body(
-                            &fn_spec.captures,
-                            &fn_spec.ensures,
-                            &func.sig.output,
-                        )?,
-                        vis: Visibility::Inherited,
-                        defaultness: None,
-                    };
+                        // Embed `spec` elements as `__anodized_fn_*` functions.
+                        let spec_requires_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
+                            block: Self::build_precondition_fn_body(&fn_spec.requires),
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+                        let spec_maintains_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
+                            block: Self::build_precondition_fn_body(&fn_spec.maintains),
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+                        let spec_ensures_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
+                            block: Self::build_poscondition_fn_body(
+                                &fn_spec.captures,
+                                &fn_spec.ensures,
+                                &func.sig.output,
+                            )?,
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+
+                        new_items.push(ImplItem::Fn(spec_requires_fn));
+                        new_items.push(ImplItem::Fn(spec_maintains_fn));
+                        new_items.push(ImplItem::Fn(spec_ensures_fn));
+                    }
 
                     func.sig.ident = mangle_ident(original_ident);
                     self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
@@ -221,9 +229,6 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
 
                     func.attrs = func_attrs;
                     new_items.push(ImplItem::Fn(func));
-                    new_items.push(ImplItem::Fn(spec_requires_fn));
-                    new_items.push(ImplItem::Fn(spec_maintains_fn));
-                    new_items.push(ImplItem::Fn(spec_ensures_fn));
                 }
                 ImplItem::Const(mut const_item) => {
                     let (spec, attrs) = find_spec_attr(const_item.attrs)?;

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -86,7 +86,7 @@ impl Backend {
                     let mut wrapper_body: syn::Block = parse_quote!({
                         Self::#mangled_ident(#(#call_args),*)
                     });
-                    self.instrument_fn(fn_spec, &wrapper_fn.sig, &mut wrapper_body)?;
+                    self.instrument_fn(&fn_spec, &wrapper_fn.sig, &mut wrapper_body)?;
                     wrapper_fn.default = Some(wrapper_body);
                     wrapper_fn.semi_token = None;
                     new_trait_items.push(TraitItem::Fn(wrapper_fn));
@@ -211,7 +211,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     };
 
                     func.sig.ident = mangle_ident(original_ident);
-                    self.instrument_fn(fn_spec, &func.sig, &mut func.block)?;
+                    self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
                     // Add a default `#[inline]` attribute unless one is already there.
                     // The caller can supress this with `#[inline(never)]`

--- a/crates/anodized-core/src/instrument/traits/tests.rs
+++ b/crates/anodized-core/src/instrument/traits/tests.rs
@@ -23,15 +23,6 @@ fn embed_spec_item_trait() {
 
     let expected: TokenStream = parse_quote! {
         trait TRAIT {
-            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
-            }
-
-            #[doc(hidden)]
-            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                BODY
-            }
-
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
@@ -49,6 +40,15 @@ fn embed_spec_item_trait() {
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
                 let () = ();
                 let _ = |PAT_1: &RET_TYPE| COND_3;
+            }
+
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
+            }
+
+            #[doc(hidden)]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
             }
         }
     };
@@ -78,11 +78,6 @@ fn embed_spec_item_impl_trait() {
 
     let expected: TokenStream = parse_quote! {
         impl TRAIT for IMPL_TYPE {
-            #[inline]
-            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                BODY
-            }
-
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
@@ -100,6 +95,11 @@ fn embed_spec_item_impl_trait() {
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
                 let () = ();
                 let _ = |PAT_1: &RET_TYPE| COND_3;
+            }
+
+            #[inline]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
             }
         }
     };

--- a/crates/anodized-macros/Cargo.toml
+++ b/crates/anodized-macros/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 proc-macro = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_panic)", "cfg(anodized_print)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)"] }
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -9,6 +9,7 @@ use anodized_core::{
 };
 
 const BACKEND: Backend = Backend {
+    embed_spec: cfg!(not(anodized_discard_specs)),
     emit_print: cfg!(anodized_print),
     emit_panic: cfg!(anodized_panic),
 };

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 license.workspace = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_panic)", "cfg(anodized_print)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)"] }
 
 [dependencies]
 anodized-logic.workspace = true

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -81,7 +81,7 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `anodized_trace` | Planned   | emits a trace event    |
 | `anodized_trap`  | Planned   | breaks into a debugger |
 
-**NOTE**: `anodized_discard_specs` to disable embedding the specs as Rust code. Note that this has **no effect on runtime performance** because the embedded specs are always dead code. However, it **prevents spec validation** by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
+**NOTE**: You can use `anodized_discard_specs` to disable embedding the specs as Rust code. Note that this has **no effect on runtime performance** because the embedded specs are always dead code. However, it **prevents spec validation** by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
 
 **Analyzer Integrations**
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -81,7 +81,7 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `anodized_trace` | Planned   | emits a trace event    |
 | `anodized_trap`  | Planned   | breaks into a debugger |
 
-There's also `anodized_discard_specs` to disable embedding the specs as Rust code. Note that this has *no effect on runtime performance* because the embedded specs are always dead code. However, it *prevents spec validation* by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
+**NOTE**: `anodized_discard_specs` to disable embedding the specs as Rust code. Note that this has **no effect on runtime performance** because the embedded specs are always dead code. However, it **prevents spec validation** by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
 
 **Analyzer Integrations**
 

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -81,6 +81,8 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `anodized_trace` | Planned   | emits a trace event    |
 | `anodized_trap`  | Planned   | breaks into a debugger |
 
+There's also `anodized_discard_specs` which disables embedding the specs as Rust constructs. Note that this has *no effect on runtime performance* because the embedded specs are always dead code. However, it *prevents spec validation* by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
+
 **Analyzer Integrations**
 
 | System  | Status      | Notes                 |

--- a/crates/anodized/README.md
+++ b/crates/anodized/README.md
@@ -81,7 +81,7 @@ Anodized aims to become a common layer across runtime checks, fuzzing, and verif
 | `anodized_trace` | Planned   | emits a trace event    |
 | `anodized_trap`  | Planned   | breaks into a debugger |
 
-There's also `anodized_discard_specs` which disables embedding the specs as Rust constructs. Note that this has *no effect on runtime performance* because the embedded specs are always dead code. However, it *prevents spec validation* by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
+There's also `anodized_discard_specs` to disable embedding the specs as Rust code. Note that this has *no effect on runtime performance* because the embedded specs are always dead code. However, it *prevents spec validation* by the Rust compiler (for syntax, scope, and types), and may thus decrease compilation speed.
 
 **Analyzer Integrations**
 


### PR DESCRIPTION
- add `anodized_discard_specs` setting to disable embedding the specs
- update instrumentation code
- update tests
- extend docs