### PR TITLE
feat: `fn` qualifiers

### DIFF
--- a/crates/anodized-core/Cargo.toml
+++ b/crates/anodized-core/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [lib]
 
 [dependencies]
+bitflags = "2.11.1"
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -39,6 +39,13 @@ impl Parse for Spec {
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
+                Keyword::Functional => {
+                    if let Err(error) =
+                        arg.parse_fn_qualifier(FnQualifiers::FUNCTIONAL, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
                 Keyword::Pure => {
                     if let Err(error) = arg.parse_fn_qualifier(FnQualifiers::PURE, &mut qualifiers)
                     {

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -33,6 +33,17 @@ impl Parse for Spec {
 
         for arg in raw_spec.args {
             match arg.keyword {
+                Keyword::Unknown(ident) => {
+                    errors.add(Error::new(
+                        arg.keyword_span,
+                        format!("unknown spec keyword `{ident}`"),
+                    ));
+                }
+                // Keyword::Pure => {
+                //     if let Err(error) = arg.parse_qualifier(&mut qualifiers) {
+                //         errors.add(error);
+                //     }
+                // }
                 Keyword::Requires => {
                     if let Err(error) = arg.parse_preconditions(&mut requires) {
                         errors.add(error);
@@ -76,10 +87,10 @@ impl Parse for Spec {
                         format!("`{}` parameter is not supported here", &arg.keyword),
                     ));
                 }
-                Keyword::Unknown(ident) => {
+                _ => {
                     errors.add(Error::new(
                         arg.keyword_span,
-                        format!("unknown spec keyword `{ident}`"),
+                        format!("`{}` parameter is not supported here", &arg.keyword),
                     ));
                 }
             }
@@ -116,25 +127,21 @@ impl Parse for DataSpec {
 
         for arg in raw_spec.args {
             match arg.keyword {
+                Keyword::Unknown(ident) => {
+                    errors.add(Error::new(
+                        arg.keyword_span,
+                        format!("unknown spec keyword `{ident}`"),
+                    ));
+                }
                 Keyword::Maintains => {
                     if let Err(error) = arg.parse_preconditions(&mut maintains) {
                         errors.add(error);
                     }
                 }
-                Keyword::Requires
-                | Keyword::Captures
-                | Keyword::Binds
-                | Keyword::Ensures
-                | Keyword::Decreases => {
+                _ => {
                     errors.add(Error::new(
                         arg.keyword_span,
                         format!("`{}` parameter is not supported here", &arg.keyword),
-                    ));
-                }
-                Keyword::Unknown(ident) => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("unknown spec keyword `{ident}`"),
                     ));
                 }
             }
@@ -163,6 +170,12 @@ impl Parse for LoopSpec {
 
         for arg in raw_spec.args {
             match arg.keyword {
+                Keyword::Unknown(ident) => {
+                    errors.add(Error::new(
+                        arg.keyword_span,
+                        format!("unknown spec keyword `{ident}`"),
+                    ));
+                }
                 Keyword::Maintains => {
                     if let Err(error) = arg.parse_preconditions(&mut maintains) {
                         errors.add(error);
@@ -179,16 +192,10 @@ impl Parse for LoopSpec {
                         errors.add(error);
                     }
                 }
-                Keyword::Requires | Keyword::Captures | Keyword::Binds | Keyword::Ensures => {
+                _ => {
                     errors.add(Error::new(
                         arg.keyword_span,
                         format!("`{}` parameter is not supported here", &arg.keyword),
-                    ));
-                }
-                Keyword::Unknown(ident) => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("unknown spec keyword `{ident}`"),
                     ));
                 }
             }

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -7,7 +7,7 @@ use syn::{
 
 use crate::{
     Capture, DataSpec, LoopSpec, LoopVariant, PostCondition, PreCondition, Spec,
-    annotate::syntax::{CaptureExpr, SpecArg},
+    annotate::syntax::{CaptureExpr, SpecArg, SpecArgValue},
     qualifiers::FnQualifiers,
 };
 
@@ -256,7 +256,13 @@ impl SpecArg {
         if let Some(first_attr) = self.attrs.first() {
             return Err(Error::new_spanned(
                 first_attr,
-                "attributes are not supported on `captures`",
+                format!("attributes are not supported on `{}`", self.keyword),
+            ));
+        }
+        if !matches!(self.value, SpecArgValue::None) {
+            return Err(Error::new_spanned(
+                self.value,
+                format!("qualifier `{}` does not take a value", self.keyword),
             ));
         }
         if qualifiers.contains(value) {

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -8,6 +8,7 @@ use syn::{
 use crate::{
     Capture, DataSpec, LoopSpec, LoopVariant, PostCondition, PreCondition, Spec,
     annotate::syntax::{CaptureExpr, SpecArg},
+    qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -21,6 +22,7 @@ impl Parse for Spec {
         let raw_spec = syntax::SpecArgs::parse(input)?;
 
         let mut errors = MultiError::empty();
+        let mut qualifiers = FnQualifiers::empty();
         let mut requires: Vec<PreCondition> = vec![];
         let mut maintains: Vec<PreCondition> = vec![];
         let mut captures: Vec<Capture> = vec![];
@@ -95,6 +97,7 @@ impl Parse for Spec {
         }
 
         Ok(Self {
+            qualifiers,
             requires,
             maintains,
             captures,

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -39,11 +39,46 @@ impl Parse for Spec {
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
-                // Keyword::Pure => {
-                //     if let Err(error) = arg.parse_qualifier(&mut qualifiers) {
-                //         errors.add(error);
-                //     }
-                // }
+                Keyword::Pure => {
+                    if let Err(error) = arg.parse_fn_qualifier(FnQualifiers::PURE, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
+                Keyword::Total => {
+                    if let Err(error) = arg.parse_fn_qualifier(FnQualifiers::TOTAL, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
+                Keyword::Deterministic => {
+                    if let Err(error) =
+                        arg.parse_fn_qualifier(FnQualifiers::DETERMINISTIC, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
+                Keyword::Effectfree => {
+                    if let Err(error) =
+                        arg.parse_fn_qualifier(FnQualifiers::EFFECTFREE, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
+                Keyword::Infallible => {
+                    if let Err(error) =
+                        arg.parse_fn_qualifier(FnQualifiers::INFALLIBLE, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
+                Keyword::Terminating => {
+                    if let Err(error) =
+                        arg.parse_fn_qualifier(FnQualifiers::TERMINATING, &mut qualifiers)
+                    {
+                        errors.add(error);
+                    }
+                }
                 Keyword::Requires => {
                     if let Err(error) = arg.parse_preconditions(&mut requires) {
                         errors.add(error);
@@ -87,19 +122,15 @@ impl Parse for Spec {
                         format!("`{}` parameter is not supported here", &arg.keyword),
                     ));
                 }
-                _ => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("`{}` parameter is not supported here", &arg.keyword),
-                    ));
-                }
             }
         }
 
         if !is_sorted {
             errors.add(Error::new(
                 input.span(),
-                "parameters are out of order: the expected order is `requires`, `maintains`, `captures`, `binds`, `ensures`",
+                "parameters are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `binds`, `ensures`, where `<QUALIFIERS>` are:\n
+`pure` (`deterministic`, `effectfree`),\n
+`total` (`infallible`, `terminating`)",
             ));
         }
 
@@ -221,6 +252,23 @@ impl Parse for LoopSpec {
 }
 
 impl SpecArg {
+    fn parse_fn_qualifier(self, value: FnQualifiers, qualifiers: &mut FnQualifiers) -> Result<()> {
+        if let Some(first_attr) = self.attrs.first() {
+            return Err(Error::new_spanned(
+                first_attr,
+                "attributes are not supported on `captures`",
+            ));
+        }
+        if qualifiers.contains(value) {
+            return Err(Error::new(
+                self.keyword_span,
+                "this qualifier is redundant; remove it",
+            ));
+        }
+        *qualifiers |= value;
+        Ok(())
+    }
+
     fn parse_preconditions(self, preconditions: &mut Vec<PreCondition>) -> Result<()> {
         let cfg_attr = find_cfg_attribute(&self.attrs)?;
         let cfg: Option<Meta> = if let Some(attr) = cfg_attr {

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -136,8 +136,9 @@ impl Parse for Spec {
             errors.add(Error::new(
                 input.span(),
                 "parameters are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `binds`, `ensures`, where `<QUALIFIERS>` are:\n
-`pure` (`deterministic`, `effectfree`),\n
-`total` (`infallible`, `terminating`)",
+`functional` (`pure` and `total`),\n
+`pure` (`deterministic` and `effectfree`),\n
+`total` (`infallible` and `terminating`)",
             ));
         }
 

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -37,7 +37,7 @@ pub struct SpecArg {
     pub attrs: Vec<Attribute>,
     pub keyword: Keyword,
     pub keyword_span: Span,
-    pub colon: Token![:],
+    pub colon: Option<Token![:]>,
     pub value: SpecArgValue,
 }
 
@@ -45,11 +45,18 @@ impl Parse for SpecArg {
     fn parse(input: ParseStream) -> Result<Self> {
         let attrs = input.call(Attribute::parse_outer)?;
         let (keyword, keyword_span) = Keyword::parse(input)?;
-        let colon = input.parse()?;
-        let value = match keyword {
-            Keyword::Binds => SpecArgValue::parse_pat_or_expr(input)?,
-            Keyword::Captures => SpecArgValue::Captures(input.parse()?),
-            _ => SpecArgValue::parse_expr_or_pat(input)?,
+
+        let (colon, value) = if input.peek(Token![:]) {
+            (
+                input.parse()?,
+                match keyword {
+                    Keyword::Binds => SpecArgValue::parse_pat_or_expr(input)?,
+                    Keyword::Captures => SpecArgValue::Captures(input.parse()?),
+                    _ => SpecArgValue::parse_expr_or_pat(input)?,
+                },
+            )
+        } else {
+            (None, SpecArgValue::None)
         };
 
         Ok(Self {
@@ -69,6 +76,7 @@ impl Parse for SpecArg {
 /// and even fragments that would never appear as part of a valid Rust program.
 #[derive(Debug, Clone)]
 pub enum SpecArgValue {
+    None,
     Expr(Expr),
     Pat(Pat),
     Captures(Captures),
@@ -154,6 +162,7 @@ impl SpecArgValue {
 impl ToTokens for SpecArgValue {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
+            SpecArgValue::None => {}
             SpecArgValue::Expr(expr) => expr.to_tokens(tokens),
             SpecArgValue::Pat(pat) => pat.to_tokens(tokens),
             SpecArgValue::Captures(captures) => captures.to_tokens(tokens),
@@ -243,6 +252,12 @@ impl Parse for CaptureExpr {
 /// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
 /// as if they were built-in Rust keywords during parsing.
 pub mod kw {
+    syn::custom_keyword!(pure);
+    syn::custom_keyword!(total);
+    syn::custom_keyword!(deterministic);
+    syn::custom_keyword!(effectless);
+    syn::custom_keyword!(infallible);
+    syn::custom_keyword!(terminating);
     syn::custom_keyword!(requires);
     syn::custom_keyword!(maintains);
     syn::custom_keyword!(captures);
@@ -254,6 +269,12 @@ pub mod kw {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum Keyword {
     Unknown(Ident),
+    Pure,
+    Total,
+    Deterministic,
+    Effectless,
+    Infallible,
+    Terminating,
     Requires,
     Maintains,
     Captures,
@@ -265,7 +286,25 @@ pub enum Keyword {
 impl Keyword {
     fn parse(input: ParseStream) -> Result<(Self, Span)> {
         use Keyword::*;
-        Ok(if input.peek(kw::requires) {
+        Ok(if input.peek(kw::pure) {
+            let keyword: kw::pure = input.parse()?;
+            (Pure, keyword.span)
+        } else if input.peek(kw::total) {
+            let keyword: kw::total = input.parse()?;
+            (Total, keyword.span)
+        } else if input.peek(kw::deterministic) {
+            let keyword: kw::deterministic = input.parse()?;
+            (Deterministic, keyword.span)
+        } else if input.peek(kw::effectless) {
+            let keyword: kw::effectless = input.parse()?;
+            (Effectless, keyword.span)
+        } else if input.peek(kw::infallible) {
+            let keyword: kw::infallible = input.parse()?;
+            (Infallible, keyword.span)
+        } else if input.peek(kw::terminating) {
+            let keyword: kw::terminating = input.parse()?;
+            (Terminating, keyword.span)
+        } else if input.peek(kw::requires) {
             let keyword: kw::requires = input.parse()?;
             (Requires, keyword.span)
         } else if input.peek(kw::maintains) {
@@ -294,13 +333,19 @@ impl Keyword {
 impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Keyword::Unknown(ident) => write!(f, "{}", ident),
+            Keyword::Pure => write!(f, "pure"),
+            Keyword::Total => write!(f, "total"),
+            Keyword::Deterministic => write!(f, "deterministic"),
+            Keyword::Effectless => write!(f, "effectless"),
+            Keyword::Infallible => write!(f, "infallible"),
+            Keyword::Terminating => write!(f, "terminating"),
             Keyword::Requires => write!(f, "requires"),
             Keyword::Maintains => write!(f, "maintains"),
             Keyword::Captures => write!(f, "captures"),
             Keyword::Binds => write!(f, "binds"),
             Keyword::Ensures => write!(f, "ensures"),
             Keyword::Decreases => write!(f, "decreases"),
-            Keyword::Unknown(ident) => write!(f, "{}", ident),
         }
     }
 }

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -255,7 +255,7 @@ pub mod kw {
     syn::custom_keyword!(pure);
     syn::custom_keyword!(total);
     syn::custom_keyword!(deterministic);
-    syn::custom_keyword!(effectless);
+    syn::custom_keyword!(effectfree);
     syn::custom_keyword!(infallible);
     syn::custom_keyword!(terminating);
     syn::custom_keyword!(requires);
@@ -272,7 +272,7 @@ pub enum Keyword {
     Pure,
     Total,
     Deterministic,
-    Effectless,
+    Effectfree,
     Infallible,
     Terminating,
     Requires,
@@ -295,9 +295,9 @@ impl Keyword {
         } else if input.peek(kw::deterministic) {
             let keyword: kw::deterministic = input.parse()?;
             (Deterministic, keyword.span)
-        } else if input.peek(kw::effectless) {
-            let keyword: kw::effectless = input.parse()?;
-            (Effectless, keyword.span)
+        } else if input.peek(kw::effectfree) {
+            let keyword: kw::effectfree = input.parse()?;
+            (Effectfree, keyword.span)
         } else if input.peek(kw::infallible) {
             let keyword: kw::infallible = input.parse()?;
             (Infallible, keyword.span)
@@ -337,7 +337,7 @@ impl std::fmt::Display for Keyword {
             Keyword::Pure => write!(f, "pure"),
             Keyword::Total => write!(f, "total"),
             Keyword::Deterministic => write!(f, "deterministic"),
-            Keyword::Effectless => write!(f, "effectless"),
+            Keyword::Effectfree => write!(f, "effectfree"),
             Keyword::Infallible => write!(f, "infallible"),
             Keyword::Terminating => write!(f, "terminating"),
             Keyword::Requires => write!(f, "requires"),

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -10,6 +10,7 @@ use syn::{
 /// Raw spec arguments, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
 ///
 /// Can represent a well-formed but invalid spec so that e.g. `anodized-fmt` may work with it.
+#[derive(Debug, Clone)]
 pub struct SpecArgs {
     pub args: Punctuated<SpecArg, Token![,]>,
 }
@@ -33,6 +34,7 @@ impl SpecArgs {
 }
 
 /// A single spec argument.
+#[derive(Debug, Clone)]
 pub struct SpecArg {
     pub attrs: Vec<Attribute>,
     pub keyword: Keyword,
@@ -74,7 +76,7 @@ impl Parse for SpecArg {
 /// NOTE:
 /// a [`SpecArgValue`] may hold unrelated syntactic elements such as ['syn::Expr`], [`syn::Pat`],
 /// and even fragments that would never appear as part of a valid Rust program.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SpecArgValue {
     None,
     Expr(Expr),
@@ -172,7 +174,7 @@ impl ToTokens for SpecArgValue {
 
 /// A group of capture expressions, either a single one or a list.
 /// These are not composed of top level [`syn::Expr`] expressions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Captures {
     One(Box<CaptureExpr>),
     Many {
@@ -213,7 +215,7 @@ impl ToTokens for Captures {
 }
 
 /// The form in a `captures` clause: <expression> `as` <pattern>.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CaptureExpr {
     pub expr: Option<Expr>,
     pub as_: Option<Token![as]>,
@@ -266,7 +268,7 @@ pub mod kw {
     syn::custom_keyword!(decreases);
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Keyword {
     Unknown(Ident),
     Pure,

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -254,6 +254,7 @@ impl Parse for CaptureExpr {
 /// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
 /// as if they were built-in Rust keywords during parsing.
 pub mod kw {
+    syn::custom_keyword!(functional);
     syn::custom_keyword!(pure);
     syn::custom_keyword!(total);
     syn::custom_keyword!(deterministic);
@@ -271,6 +272,7 @@ pub mod kw {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Keyword {
     Unknown(Ident),
+    Functional,
     Pure,
     Total,
     Deterministic,
@@ -288,7 +290,10 @@ pub enum Keyword {
 impl Keyword {
     fn parse(input: ParseStream) -> Result<(Self, Span)> {
         use Keyword::*;
-        Ok(if input.peek(kw::pure) {
+        Ok(if input.peek(kw::functional) {
+            let keyword: kw::functional = input.parse()?;
+            (Functional, keyword.span)
+        } else if input.peek(kw::pure) {
             let keyword: kw::pure = input.parse()?;
             (Pure, keyword.span)
         } else if input.peek(kw::total) {
@@ -336,6 +341,7 @@ impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Keyword::Unknown(ident) => write!(f, "{}", ident),
+            Keyword::Functional => write!(f, "functional"),
             Keyword::Pure => write!(f, "pure"),
             Keyword::Total => write!(f, "total"),
             Keyword::Deterministic => write!(f, "deterministic"),

--- a/crates/anodized-core/src/annotate/tests.rs
+++ b/crates/anodized-core/src/annotate/tests.rs
@@ -30,6 +30,85 @@ fn simple_spec() {
 }
 
 #[test]
+fn fn_qualifiers_pure_total() {
+    let spec: Spec = parse_quote! {
+        pure,
+        total,
+    };
+
+    let expected = Spec {
+        qualifiers: FnQualifiers::PURE | FnQualifiers::TOTAL,
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
+    let spec: Spec = parse_quote! {
+        deterministic,
+        effectfree,
+        infallible,
+        terminating,
+    };
+
+    let expected = Spec {
+        qualifiers: FnQualifiers::DETERMINISTIC
+            | FnQualifiers::EFFECTFREE
+            | FnQualifiers::INFALLIBLE
+            | FnQualifiers::TERMINATING,
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_pure_deterministic() {
+    let _: Spec = parse_quote! {
+        pure,
+        deterministic,
+    };
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_pure_effectfree() {
+    let _: Spec = parse_quote! {
+        pure,
+        effectfree,
+    };
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_total_infallible() {
+    let _: Spec = parse_quote! {
+        total,
+        infallible,
+    };
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_total_terminating() {
+    let _: Spec = parse_quote! {
+        total,
+        terminating,
+    };
+}
+
+#[test]
 fn all_clauses() {
     let spec: Spec = parse_quote! {
         requires: x > 0 && x.is_power_of_two(),

--- a/crates/anodized-core/src/annotate/tests.rs
+++ b/crates/anodized-core/src/annotate/tests.rs
@@ -73,6 +73,38 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
 }
 
 #[test]
+#[should_panic = "expected `,`"]
+fn fn_qualifiers_typo_missing_comma() {
+    let _: Spec = parse_quote! {
+        pure total,
+    };
+}
+
+#[test]
+#[should_panic = "qualifier `pure` does not take a value"]
+fn fn_qualifiers_typo_colon_instead_of_comma() {
+    let _: Spec = parse_quote! {
+        pure: total,
+    };
+}
+
+#[test]
+#[should_panic = "expected an expression or a pattern"]
+fn fn_qualifiers_invalid_colon() {
+    let _: Spec = parse_quote! {
+        pure:,
+    };
+}
+
+#[test]
+#[should_panic = "qualifier `pure` does not take a value"]
+fn fn_qualifiers_invalid_value_expr() {
+    let _: Spec = parse_quote! {
+        pure: x == 42,
+    };
+}
+
+#[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_pure_deterministic() {
     let _: Spec = parse_quote! {
@@ -994,4 +1026,30 @@ fn captures_pat_without_as_errors() {
         "{}",
         err
     );
+}
+
+#[test]
+fn spec_arg_can_omit_value() {
+    let spec_args: syntax::SpecArgs = parse_quote! {
+        key_1,
+        key_2: value,
+        key_3: value as expr,
+    };
+
+    let args: Vec<_> = spec_args.args.into_iter().collect();
+    let [arg_1, arg_2, arg_3] = args.as_slice() else {
+        panic!("expected 3 args");
+    };
+
+    assert!(arg_1.keyword.to_string() == "key_1");
+    assert!(arg_1.colon.is_none());
+    assert_eq!(arg_1.value, SpecArgValue::None);
+
+    assert!(arg_2.keyword.to_string() == "key_2");
+    assert!(arg_2.colon.is_some());
+    assert_eq!(arg_2.value, SpecArgValue::Expr(parse_quote!(value)));
+
+    assert!(arg_3.keyword.to_string() == "key_3");
+    assert!(arg_3.colon.is_some());
+    assert_eq!(arg_3.value, SpecArgValue::Expr(parse_quote!(value as expr)));
 }

--- a/crates/anodized-core/src/annotate/tests.rs
+++ b/crates/anodized-core/src/annotate/tests.rs
@@ -30,6 +30,24 @@ fn simple_spec() {
 }
 
 #[test]
+fn fn_qualifiers_functional() {
+    let spec: Spec = parse_quote! {
+        functional
+    };
+
+    let expected = Spec {
+        qualifiers: FnQualifiers::FUNCTIONAL,
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec, &expected);
+}
+
+#[test]
 fn fn_qualifiers_pure_total() {
     let spec: Spec = parse_quote! {
         pure,
@@ -97,10 +115,28 @@ fn fn_qualifiers_invalid_colon() {
 }
 
 #[test]
-#[should_panic = "qualifier `pure` does not take a value"]
+#[should_panic = "qualifier `functional` does not take a value"]
 fn fn_qualifiers_invalid_value_expr() {
     let _: Spec = parse_quote! {
-        pure: x == 42,
+        functional: x == 42,
+    };
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_functional_pure() {
+    let _: Spec = parse_quote! {
+        functional,
+        pure,
+    };
+}
+
+#[test]
+#[should_panic = "this qualifier is redundant; remove it"]
+fn fn_qualifiers_functional_total() {
+    let _: Spec = parse_quote! {
+        functional,
+        total,
     };
 }
 

--- a/crates/anodized-core/src/annotate/tests.rs
+++ b/crates/anodized-core/src/annotate/tests.rs
@@ -12,6 +12,7 @@ fn simple_spec() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![PreCondition {
             closure: parse_quote! { || is_valid(x) },
             cfg: None,
@@ -38,6 +39,7 @@ fn all_clauses() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![PreCondition {
             closure: parse_quote! { || x > 0 && x.is_power_of_two() },
             cfg: None,
@@ -110,6 +112,7 @@ fn array_of_conditions() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![
             PreCondition {
                 closure: parse_quote! { || x >= 0 },
@@ -145,6 +148,7 @@ fn ensures_with_explicit_closure() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -168,6 +172,7 @@ fn multiple_clauses_of_same_flavor() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![
             PreCondition {
                 closure: parse_quote! { || x > 0 || x < -10 },
@@ -212,6 +217,7 @@ fn mixed_single_and_array_clauses() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![
             PreCondition {
                 closure: parse_quote! { || x == 0 },
@@ -258,6 +264,7 @@ fn cfg_attributes() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![PreCondition {
             closure: parse_quote! { || x > 0 && is_mode() },
             cfg: Some(parse_quote! { test }),
@@ -311,6 +318,7 @@ fn macro_in_condition() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![PreCondition {
             closure: parse_quote! { || matches!(self.state, State::Idle) },
             cfg: None,
@@ -341,6 +349,7 @@ fn binds_pattern() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -372,6 +381,7 @@ fn multiple_conditions() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![
             PreCondition {
                 closure: parse_quote! { || self.initialized },
@@ -409,6 +419,7 @@ fn rename_return_value() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -436,6 +447,7 @@ fn captures_simple_identifier() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -460,6 +472,7 @@ fn captures_identifier_with_alias() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -492,6 +505,7 @@ fn captures_array() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -539,6 +553,7 @@ fn captures_with_all_clauses() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![PreCondition {
             closure: parse_quote! { || x > 0 },
             cfg: None,
@@ -578,6 +593,7 @@ fn captures_array_expression() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -672,6 +688,7 @@ fn captures_edge_case_cast_expr() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -696,6 +713,7 @@ fn captures_edge_case_array_of_cast_exprs() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -726,6 +744,7 @@ fn captures_edge_case_list_of_cast_exprs() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -756,6 +775,7 @@ fn captures_pattern_matches_slices() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -776,6 +796,7 @@ fn captures_pattern_matches_tuples() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -796,6 +817,7 @@ fn captures_pattern_matches_structs() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -816,6 +838,7 @@ fn captures_pattern_matches_nested() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -836,6 +859,7 @@ fn captures_pattern_with_binding_modifier() {
     };
 
     let expected = Spec {
+        qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -82,7 +82,7 @@ impl Config {
         );
 
         let message = format!(
-            "the qualifiers on the impl `{}::{fn_ident}` must be stronger than the qualifiers on the trait `{}::{fn_ident}`",
+            "the qualifiers on the impl `{}::{fn_ident}` cannot be weaker than the qualifiers on the trait `{}::{fn_ident}`",
             impl_type.to_token_stream(),
             trait_path.to_token_stream(),
         );

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Block, Expr, Ident, Pat, PatIdent, ReturnType, Signature, Stmt,
+    Attribute, Block, Expr, Ident, Pat, PatIdent, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
     parse_quote,
 };
@@ -54,15 +54,46 @@ impl Config {
 
     pub fn build_qualifier_const_item<SomeConstItem: Parse>(
         attrs: &[Attribute],
+        prefix: &str,
         qualifiers: FnQualifiers,
-        ident: &Ident,
+        fn_ident: &Ident,
     ) -> SomeConstItem {
         let qualifier_bits = qualifiers.bits();
-        let name: Ident =
-            syn::Ident::new(&format!("__anodized_fn_qualifiers_{}", ident), ident.span());
+        let name: Ident = syn::Ident::new(&format!("{}_{}", prefix, fn_ident), fn_ident.span());
         parse_quote! {
             #(#attrs)*
             const #name: u32 = #qualifier_bits;
+        }
+    }
+
+    pub fn build_qualifier_check_stmt(
+        fn_ident: &Ident,
+        impl_type: &Type,
+        trait_path: &Path,
+    ) -> Stmt {
+        let impl_const_name = Ident::new(
+            &format!("__anodized_fn_qualifiers_{}", fn_ident),
+            fn_ident.span(),
+        );
+
+        let trait_const_name = Ident::new(
+            &format!("__anodized_fn_qualifiers_trait_{}", fn_ident),
+            fn_ident.span(),
+        );
+
+        let message = format!(
+            "the qualifiers on the impl `{}::{fn_ident}` must be stronger than the qualifiers on the trait `{}::{fn_ident}`",
+            impl_type.to_token_stream(),
+            trait_path.to_token_stream(),
+        );
+
+        parse_quote! {
+            const {
+                assert!(
+                    Self::#impl_const_name == Self::#trait_const_name | Self::#impl_const_name,
+                    #message,
+                );
+            };
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns/mod.rs
+++ b/crates/anodized-core/src/instrument/fns/mod.rs
@@ -4,12 +4,15 @@ mod tests;
 use crate::{
     Capture, PostCondition, PreCondition, Spec,
     instrument::{Config, build_assert, build_eprint},
+    qualifiers::FnQualifiers,
 };
 
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Block, Expr, Ident, Pat, PatIdent, ReturnType, Signature, Stmt, parse::Result, parse_quote,
+    Attribute, Block, Expr, Ident, Pat, PatIdent, ReturnType, Signature, Stmt,
+    parse::{Parse, Result},
+    parse_quote,
 };
 
 impl Config {
@@ -46,6 +49,20 @@ impl Config {
             inputs: sig.inputs.clone(),
             variadic: sig.variadic.clone(),
             output: syn::ReturnType::Default,
+        }
+    }
+
+    pub fn build_qualifier_const_item<SomeConstItem: Parse>(
+        attrs: &[Attribute],
+        qualifiers: FnQualifiers,
+        ident: &Ident,
+    ) -> SomeConstItem {
+        let qualifier_bits = qualifiers.bits();
+        let name: Ident =
+            syn::Ident::new(&format!("__anodized_fn_qualifiers_{}", ident), ident.span());
+        parse_quote! {
+            #(#attrs)*
+            const #name: u32 = #qualifier_bits;
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns/tests.rs
+++ b/crates/anodized-core/src/instrument/fns/tests.rs
@@ -31,7 +31,12 @@ fn embed_spec_item_fn() {
         }
     };
 
+    let qualifier_bits = FnQualifiers::empty().bits();
     let expected: TokenStream = parse_quote! {
+        #[doc(hidden)]
+        #[allow(warnings)]
+        const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -30,8 +30,12 @@ impl Config {
             ];
 
             // Embed `spec` elements as `__anodized_fn_*` items.
-            let spec_qualifiers_const: ItemConst =
-                Self::build_qualifier_const_item(&attrs, spec.qualifiers, &item_fn.sig.ident);
+            let spec_qualifiers_const: ItemConst = Self::build_qualifier_const_item(
+                &attrs,
+                "__anodized_fn_qualifiers",
+                spec.qualifiers,
+                &item_fn.sig.ident,
+            );
             let spec_requires_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,

--- a/crates/anodized-core/src/instrument/mod.rs
+++ b/crates/anodized-core/src/instrument/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Attribute, ItemFn, ItemImpl, ItemTrait, Meta, Result, parse_quote};
+use syn::{Attribute, ItemConst, ItemFn, ItemImpl, ItemTrait, Meta, Result, parse_quote};
 
 use crate::{DataSpec, Spec};
 
@@ -29,7 +29,9 @@ impl Config {
                 parse_quote!(#[allow(warnings)]),
             ];
 
-            // Embed `spec` elements as `__anodized_fn_*` functions.
+            // Embed `spec` elements as `__anodized_fn_*` items.
+            let spec_qualifiers_const: ItemConst =
+                Self::build_qualifier_const_item(&attrs, spec.qualifiers, &item_fn.sig.ident);
             let spec_requires_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
@@ -53,6 +55,7 @@ impl Config {
                 )?),
             };
 
+            spec_qualifiers_const.to_tokens(&mut tokens);
             spec_requires_fn.to_tokens(&mut tokens);
             spec_maintains_fn.to_tokens(&mut tokens);
             spec_ensures_fn.to_tokens(&mut tokens);

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -188,10 +188,9 @@ impl Config {
                     let (spec_attr, func_attrs) = find_spec_attr(func.attrs)?;
                     func.attrs = func_attrs;
 
-                    let original_ident = &func.sig.ident;
-                    if original_ident.to_string().starts_with("__anodized_") {
+                    if func.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(syn::Error::new_spanned(
-                            original_ident,
+                            func.sig.ident,
                             r#"An item with the `__anodized_` prefix is internal. Do not implement it directly.
 Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation."#,
                         ));
@@ -247,16 +246,6 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         new_items.push(ImplItem::Fn(spec_ensures_fn));
                     }
 
-                    if self.emit_anything() {
-                        func.sig.ident = mangle_ident(original_ident);
-
-                        // Add a default `#[inline]` attribute unless one is already there.
-                        // The caller can supress this with `#[inline(never)]`
-                        if !has_inline_attr(&func.attrs) {
-                            func.attrs.push(parse_quote!(#[inline]));
-                        }
-                    }
-
                     self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
                     if self.embed_spec {
@@ -271,6 +260,15 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         );
                     }
 
+                    if self.emit_anything() {
+                        func.sig.ident = mangle_ident(&func.sig.ident);
+
+                        // Add a default `#[inline]` attribute unless one is already there.
+                        // The caller can supress this with `#[inline(never)]`
+                        if !has_inline_attr(&func.attrs) {
+                            func.attrs.push(parse_quote!(#[inline]));
+                        }
+                    }
                     new_items.push(ImplItem::Fn(func));
                 }
                 ImplItem::Const(mut const_item) => {

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -56,7 +56,12 @@ impl Config {
                             parse_quote!(#[allow(warnings)]),
                         ];
 
-                        // Embed `spec` elements as `__anodized_fn_*` functions.
+                        // Embed `spec` elements as `__anodized_fn_*` items.
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
                         let spec_requires_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
                             sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
@@ -80,6 +85,7 @@ impl Config {
                             semi_token: None,
                         };
 
+                        new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
                         new_trait_items.push(TraitItem::Fn(spec_requires_fn));
                         new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -59,6 +59,13 @@ impl Config {
                         // Embed `spec` elements as `__anodized_fn_*` items.
                         let spec_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
+                            "__anodized_fn_qualifiers",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
+                        let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers_trait",
                             fn_spec.qualifiers,
                             &func.sig.ident,
                         );
@@ -86,6 +93,7 @@ impl Config {
                         };
 
                         new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
+                        new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
                         new_trait_items.push(TraitItem::Fn(spec_requires_fn));
                         new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
@@ -160,7 +168,7 @@ impl Config {
         spec: DataSpec,
         mut the_impl: syn::ItemImpl,
     ) -> syn::Result<syn::ItemImpl> {
-        let Some((trait_bang, ref _trait_path, _trait_for)) = the_impl.trait_ else {
+        let Some((trait_bang, ref trait_path, _trait_for)) = the_impl.trait_ else {
             return Err(make_item_error(&the_impl, "inherent impl"));
         };
 
@@ -200,7 +208,13 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                             parse_quote!(#[allow(warnings)]),
                         ];
 
-                        // Embed `spec` elements as `__anodized_fn_*` functions.
+                        // Embed `spec` elements as `__anodized_fn_*` items.
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
                         let spec_requires_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
                             sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
@@ -227,6 +241,17 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                             defaultness: None,
                         };
 
+                        // Add a compile-time check to the body.
+                        func.block.stmts.insert(
+                            0,
+                            Self::build_qualifier_check_stmt(
+                                &func.sig.ident,
+                                &the_impl.self_ty,
+                                trait_path,
+                            ),
+                        );
+
+                        new_items.push(ImplItem::Const(spec_qualifiers_const));
                         new_items.push(ImplItem::Fn(spec_requires_fn));
                         new_items.push(ImplItem::Fn(spec_maintains_fn));
                         new_items.push(ImplItem::Fn(spec_ensures_fn));

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -57,15 +57,15 @@ impl Config {
                         ];
 
                         // Embed `spec` elements as `__anodized_fn_*` items.
-                        let spec_qualifiers_const = Self::build_qualifier_const_item(
-                            &attrs,
-                            "__anodized_fn_qualifiers",
-                            fn_spec.qualifiers,
-                            &func.sig.ident,
-                        );
                         let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
                             "__anodized_fn_qualifiers_trait",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers",
                             fn_spec.qualifiers,
                             &func.sig.ident,
                         );
@@ -92,8 +92,8 @@ impl Config {
                             semi_token: None,
                         };
 
-                        new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
                         new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
+                        new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
                         new_trait_items.push(TraitItem::Fn(spec_requires_fn));
                         new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));

--- a/crates/anodized-core/src/instrument/traits/mod.rs
+++ b/crates/anodized-core/src/instrument/traits/mod.rs
@@ -241,16 +241,6 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                             defaultness: None,
                         };
 
-                        // Add a compile-time check to the body.
-                        func.block.stmts.insert(
-                            0,
-                            Self::build_qualifier_check_stmt(
-                                &func.sig.ident,
-                                &the_impl.self_ty,
-                                trait_path,
-                            ),
-                        );
-
                         new_items.push(ImplItem::Const(spec_qualifiers_const));
                         new_items.push(ImplItem::Fn(spec_requires_fn));
                         new_items.push(ImplItem::Fn(spec_maintains_fn));
@@ -268,6 +258,19 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     }
 
                     self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
+
+                    if self.embed_spec {
+                        // Add a compile-time check to the body.
+                        func.block.stmts.insert(
+                            0,
+                            Self::build_qualifier_check_stmt(
+                                &func.sig.ident,
+                                &the_impl.self_ty,
+                                trait_path,
+                            ),
+                        );
+                    }
+
                     new_items.push(ImplItem::Fn(func));
                 }
                 ImplItem::Const(mut const_item) => {

--- a/crates/anodized-core/src/instrument/traits/tests.rs
+++ b/crates/anodized-core/src/instrument/traits/tests.rs
@@ -30,6 +30,10 @@ fn embed_spec_item_trait() {
 
             #[doc(hidden)]
             #[allow(warnings)]
+            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
                 let _ = | | COND_1;
             }
@@ -76,8 +80,13 @@ fn embed_spec_item_impl_trait() {
         }
     };
 
+    let qualifier_bits = FnQualifiers::empty().bits();
     let expected: TokenStream = parse_quote! {
         impl TRAIT for IMPL_TYPE {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
@@ -98,6 +107,14 @@ fn embed_spec_item_impl_trait() {
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                const {
+                    assert!(
+                        Self::__anodized_fn_qualifiers_FUNC ==
+                            Self::__anodized_fn_qualifiers_trait_FUNC |
+                            Self::__anodized_fn_qualifiers_FUNC,
+                        "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
+                    );
+                };
                 BODY
             }
         }

--- a/crates/anodized-core/src/instrument/traits/tests.rs
+++ b/crates/anodized-core/src/instrument/traits/tests.rs
@@ -26,11 +26,11 @@ fn embed_spec_item_trait() {
         trait TRAIT {
             #[doc(hidden)]
             #[allow(warnings)]
-            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
 
             #[doc(hidden)]
             #[allow(warnings)]
-            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
 
             #[doc(hidden)]
             #[allow(warnings)]

--- a/crates/anodized-core/src/instrument/traits/tests.rs
+++ b/crates/anodized-core/src/instrument/traits/tests.rs
@@ -1,4 +1,4 @@
-use crate::test_util::assert_tokens_eq;
+use crate::{qualifiers::FnQualifiers, test_util::assert_tokens_eq};
 
 use super::*;
 use proc_macro2::TokenStream;
@@ -21,8 +21,13 @@ fn embed_spec_item_trait() {
         }
     };
 
+    let qualifier_bits = FnQualifiers::empty().bits();
     let expected: TokenStream = parse_quote! {
         trait TRAIT {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -45,7 +45,8 @@ impl Spec {
 
     /// Returns `true` if the spec is empty (specifies nothing), otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
-        self.requires.is_empty()
+        self.qualifiers.is_empty()
+            && self.requires.is_empty()
             && self.maintains.is_empty()
             && self.ensures.is_empty()
             && self.captures.is_empty()

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -3,8 +3,11 @@
 use proc_macro2::Span;
 use syn::{Error, Expr, ExprClosure, Meta, Pat};
 
+use crate::qualifiers::FnQualifiers;
+
 pub mod annotate;
 pub mod instrument;
+pub mod qualifiers;
 
 #[cfg(test)]
 mod test_util;
@@ -13,6 +16,8 @@ mod test_util;
 #[derive(Debug)]
 // TODO: Rename to `FnSpec` to reduce ambiguity.
 pub struct Spec {
+    /// Qualifiers that constrain the behavior of the computation.
+    pub qualifiers: FnQualifiers,
     /// Preconditions: conditions that must hold when the function is called.
     pub requires: Vec<PreCondition>,
     /// Invariants: conditions that must hold both when the function is called and when it returns.
@@ -29,6 +34,7 @@ impl Spec {
     /// Empty spec that contains no elements.
     pub fn empty() -> Self {
         Self {
+            qualifiers: FnQualifiers::empty(),
             requires: vec![],
             maintains: vec![],
             captures: vec![],

--- a/crates/anodized-core/src/qualifiers.rs
+++ b/crates/anodized-core/src/qualifiers.rs
@@ -21,5 +21,8 @@ bitflags! {
 
         /// A total `fn` is both infallible and terminating.
         const TOTAL = Self::INFALLIBLE.bits() | Self::TERMINATING.bits();
+
+        /// A functional `fn` is both pure and total.
+        const FUNCTIONAL = Self::PURE.bits() | Self::TOTAL.bits();
     }
 }

--- a/crates/anodized-core/src/qualifiers.rs
+++ b/crates/anodized-core/src/qualifiers.rs
@@ -1,0 +1,25 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// A combination of `fn` qualifiers.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct FnQualifiers: u32 {
+        /// A deterministic `fn`'s return value only depends on its arguments.
+        const DETERMINISTIC = 1 << 0;
+
+        /// An effectless `fn` has no side effects.
+        const EFFECTLESS = 1 << 1;
+
+        /// An infallible `fn` does not panic or abort.
+        const INFALLIBLE = 1 << 2;
+
+        /// A terminating `fn` does not run forever.
+        const TERMINATING = 1 << 3;
+
+        /// A pure `fn` is both deterministic and effectless.
+        const PURE = Self::DETERMINISTIC.bits() | Self::EFFECTLESS.bits();
+
+        /// A total `fn` is both infallible and terminating.
+        const TOTAL = Self::INFALLIBLE.bits() | Self::TERMINATING.bits();
+    }
+}

--- a/crates/anodized-core/src/qualifiers.rs
+++ b/crates/anodized-core/src/qualifiers.rs
@@ -4,7 +4,7 @@ bitflags! {
     /// A combination of `fn` qualifiers.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct FnQualifiers: u32 {
-        /// A deterministic `fn`'s return value only depends on its arguments.
+        /// A deterministic `fn`'s return value depends only on its arguments.
         const DETERMINISTIC = 1 << 0;
 
         /// An effectfree `fn` has no side effects.

--- a/crates/anodized-core/src/qualifiers.rs
+++ b/crates/anodized-core/src/qualifiers.rs
@@ -7,8 +7,8 @@ bitflags! {
         /// A deterministic `fn`'s return value only depends on its arguments.
         const DETERMINISTIC = 1 << 0;
 
-        /// An effectless `fn` has no side effects.
-        const EFFECTLESS = 1 << 1;
+        /// An effectfree `fn` has no side effects.
+        const EFFECTFREE = 1 << 1;
 
         /// An infallible `fn` does not panic or abort.
         const INFALLIBLE = 1 << 2;
@@ -16,8 +16,8 @@ bitflags! {
         /// A terminating `fn` does not run forever.
         const TERMINATING = 1 << 3;
 
-        /// A pure `fn` is both deterministic and effectless.
-        const PURE = Self::DETERMINISTIC.bits() | Self::EFFECTLESS.bits();
+        /// A pure `fn` is both deterministic and effectfree.
+        const PURE = Self::DETERMINISTIC.bits() | Self::EFFECTFREE.bits();
 
         /// A total `fn` is both infallible and terminating.
         const TOTAL = Self::INFALLIBLE.bits() | Self::TERMINATING.bits();

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -10,6 +10,7 @@ pub fn assert_tokens_eq(left: &impl ToTokens, right: &impl ToTokens) {
 pub fn assert_spec_eq(left: &Spec, right: &Spec) {
     // Destructure to ensure we handle all fields - compilation will fail if fields are added
     let Spec {
+        qualifiers: left_qualifiers,
         requires: left_requires,
         maintains: left_maintains,
         captures: left_captures,
@@ -18,12 +19,18 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
     } = left;
 
     let Spec {
+        qualifiers: right_qualifiers,
         requires: right_requires,
         maintains: right_maintains,
         captures: right_captures,
         ensures: right_ensures,
         span: _,
     } = right;
+
+    assert_eq!(
+        left_qualifiers, right_qualifiers,
+        "qualifiers do not match: {left_qualifiers:?} vs {right_qualifiers:?}"
+    );
 
     assert_slice_eq(
         left_requires,

--- a/crates/anodized-fmt/src/formatter/mod.rs
+++ b/crates/anodized-fmt/src/formatter/mod.rs
@@ -125,6 +125,7 @@ impl<'a> Formatter<'a> {
 
         // Format the value based on what it contains
         let value_str = match &arg.value {
+            SpecArgValue::None => String::new(),
             SpecArgValue::Expr(expr) => {
                 // Special handling for arrays to format with proper indentation
                 if let syn::Expr::Array(array) = expr {
@@ -138,7 +139,11 @@ impl<'a> Formatter<'a> {
             SpecArgValue::Captures(captures) => self.format_captures(captures),
         };
 
-        self.write(&format!("{}: {},", arg.keyword, value_str));
+        if value_str.is_empty() {
+            self.write(&format!("{},", arg.keyword));
+        } else {
+            self.write(&format!("{}: {},", arg.keyword, value_str));
+        }
     }
 
     /// Format a group of captures.

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -1,6 +1,7 @@
 use anodized::spec;
 
 #[spec(
+    functional,
     requires: divisor != 0,
     ensures: *output < dividend,
 )]

--- a/crates/anodized/tests/build_fail.rs
+++ b/crates/anodized/tests/build_fail.rs
@@ -1,9 +1,16 @@
 #[test]
 fn qualifier_narrowing_fails_to_compile() {
-    let status = std::process::Command::new("cargo")
+    let output = std::process::Command::new("cargo")
         .arg("build")
         .current_dir("tests/build_fail/trait_narrowing")
-        .status()
+        .output()
         .expect("failed to run cargo");
-    assert!(!status.success(), "expected compilation to fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "expected compilation to fail");
+    assert!(
+        stderr.contains("the qualifiers on the impl `WeakerImplQualifiers < T >::find_min` cannot be weaker than the qualifiers on the trait `MinFinder < T >::find_min`"),
+        "expected specific error message, got:\n{stderr}"
+    );
 }

--- a/crates/anodized/tests/build_fail.rs
+++ b/crates/anodized/tests/build_fail.rs
@@ -1,0 +1,9 @@
+#[test]
+fn qualifier_narrowing_fails_to_compile() {
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .current_dir("tests/build_fail/trait_narrowing")
+        .status()
+        .expect("failed to run cargo");
+    assert!(!status.success(), "expected compilation to fail");
+}

--- a/crates/anodized/tests/build_fail/trait_narrowing/Cargo.toml
+++ b/crates/anodized/tests/build_fail/trait_narrowing/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = []
+
+[package]
+name = "test_trait_narrowing"
+publish = false
+edition = "2024"
+
+[[bin]]
+name = "main"
+path = "main.rs"
+
+[dependencies]
+anodized = { path = "../../../" }

--- a/crates/anodized/tests/build_fail/trait_narrowing/main.rs
+++ b/crates/anodized/tests/build_fail/trait_narrowing/main.rs
@@ -1,0 +1,53 @@
+use anodized::spec;
+
+/////////////////////////
+// Test static checks. //
+/////////////////////////
+
+#[spec]
+trait MinFinder<T: Copy + PartialOrd> {
+    #[spec(
+        total,
+        requires: [
+            input.len() > 0,
+        ],
+        ensures: [
+            input.iter().all(|item| output <= item),
+            input.iter().any(|item| output == item) || input.len() == 0,
+        ],
+    )]
+    fn find_min(input: &[T]) -> T;
+}
+
+struct WeakerImplQualifiers<T>(std::marker::PhantomData<T>);
+
+#[spec]
+impl<T: Copy + PartialOrd> MinFinder<T> for WeakerImplQualifiers<T> {
+    #[spec(
+        // INVALID - Weaker than trait qualifiers: may panic or run forever.
+        deterministic,
+        requires: [],
+        ensures: [
+            input.iter().all(|item| output <= item),
+            input.iter().any(|item| output == item),
+        ],
+    )]
+    fn find_min(input: &[T]) -> T {
+        let _: u32 = const { Self::__anodized_fn_qualifiers_find_min };
+        let _ = input;
+        // Panic on empty input.
+        let mut min = input[0];
+        for item in input.iter().copied() {
+            if item < min {
+                min = item;
+            }
+        }
+        min
+    }
+}
+
+fn main() {
+    let seq = [5, -42, 3];
+    // NOTE: The `fn` must be used for the compile-time check to fire.
+    assert_eq!(WeakerImplQualifiers::<i32>::find_min(&seq), -42);
+}

--- a/crates/anodized/tests/trait_narrowing.rs
+++ b/crates/anodized/tests/trait_narrowing.rs
@@ -91,7 +91,7 @@ impl MinFinder<u32> for WeakerImplPost {
 #[test]
 fn runtime_allows_valid_narrowing() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
-    let seq = [5.0, -42.0, 3.14];
+    let seq = [5.0, -42.0, std::f32::consts::PI];
     assert_eq!(ValidNarrowing::find_min(&seq), -42.0);
 }
 

--- a/crates/anodized/tests/trait_narrowing.rs
+++ b/crates/anodized/tests/trait_narrowing.rs
@@ -5,8 +5,9 @@ use anodized::spec;
 //////////////////////////
 
 #[spec]
-trait MinFinder {
+trait MinFinder<T: PartialOrd> {
     #[spec(
+        total,
         requires: [
             input.len() > 0,
         ],
@@ -15,14 +16,16 @@ trait MinFinder {
             input.iter().any(|item| output == item) || input.len() == 0,
         ],
     )]
-    fn find_min(input: &[f32]) -> f32;
+    fn find_min(input: &[T]) -> T;
 }
 
 pub struct ValidNarrowing;
 
 #[spec]
-impl MinFinder for ValidNarrowing {
+impl MinFinder<f32> for ValidNarrowing {
     #[spec(
+        // Stronger than trait qualifiers: is also `pure` (`deterministic` and `effectfree`).
+        functional,
         // Weaker than trait precondition: allows `input` to be empty.
         requires: [],
         // Stronger than trait postcondition: clarifies what to output when `input` is empty.
@@ -47,8 +50,9 @@ impl MinFinder for ValidNarrowing {
 pub struct StrongerImplPre;
 
 #[spec]
-impl MinFinder for StrongerImplPre {
+impl MinFinder<i32> for StrongerImplPre {
     #[spec(
+        total,
         // INVALID - Stronger than trait precondition: requires sorted `input`.
         requires: [
             input.len() > 0,
@@ -59,7 +63,7 @@ impl MinFinder for StrongerImplPre {
             input.iter().any(|item| output == item) || input.len() == 0,
         ],
     )]
-    fn find_min(input: &[f32]) -> f32 {
+    fn find_min(input: &[i32]) -> i32 {
         input[0]
     }
 }
@@ -67,8 +71,9 @@ impl MinFinder for StrongerImplPre {
 pub struct WeakerImplPost;
 
 #[spec]
-impl MinFinder for WeakerImplPost {
+impl MinFinder<u32> for WeakerImplPost {
     #[spec(
+        total,
         requires: [
             input.len() > 0,
         ],
@@ -77,18 +82,17 @@ impl MinFinder for WeakerImplPost {
             input.iter().all(|item| output <= item),
         ],
     )]
-    fn find_min(input: &[f32]) -> f32 {
+    fn find_min(input: &[u32]) -> u32 {
         let _ = input;
-        f32::NEG_INFINITY
+        0
     }
 }
-
-const TEST_INPUT: [f32; 3] = [5.0, -42.0, std::f32::consts::PI];
 
 #[test]
 fn runtime_allows_valid_narrowing() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
-    assert_eq!(ValidNarrowing::find_min(&TEST_INPUT), -42.0);
+    let seq = [5.0, -42.0, 3.14];
+    assert_eq!(ValidNarrowing::find_min(&seq), -42.0);
 }
 
 #[cfg(anodized_panic)]
@@ -96,7 +100,8 @@ fn runtime_allows_valid_narrowing() {
 #[should_panic(expected = "Precondition failed: input.is_sorted()")]
 fn runtime_rejects_stronger_impl_precondition() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
-    assert_eq!(StrongerImplPre::find_min(&TEST_INPUT), -42.0);
+    let seq = [5, -42, 3];
+    assert_eq!(StrongerImplPre::find_min(&seq), -42);
 }
 
 #[cfg(anodized_panic)]
@@ -105,7 +110,8 @@ fn runtime_rejects_stronger_impl_precondition() {
 Postcondition failed: | output | input.iter().any(| item | output == item) || input.len() == 0")]
 fn runtime_rejects_weaker_impl_postcondition() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
-    assert_eq!(WeakerImplPost::find_min(&TEST_INPUT), -42.0);
+    let seq = [5, 42, 3];
+    assert_eq!(WeakerImplPost::find_min(&seq), 3);
 }
 
 //////////////////////////////////////////////////////


### PR DESCRIPTION
- Refactor `SpecArgs` to accept key-only args, i.e. no value.
- Introduce new keywords: `functional`, `pure`, `total`, `deterministic`, `effectfree`, `infallible`, `terminating`.
- Add `FnQualifiers` to represent `fn` qualifiers internally.
- Extend instrumentation to embed qualifier information.
- Implement simple compile-time check to enforce `trait` spec narrowing of qualifiers.
- Add tests and new `build_fail` strategy to work around a limitation in `trybuild`.