### PR TITLE
test: CI for test-util and fuzz targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,44 @@ jobs:
 
       - name: Integration test anodized-logic
         run: cargo test -p anodized-logic --tests --no-fail-fast
+
+  test-test-util:
+    name: Lint test-util
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Lint test-util
+        run: cargo clippy -p test-util --all-targets -- -D warnings
+
+      - name: Test test-util
+        run: cargo test -p test-util --no-fail-fast
+
+  test-fuzz:
+    name: Lint and smoke-test fuzz targets
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Lint fuzz targets
+        run: cargo clippy -p fuzz --all-targets -- -D warnings
+
+      - name: Smoke test fuzz target (fmt_ws_invariant)
+        run: cd fuzz && cargo +nightly fuzz run --no-cfg-fuzzing fmt_ws_invariant -- -runs=1000 -max_total_time=30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,4 @@ jobs:
         run: cargo clippy -p fuzz --all-targets -- -D warnings
 
       - name: Smoke test fuzz target (fmt_ws_invariant)
-        run: cd fuzz && cargo +nightly fuzz run --no-cfg-fuzzing fmt_ws_invariant -- -runs=1000 -max_total_time=30
+        run: cargo +nightly fuzz build

--- a/crates/anodized-core/src/annotate/mod.rs
+++ b/crates/anodized-core/src/annotate/mod.rs
@@ -126,7 +126,7 @@ impl Parse for Spec {
                 Keyword::Decreases => {
                     errors.add(Error::new(
                         arg.keyword_span,
-                        format!("`{}` parameter is not supported here", &arg.keyword),
+                        format!("`{}` parameter is not supported here", arg.keyword),
                     ));
                 }
             }
@@ -180,7 +180,7 @@ impl Parse for DataSpec {
                 _ => {
                     errors.add(Error::new(
                         arg.keyword_span,
-                        format!("`{}` parameter is not supported here", &arg.keyword),
+                        format!("`{}` parameter is not supported here", arg.keyword),
                     ));
                 }
             }
@@ -234,7 +234,7 @@ impl Parse for LoopSpec {
                 _ => {
                     errors.add(Error::new(
                         arg.keyword_span,
-                        format!("`{}` parameter is not supported here", &arg.keyword),
+                        format!("`{}` parameter is not supported here", arg.keyword),
                     ));
                 }
             }

--- a/crates/test-util/src/fmt.rs
+++ b/crates/test-util/src/fmt.rs
@@ -83,14 +83,8 @@ impl Template {
 }
 
 /// A non-empty sequence of whitespace characters.
-#[derive(Debug, Clone, Arbitrary)]
-pub struct Whitespace(Vec<WsChar>, WsChar);
-
-impl Default for Whitespace {
-    fn default() -> Self {
-        Whitespace(vec![], WsChar::Space)
-    }
-}
+#[derive(Debug, Clone, Default, Arbitrary)]
+pub struct Whitespace(Vec<WsChar>);
 
 impl Whitespace {
     fn to_string(self: Whitespace) -> String {
@@ -98,11 +92,11 @@ impl Whitespace {
     }
 
     fn to_non_empty_string(self: Whitespace) -> String {
-        self.0
-            .into_iter()
-            .chain(std::iter::once(self.1))
-            .map(char::from)
-            .collect()
+        if !self.0.is_empty() {
+            self.to_string()
+        } else {
+            " ".into()
+        }
     }
 }
 
@@ -147,12 +141,12 @@ mod tests {
         let template = Template::new().fixed("x").z().fixed("=").p().fixed("1");
 
         let variation = Variation(vec![
-            Whitespace(vec![WsChar::Space], WsChar::Tab), // for z() - only vec is used
-            Whitespace(vec![WsChar::Tab, WsChar::Newline], WsChar::Space), // for p() - vec + second
+            Whitespace(vec![WsChar::Tab, WsChar::Newline]), // for z()
+            Whitespace(vec![]),                             // for p()
         ]);
 
         let output = template.generate(variation);
-        assert_eq!(output, "x =\t\n 1");
+        assert_eq!(output, "x\t\n= 1");
     }
 
     #[test]
@@ -166,16 +160,13 @@ mod tests {
 
     #[test]
     fn whitespace_to_string_methods() {
-        // to_string() uses only the Vec, omitting the second WsChar
-        let ws1 = Whitespace(vec![WsChar::Tab, WsChar::Space], WsChar::Newline);
+        let ws1 = Whitespace(vec![WsChar::Tab, WsChar::Space]);
         assert_eq!(ws1.to_string(), "\t ");
 
-        // to_non_empty_string() uses Vec + second WsChar
-        let ws2 = Whitespace(vec![WsChar::Space], WsChar::Tab);
-        assert_eq!(ws2.to_non_empty_string(), " \t");
+        let ws2 = Whitespace(vec![]);
+        assert_eq!(ws2.to_non_empty_string(), " ");
 
-        // Empty vec: to_string() is empty, to_non_empty_string() uses second WsChar
-        let ws3 = Whitespace(vec![], WsChar::Newline);
+        let ws3 = Whitespace(vec![WsChar::Newline]);
         assert_eq!(ws3.clone().to_string(), "");
         assert_eq!(ws3.to_non_empty_string(), "\n");
     }

--- a/crates/test-util/src/fmt.rs
+++ b/crates/test-util/src/fmt.rs
@@ -161,13 +161,15 @@ mod tests {
     #[test]
     fn whitespace_to_string_methods() {
         let ws1 = Whitespace(vec![WsChar::Tab, WsChar::Space]);
-        assert_eq!(ws1.to_string(), "\t ");
+        assert_eq!(ws1.clone().to_string(), "\t ");
+        assert_eq!(ws1.to_non_empty_string(), "\t ");
 
         let ws2 = Whitespace(vec![]);
+        assert_eq!(ws2.clone().to_string(), "");
         assert_eq!(ws2.to_non_empty_string(), " ");
 
         let ws3 = Whitespace(vec![WsChar::Newline]);
-        assert_eq!(ws3.clone().to_string(), "");
+        assert_eq!(ws3.clone().to_string(), "\n");
         assert_eq!(ws3.to_non_empty_string(), "\n");
     }
 }

--- a/crates/test-util/src/fmt.rs
+++ b/crates/test-util/src/fmt.rs
@@ -124,3 +124,59 @@ impl From<WsChar> for char {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_variation_produces_minimal_whitespace() {
+        let template = Template::new()
+            .fixed("fn")
+            .z() // zero-or-more -> empty
+            .fixed("foo")
+            .p() // one-or-more -> single space
+            .fixed("()");
+
+        let output = template.generate(Variation::default());
+        assert_eq!(output, "fnfoo ()");
+    }
+
+    #[test]
+    fn custom_variation_uses_provided_whitespace() {
+        let template = Template::new().fixed("x").z().fixed("=").p().fixed("1");
+
+        let variation = Variation(vec![
+            Whitespace(vec![WsChar::Space], WsChar::Tab), // for z() - only vec is used
+            Whitespace(vec![WsChar::Tab, WsChar::Newline], WsChar::Space), // for p() - vec + second
+        ]);
+
+        let output = template.generate(variation);
+        assert_eq!(output, "x =\t\n 1");
+    }
+
+    #[test]
+    fn tokens_splits_on_whitespace() {
+        let template = Template::new().tokens("a b  c");
+        let output = template.generate(Variation::default());
+        // Should be: "a" + Z + "b" + Z + "c"
+        // With default variation, Z becomes empty
+        assert_eq!(output, "abc");
+    }
+
+    #[test]
+    fn whitespace_to_string_methods() {
+        // to_string() uses only the Vec, omitting the second WsChar
+        let ws1 = Whitespace(vec![WsChar::Tab, WsChar::Space], WsChar::Newline);
+        assert_eq!(ws1.to_string(), "\t ");
+
+        // to_non_empty_string() uses Vec + second WsChar
+        let ws2 = Whitespace(vec![WsChar::Space], WsChar::Tab);
+        assert_eq!(ws2.to_non_empty_string(), " \t");
+
+        // Empty vec: to_string() is empty, to_non_empty_string() uses second WsChar
+        let ws3 = Whitespace(vec![], WsChar::Newline);
+        assert_eq!(ws3.clone().to_string(), "");
+        assert_eq!(ws3.to_non_empty_string(), "\n");
+    }
+}

--- a/crates/test-util/src/fmt.rs
+++ b/crates/test-util/src/fmt.rs
@@ -4,7 +4,7 @@
 use arbitrary::Arbitrary;
 
 /// A template to generate formatting variations of a piece of code.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Template(Vec<Span>);
 
 #[derive(Debug, Clone)]
@@ -18,19 +18,13 @@ pub enum Span {
 }
 
 /// Describes a variation the template can generate.
-#[derive(Debug, Clone, Arbitrary)]
+#[derive(Debug, Clone, Default, Arbitrary)]
 pub struct Variation(Vec<Whitespace>);
-
-impl Default for Variation {
-    fn default() -> Self {
-        Variation(vec![])
-    }
-}
 
 impl Template {
     /// New empty template.
     pub fn new() -> Self {
-        Template(vec![])
+        Self::default()
     }
 
     /// Add a placeholder for zero or more whitespace characters.
@@ -46,13 +40,13 @@ impl Template {
     }
 
     /// Add a fixed span of text.
-    pub fn fixed(mut self: Self, text: &str) -> Self {
+    pub fn fixed(mut self, text: &str) -> Self {
         self.0.push(Span::F(text.to_string()));
         self
     }
 
     /// Add tokens, replacing each internal span of whitespace with a `.z()`.
-    pub fn tokens(mut self: Self, text: &str) -> Self {
+    pub fn tokens(mut self, text: &str) -> Self {
         for (i, non_whitespace) in text.split_whitespace().enumerate() {
             if i > 0 {
                 self.0.push(Span::Z);
@@ -100,14 +94,14 @@ impl Default for Whitespace {
 
 impl Whitespace {
     fn to_string(self: Whitespace) -> String {
-        self.0.into_iter().map(|w| char::from(w)).collect()
+        self.0.into_iter().map(char::from).collect()
     }
 
     fn to_non_empty_string(self: Whitespace) -> String {
         self.0
             .into_iter()
             .chain(std::iter::once(self.1))
-            .map(|w| char::from(w))
+            .map(char::from)
             .collect()
     }
 }


### PR DESCRIPTION
- Add unit tests to test-utils
- Fix clippy warnings in `test-util/src/fmt.rs` and `anodized-core/src/annotate/mod.rs`
- Derive `Default` for `Template`, `Variation` and `Whitespace`
- Add CI job for test-util (lint + test)
- Add CI job for fuzz targets (lint + build)