### PR TITLE
[anodized-core] test: use pretty_assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ anodized-logic = { version = "0.5.1", path = "crates/anodized-logic" }
 anodized-macros = { version = "0.5.1", path = "crates/anodized-macros" }
 test-util = { path = "crates/test-util" }
 num-bigint = "0.4.6"
+pretty_assertions = "1"
+prettyplease = "0.2"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
 syn = { version = "2.0", features = ["extra-traits", "full", "visit", "visit-mut"] }

--- a/crates/anodized-core/Cargo.toml
+++ b/crates/anodized-core/Cargo.toml
@@ -17,3 +17,7 @@ bitflags = "2.11.1"
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true
+prettyplease.workspace = true

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -10,15 +10,13 @@ pub fn assert_tokens_eq(left: &impl ToTokens, right: &impl ToTokens) {
 
 fn pretty_print_tokens(ts: proc_macro2::TokenStream) -> String {
     let file: syn::File = syn::parse2(ts.clone())
-        .or_else(|_| {
+        .or_else(|_|
             // Token stream cannot be parsed as top-level items; wrap in function
-            let wrapped: proc_macro2::TokenStream = quote! {
+            syn::parse2(quote! {
                 fn main() {
                     #ts
                 }
-            };
-            syn::parse2(wrapped)
-        })
+            }))
         .expect("wrap tokens in a file");
     prettyplease::unparse(&file)
 }

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,10 +1,26 @@
 use crate::{Capture, PostCondition, PreCondition, Spec};
-use quote::ToTokens;
+use pretty_assertions::assert_eq;
+use quote::{ToTokens, quote};
 
 pub fn assert_tokens_eq(left: &impl ToTokens, right: &impl ToTokens) {
-    let left_str = left.to_token_stream().to_string();
-    let right_str = right.to_token_stream().to_string();
+    let left_str = pretty_print_tokens(left.to_token_stream());
+    let right_str = pretty_print_tokens(right.to_token_stream());
     assert_eq!(left_str, right_str);
+}
+
+fn pretty_print_tokens(ts: proc_macro2::TokenStream) -> String {
+    let file: syn::File = syn::parse2(ts.clone())
+        .or_else(|_| {
+            // Token stream cannot be parsed as top-level items; wrap in function
+            let wrapped: proc_macro2::TokenStream = quote! {
+                fn main() {
+                    #ts
+                }
+            };
+            syn::parse2(wrapped)
+        })
+        .expect("wrap tokens in a file");
+    prettyplease::unparse(&file)
 }
 
 pub fn assert_spec_eq(left: &Spec, right: &Spec) {

--- a/crates/anodized-fmt/Cargo.toml
+++ b/crates/anodized-fmt/Cargo.toml
@@ -20,17 +20,17 @@ path = "src/lib.rs"
 
 [dependencies]
 anodized-core.workspace = true
+prettyplease.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 
 clap = { version = "4", features = ["derive"] }
 crop = "0.4"
-prettyplease = "0.2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 toml = "0.9"
 walkdir = "2"
 
 [dev-dependencies]
-pretty_assertions = "1"
+pretty_assertions.workspace = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,10 +9,10 @@ cargo-fuzz = true
 
 [dependencies]
 anodized-fmt.workspace = true
+pretty_assertions.workspace = true
 test-util.workspace = true
 
 libfuzzer-sys = "0.4"
-pretty_assertions = "1"
 
 [[bin]]
 name = "fmt_ws_invariant"


### PR DESCRIPTION
- Promote `prettyplease` and `pretty_assertions` to workspace-level deps.
- Use `pretty_assertions::assert_eq` in unit tests.