### PR TITLE
[anodized-core] feat: improve spec embedding

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.cargo.cfgs": ["anodized_panic"]
-}

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -40,13 +40,10 @@ impl Config {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
                 sig: Self::build_spec_fn_sig("__anodized_fn_requires", &item_fn.sig),
-                block: Box::new(Self::build_precondition_fn_body(&spec.requires)),
-            };
-            let spec_maintains_fn = ItemFn {
-                attrs: attrs.to_vec(),
-                vis: syn::Visibility::Inherited,
-                sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &item_fn.sig),
-                block: Box::new(Self::build_precondition_fn_body(&spec.maintains)),
+                block: Box::new(Self::build_precondition_fn_body(
+                    &spec.requires,
+                    &spec.maintains,
+                )),
             };
             let spec_ensures_fn = ItemFn {
                 attrs: attrs.to_vec(),
@@ -61,7 +58,6 @@ impl Config {
 
             spec_qualifiers_const.to_tokens(&mut tokens);
             spec_requires_fn.to_tokens(&mut tokens);
-            spec_maintains_fn.to_tokens(&mut tokens);
             spec_ensures_fn.to_tokens(&mut tokens);
         }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -39,7 +39,7 @@ impl Config {
             let spec_requires_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
-                sig: Self::build_requires_fn_sig("__anodized_fn_requires", &item_fn.sig),
+                sig: Self::build_precondition_fn_sig("__anodized_fn_requires", &item_fn.sig),
                 block: Box::new(Self::build_precondition_fn_body(
                     &spec.requires,
                     &spec.maintains,
@@ -48,7 +48,7 @@ impl Config {
             let spec_ensures_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
-                sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+                sig: Self::build_postcondition_fn_sig("__anodized_fn_ensures", &item_fn.sig),
                 block: Box::new(Self::build_postcondition_fn_body(
                     &spec.maintains,
                     &spec.captures,

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -39,7 +39,7 @@ impl Config {
             let spec_requires_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
-                sig: Self::build_spec_fn_sig("__anodized_fn_requires", &item_fn.sig),
+                sig: Self::build_requires_fn_sig("__anodized_fn_requires", &item_fn.sig),
                 block: Box::new(Self::build_precondition_fn_body(
                     &spec.requires,
                     &spec.maintains,
@@ -48,8 +48,9 @@ impl Config {
             let spec_ensures_fn = ItemFn {
                 attrs: attrs.to_vec(),
                 vis: syn::Visibility::Inherited,
-                sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &item_fn.sig),
-                block: Box::new(Self::build_poscondition_fn_body(
+                sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+                block: Box::new(Self::build_postcondition_fn_body(
+                    &spec.maintains,
                     &spec.captures,
                     &spec.ensures,
                     &item_fn.sig.output,

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -18,7 +18,7 @@ impl Config {
 
         let ident = &item_struct.ident;
         let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
-        let statements = Self::build_precondition_fn_body(&spec.maintains).stmts;
+        let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;
 
         item_struct.to_tokens(&mut tokens);
 
@@ -27,7 +27,7 @@ impl Config {
                 #[doc(hidden)]
                 #[allow(warnings)]
                 impl #impl_generics #ident #ty_generics #where_clause {
-                    fn __anodized_data_maintains(&self) {
+                    fn __anodized_data_maintains(&self) -> bool {
                         #(#statements)*
                     }
                 }
@@ -43,7 +43,7 @@ impl Config {
 
         let ident = &item_enum.ident;
         let (impl_generics, ty_generics, where_clause) = item_enum.generics.split_for_impl();
-        let statements = Self::build_precondition_fn_body(&spec.maintains).stmts;
+        let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;
 
         item_enum.to_tokens(&mut tokens);
 
@@ -52,7 +52,7 @@ impl Config {
                 #[doc(hidden)]
                 #[allow(warnings)]
                 impl #impl_generics #ident #ty_generics #where_clause {
-                    fn __anodized_data_maintains(&self) {
+                    fn __anodized_data_maintains(&self) -> bool {
                         // Bring all variants into scope for convenience.
                         use #ident::*;
                         #(#statements)*

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -39,9 +39,9 @@ fn embed_spec_item_struct() {
             'LT_1: 'LT_2,
         {
             fn __anodized_data_maintains(&self) -> bool {
-                let __anodized_clause_1 = | | -> bool { COND_1 };
-                let __anodized_clause_2 = | | -> bool { COND_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { COND_1 })();
+                let __anodized_clause_2 = (| | -> bool { COND_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             }
         }
     };
@@ -91,9 +91,9 @@ fn embed_spec_item_enum() {
         {
             fn __anodized_data_maintains(&self) -> bool {
                 use ENUM::*;
-                let __anodized_clause_1 = | | -> bool { COND_1 };
-                let __anodized_clause_2 = | | -> bool { COND_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { COND_1 })();
+                let __anodized_clause_2 = (| | -> bool { COND_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             }
         }
     };

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -38,9 +38,10 @@ fn embed_spec_item_struct() {
         where
             'LT_1: 'LT_2,
         {
-            fn __anodized_data_maintains(&self) {
-                let _ = | | -> bool { COND_1 };
-                let _ = | | -> bool { COND_2 };
+            fn __anodized_data_maintains(&self) -> bool {
+                let __anodized_clause_1 = | | -> bool { COND_1 };
+                let __anodized_clause_2 = | | -> bool { COND_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             }
         }
     };
@@ -88,10 +89,11 @@ fn embed_spec_item_enum() {
         where
             'LT_1: 'LT_2,
         {
-            fn __anodized_data_maintains(&self) {
+            fn __anodized_data_maintains(&self) -> bool {
                 use ENUM::*;
-                let _ = | | -> bool { COND_1 };
-                let _ = | | -> bool { COND_2 };
+                let __anodized_clause_1 = | | -> bool { COND_1 };
+                let __anodized_clause_2 = | | -> bool { COND_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             }
         }
     };

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -132,8 +132,8 @@ impl Config {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let closure = &condition.closure;
-            statements.push(parse_quote! { let #name = #closure; });
-            clauses.push(parse_quote! { #name() });
+            statements.push(parse_quote! { let #name = (#closure)(); });
+            clauses.push(parse_quote! { #name });
         }
 
         if clauses.is_empty() {
@@ -161,8 +161,8 @@ impl Config {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let closure = &condition.closure;
-            statements.push(parse_quote! { let #name = #closure; });
-            clauses.push(parse_quote! { #name() });
+            statements.push(parse_quote! { let #name = (#closure)(); });
+            clauses.push(parse_quote! { #name });
         }
 
         {
@@ -185,14 +185,14 @@ impl Config {
             let closure = &condition.closure;
             let input = closure.inputs.first().expect("valid postcondition");
             if let Pat::Type(_) = input {
-                statements.push(parse_quote! { let #name = #closure; });
+                statements.push(parse_quote! { let #name = (#closure)(__anodized_output); });
             } else {
                 let body = &closure.body;
                 statements.push(parse_quote! {
-                    let #name = | #input: &#output_type | -> bool { #body };
+                    let #name = (| #input: &#output_type | -> bool { #body })(__anodized_output);
                 });
             }
-            clauses.push(parse_quote! { #name(__anodized_output) });
+            clauses.push(parse_quote! { #name });
         }
 
         if clauses.is_empty() {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -49,7 +49,7 @@ impl Config {
             paren_token: sig.paren_token,
             inputs: sig.inputs.clone(),
             variadic: sig.variadic.clone(),
-            output: syn::ReturnType::Default,
+            output: parse_quote!(-> bool),
         }
     }
 
@@ -98,14 +98,28 @@ impl Config {
         }
     }
 
-    pub fn build_precondition_fn_body(conditions: &[PreCondition]) -> Block {
-        let statements = conditions.iter().map(|condition| -> Stmt {
+    pub fn build_precondition_fn_body(
+        requires: &[PreCondition],
+        maintains: &[PreCondition],
+    ) -> Block {
+        let conditions = requires.iter().chain(maintains);
+
+        let mut statements: Vec<Stmt> = vec![];
+        let mut clauses: Vec<Expr> = vec![];
+        for (i, condition) in conditions.enumerate() {
+            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let closure = &condition.closure;
-            parse_quote! { let _ = #closure; }
-        });
+            statements.push(parse_quote! { let #name = #closure; });
+            clauses.push(parse_quote! { #name() });
+        }
+        if clauses.is_empty() {
+            clauses.push(parse_quote!(true));
+        }
+
         parse_quote! {
             {
                 #(#statements)*
+                #(#clauses)&&*
             }
         }
     }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -37,7 +37,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn build_spec_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+    pub fn build_requires_fn_sig(prefix: &str, sig: &Signature) -> Signature {
         Signature {
             constness: sig.constness,
             asyncness: sig.asyncness,
@@ -48,6 +48,29 @@ impl Config {
             generics: sig.generics.clone(),
             paren_token: sig.paren_token,
             inputs: sig.inputs.clone(),
+            variadic: sig.variadic.clone(),
+            output: parse_quote!(-> bool),
+        }
+    }
+
+    pub fn build_ensures_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+        let mut inputs = sig.inputs.clone();
+        let output_binder = match &sig.output {
+            ReturnType::Type(_, return_type) => parse_quote!(__anodized_output: &#return_type),
+            ReturnType::Default => parse_quote!(__anodized_output: &()),
+        };
+        inputs.push(output_binder);
+
+        Signature {
+            constness: sig.constness,
+            asyncness: sig.asyncness,
+            unsafety: sig.unsafety,
+            abi: sig.abi.clone(),
+            fn_token: sig.fn_token,
+            ident: syn::Ident::new(&format!("{prefix}_{}", sig.ident), sig.ident.span()),
+            generics: sig.generics.clone(),
+            paren_token: sig.paren_token,
+            inputs,
             variadic: sig.variadic.clone(),
             output: parse_quote!(-> bool),
         }
@@ -102,16 +125,17 @@ impl Config {
         requires: &[PreCondition],
         maintains: &[PreCondition],
     ) -> Block {
-        let conditions = requires.iter().chain(maintains);
-
         let mut statements: Vec<Stmt> = vec![];
         let mut clauses: Vec<Expr> = vec![];
-        for (i, condition) in conditions.enumerate() {
+
+        for condition in requires.iter().chain(maintains) {
+            let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let closure = &condition.closure;
             statements.push(parse_quote! { let #name = #closure; });
             clauses.push(parse_quote! { #name() });
         }
+
         if clauses.is_empty() {
             clauses.push(parse_quote!(true));
         }
@@ -124,55 +148,61 @@ impl Config {
         }
     }
 
-    pub fn build_poscondition_fn_body(
+    pub fn build_postcondition_fn_body(
+        maintains: &[PreCondition],
         captures: &[Capture],
-        conditions: &[PostCondition],
+        ensures: &[PostCondition],
         return_type: &ReturnType,
     ) -> Result<Block> {
-        let aliases = captures.iter().map(|capture| &capture.pat);
-        let capture_exprs = captures.iter().map(|capture| -> Expr {
-            let expr = &capture.expr;
-            // Wrap in closure to guard against `return`.
-            parse_quote! { (|| #expr)() }
-        });
+        let mut statements: Vec<Stmt> = vec![];
+        let mut clauses: Vec<Expr> = vec![];
 
-        let mut statements = vec![];
-
-        for condition in conditions {
+        for condition in maintains {
+            let i = clauses.len();
+            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let closure = &condition.closure;
-            // TODO: This sort of validation should happen during parsing.
-            let output_binder = match closure.inputs.first() {
-                Some(output_binder) if closure.inputs.len() == 1 => output_binder,
-                _ => {
-                    return Err(syn::Error::new_spanned(
-                        &closure.inputs,
-                        "Postcondition closure must have exactly one parameter.",
-                    ));
-                }
-            };
-            let statement: Stmt = if let Pat::Type(_) = output_binder {
-                // If the output binder has a type annotation, use as-is.
-                parse_quote! { let _ = #closure; }
+            statements.push(parse_quote! { let #name = #closure; });
+            clauses.push(parse_quote! { #name() });
+        }
+
+        {
+            let aliases = captures.iter().map(|capture| &capture.pat);
+            let capture_exprs = captures.iter().map(|capture| -> Expr {
+                let expr = &capture.expr;
+                // Wrap in closure to guard against `return`.
+                parse_quote! { (|| #expr)() }
+            });
+            statements.push(parse_quote! { let (#(#aliases),*) = (#(#capture_exprs),*); });
+        }
+
+        let output_type = match return_type {
+            ReturnType::Type(_, return_type) => return_type.as_ref().clone(),
+            ReturnType::Default => parse_quote!(()),
+        };
+        for condition in ensures {
+            let i = clauses.len();
+            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
+            let closure = &condition.closure;
+            let input = closure.inputs.first().expect("valid postcondition");
+            if let Pat::Type(_) = input {
+                statements.push(parse_quote! { let #name = #closure; });
             } else {
-                // Otherwise add a type annotation.
                 let body = &closure.body;
-                let output = &closure.output;
-                match &return_type {
-                    ReturnType::Default => {
-                        parse_quote! { let _ = |#output_binder: &()| #output { #body }; }
-                    }
-                    ReturnType::Type(_, ty) => {
-                        parse_quote! { let _ = |#output_binder: &#ty| #output { #body }; }
-                    }
-                }
-            };
-            statements.push(statement);
+                statements.push(parse_quote! {
+                    let #name = | #input: &#output_type | -> bool { #body };
+                });
+            }
+            clauses.push(parse_quote! { #name(__anodized_output) });
+        }
+
+        if clauses.is_empty() {
+            clauses.push(parse_quote!(true));
         }
 
         Ok(parse_quote! {
             {
-                let (#(#aliases),*) = (#(#capture_exprs),*);
                 #(#statements)*
+                #(#clauses)&&*
             }
         })
     }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -37,7 +37,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn build_requires_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+    pub fn build_precondition_fn_sig(prefix: &str, sig: &Signature) -> Signature {
         Signature {
             constness: sig.constness,
             asyncness: sig.asyncness,
@@ -53,7 +53,7 @@ impl Config {
         }
     }
 
-    pub fn build_ensures_fn_sig(prefix: &str, sig: &Signature) -> Signature {
+    pub fn build_postcondition_fn_sig(prefix: &str, sig: &Signature) -> Signature {
         let mut inputs = sig.inputs.clone();
         let output_binder = match &sig.output {
             ReturnType::Type(_, return_type) => parse_quote!(__anodized_output: &#return_type),

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -40,28 +40,28 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-            let __anodized_clause_1 = | | -> bool { COND_1 };
-            let __anodized_clause_2 = | | -> bool { COND_2 };
-            let __anodized_clause_3 = | | -> bool { COND_3 };
-            let __anodized_clause_4 = | | -> bool { COND_4 };
-            let __anodized_clause_5 = | | -> bool { COND_5 };
-            let __anodized_clause_6 = | | -> bool { COND_6 };
-            __anodized_clause_1() && __anodized_clause_2() && __anodized_clause_3()
-                && __anodized_clause_4() && __anodized_clause_5() && __anodized_clause_6()
+            let __anodized_clause_1 = (| | -> bool { COND_1 })();
+            let __anodized_clause_2 = (| | -> bool { COND_2 })();
+            let __anodized_clause_3 = (| | -> bool { COND_3 })();
+            let __anodized_clause_4 = (| | -> bool { COND_4 })();
+            let __anodized_clause_5 = (| | -> bool { COND_5 })();
+            let __anodized_clause_6 = (| | -> bool { COND_6 })();
+            __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
+                && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
         }
 
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
-            let __anodized_clause_1 = | | -> bool { COND_4 };
-            let __anodized_clause_2 = | | -> bool { COND_5 };
-            let __anodized_clause_3 = | | -> bool { COND_6 };
+            let __anodized_clause_1 = (| | -> bool { COND_4 })();
+            let __anodized_clause_2 = (| | -> bool { COND_5 })();
+            let __anodized_clause_3 = (| | -> bool { COND_6 })();
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((| | EXPR_1)(), (| | EXPR_2)());
-            let __anodized_clause_4 = |PAT_1: &RET_TYPE| -> bool { COND_7 };
-            let __anodized_clause_5 = |PAT_1: &RET_TYPE| -> bool { COND_8 };
-            let __anodized_clause_6 = |PAT_2: TYPE| -> bool { COND_9 };
-            __anodized_clause_1() && __anodized_clause_2() && __anodized_clause_3()
-                && __anodized_clause_4(__anodized_output) && __anodized_clause_5(__anodized_output) && __anodized_clause_6(__anodized_output)
+            let __anodized_clause_4 = (|PAT_1: &RET_TYPE| -> bool { COND_7 })(__anodized_output);
+            let __anodized_clause_5 = (|PAT_1: &RET_TYPE| -> bool { COND_8 })(__anodized_output);
+            let __anodized_clause_6 = (|PAT_2: TYPE| -> bool { COND_9 })(__anodized_output);
+            __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
+                && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
         }
 
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -39,27 +39,29 @@ fn embed_spec_item_fn() {
 
         #[doc(hidden)]
         #[allow(warnings)]
-        fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-            let _ = | | -> bool { COND_1 };
-            let _ = | | -> bool { COND_2 };
-            let _ = | | -> bool { COND_3 };
+        fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
+            let __anodized_clause_1 = | | -> bool { COND_1 };
+            let __anodized_clause_2 = | | -> bool { COND_2 };
+            let __anodized_clause_3 = | | -> bool { COND_3 };
+            let __anodized_clause_4 = | | -> bool { COND_4 };
+            let __anodized_clause_5 = | | -> bool { COND_5 };
+            let __anodized_clause_6 = | | -> bool { COND_6 };
+            __anodized_clause_1() && __anodized_clause_2() && __anodized_clause_3()
+                && __anodized_clause_4() && __anodized_clause_5() && __anodized_clause_6()
         }
 
         #[doc(hidden)]
         #[allow(warnings)]
-        fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-            let _ = | | -> bool { COND_4 };
-            let _ = | | -> bool { COND_5 };
-            let _ = | | -> bool { COND_6 };
-        }
-
-        #[doc(hidden)]
-        #[allow(warnings)]
-        fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+        fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
+            let __anodized_clause_1 = | | -> bool { COND_4 };
+            let __anodized_clause_2 = | | -> bool { COND_5 };
+            let __anodized_clause_3 = | | -> bool { COND_6 };
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((| | EXPR_1)(), (| | EXPR_2)());
-            let _ = |PAT_1: &RET_TYPE| -> bool { COND_7 };
-            let _ = |PAT_1: &RET_TYPE| -> bool { COND_8 };
-            let _ = |PAT_2: TYPE| -> bool { COND_9 };
+            let __anodized_clause_4 = |PAT_1: &RET_TYPE| -> bool { COND_7 };
+            let __anodized_clause_5 = |PAT_1: &RET_TYPE| -> bool { COND_8 };
+            let __anodized_clause_6 = |PAT_2: TYPE| -> bool { COND_9 };
+            __anodized_clause_1() && __anodized_clause_2() && __anodized_clause_3()
+                && __anodized_clause_4(__anodized_output) && __anodized_clause_5(__anodized_output) && __anodized_clause_6(__anodized_output)
         }
 
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -29,7 +29,7 @@ impl Config {
 
     fn instrument_loop_body(&self, spec: LoopSpec, stmts: &mut Vec<Stmt>) {
         if self.embed_spec {
-            let maintains_block = Self::build_precondition_fn_body(&spec.maintains);
+            let maintains_block = Self::build_precondition_fn_body(&[], &spec.maintains);
             stmts.insert(
                 0,
                 parse_quote! {

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -4,7 +4,8 @@ mod loops_tests;
 
 use proc_macro2::Span;
 use syn::{
-    Block, Error, ExprClosure, ExprForLoop, ExprWhile, Ident, ItemFn, Result, Stmt, parse_quote,
+    Block, Error, Expr, ExprClosure, ExprForLoop, ExprWhile, Ident, ItemFn, Result, Stmt,
+    parse_quote,
     visit_mut::{self, VisitMut},
 };
 
@@ -40,7 +41,6 @@ impl Config {
 
             let mut variant_stmts: Vec<Stmt> = Vec::new();
             let mut variant_names: Vec<Ident> = Vec::new();
-
             if let Some(loop_variant) = &spec.decreases {
                 let i = variant_names.len();
                 let name = Ident::new(&format!("__anodized_value_{}", i + 1), Span::mixed_site());
@@ -48,13 +48,18 @@ impl Config {
                 variant_stmts.push(parse_quote! { let #name = (|| #expr)(); });
                 variant_names.push(name);
             }
+            let variant_expr: Option<Expr> = if !variant_names.is_empty() {
+                Some(parse_quote! { (#(#variant_names),*) })
+            } else {
+                None
+            };
 
             stmts.insert(
                 1,
                 parse_quote! {
                     let __anodized_loop_decreases = || {
                         #(#variant_stmts)*
-                        (#(#variant_names),*)
+                        #variant_expr
                     };
                 },
             );

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -2,8 +2,9 @@
 #[path = "loops_tests.rs"]
 mod loops_tests;
 
+use proc_macro2::Span;
 use syn::{
-    Block, Error, ExprClosure, ExprForLoop, ExprWhile, ItemFn, Result, Stmt, parse_quote,
+    Block, Error, ExprClosure, ExprForLoop, ExprWhile, Ident, ItemFn, Result, Stmt, parse_quote,
     visit_mut::{self, VisitMut},
 };
 
@@ -33,21 +34,27 @@ impl Config {
             stmts.insert(
                 0,
                 parse_quote! {
-                    let __anodized_loop_maintains = #maintains_block;
+                    let __anodized_loop_maintains = || -> bool #maintains_block;
                 },
             );
 
-            let let_decreases: Option<Stmt> = spec.decreases.map(|loop_variant| {
-                let expr = loop_variant.expr;
-                parse_quote! {
-                    let _ = || #expr;
-                }
-            });
+            let mut variant_stmts: Vec<Stmt> = Vec::new();
+            let mut variant_names: Vec<Ident> = Vec::new();
+
+            if let Some(loop_variant) = &spec.decreases {
+                let i = variant_names.len();
+                let name = Ident::new(&format!("__anodized_value_{}", i + 1), Span::mixed_site());
+                let expr = &loop_variant.expr;
+                variant_stmts.push(parse_quote! { let #name = (|| #expr)(); });
+                variant_names.push(name);
+            }
+
             stmts.insert(
                 1,
                 parse_quote! {
-                    let __anodized_loop_decreases = {
-                        #let_decreases
+                    let __anodized_loop_decreases = || {
+                        #(#variant_stmts)*
+                        (#(#variant_names),*)
                     };
                 },
             );

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -20,13 +20,14 @@ fn embed_spec_expr_while() {
 
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
-            let __anodized_loop_maintains = {
+            let __anodized_loop_maintains = || -> bool {
                 let __anodized_clause_1 = (| | -> bool { INVAR_1 })();
                 let __anodized_clause_2 = (| | -> bool { INVAR_2 })();
                 __anodized_clause_1 && __anodized_clause_2
             };
-            let __anodized_loop_decreases = {
-                let _ = | | DECREASES_1;
+            let __anodized_loop_decreases = || {
+                let __anodized_value_1 = (|| DECREASES_1)();
+                (__anodized_value_1)
             };
             LOOP_BODY
         }
@@ -54,12 +55,12 @@ fn embed_spec_expr_for() {
 
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
-            let __anodized_loop_maintains = {
+            let __anodized_loop_maintains = || -> bool {
                 let __anodized_clause_1 = (| | -> bool { INVAR_1 })();
                 let __anodized_clause_2 = (| | -> bool { INVAR_2 })();
                 __anodized_clause_1 && __anodized_clause_2
             };
-            let __anodized_loop_decreases = {};
+            let __anodized_loop_decreases = || { () };
             LOOP_BODY
         }
     };

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -21,8 +21,9 @@ fn embed_spec_expr_while() {
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
             let __anodized_loop_maintains = {
-                let _ = | | -> bool { INVAR_1 };
-                let _ = | | -> bool { INVAR_2 };
+                let __anodized_clause_1 = | | -> bool { INVAR_1 };
+                let __anodized_clause_2 = | | -> bool { INVAR_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             };
             let __anodized_loop_decreases = {
                 let _ = | | DECREASES_1;
@@ -54,8 +55,9 @@ fn embed_spec_expr_for() {
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
             let __anodized_loop_maintains = {
-                let _ = | | -> bool { INVAR_1 };
-                let _ = | | -> bool { INVAR_2 };
+                let __anodized_clause_1 = | | -> bool { INVAR_1 };
+                let __anodized_clause_2 = | | -> bool { INVAR_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             };
             let __anodized_loop_decreases = {};
             LOOP_BODY

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -60,7 +60,7 @@ fn embed_spec_expr_for() {
                 let __anodized_clause_2 = (| | -> bool { INVAR_2 })();
                 __anodized_clause_1 && __anodized_clause_2
             };
-            let __anodized_loop_decreases = || { () };
+            let __anodized_loop_decreases = || {};
             LOOP_BODY
         }
     };

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -21,9 +21,9 @@ fn embed_spec_expr_while() {
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
             let __anodized_loop_maintains = {
-                let __anodized_clause_1 = | | -> bool { INVAR_1 };
-                let __anodized_clause_2 = | | -> bool { INVAR_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { INVAR_1 })();
+                let __anodized_clause_2 = (| | -> bool { INVAR_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = {
                 let _ = | | DECREASES_1;
@@ -55,9 +55,9 @@ fn embed_spec_expr_for() {
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
             let __anodized_loop_maintains = {
-                let __anodized_clause_1 = | | -> bool { INVAR_1 };
-                let __anodized_clause_2 = | | -> bool { INVAR_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { INVAR_1 })();
+                let __anodized_clause_2 = (| | -> bool { INVAR_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = {};
             LOOP_BODY

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -73,13 +73,10 @@ impl Config {
                         let spec_requires_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
                             sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
-                            default: Some(Self::build_precondition_fn_body(&fn_spec.requires)),
-                            semi_token: None,
-                        };
-                        let spec_maintains_fn = TraitItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
-                            default: Some(Self::build_precondition_fn_body(&fn_spec.maintains)),
+                            default: Some(Self::build_precondition_fn_body(
+                                &fn_spec.requires,
+                                &fn_spec.maintains,
+                            )),
                             semi_token: None,
                         };
                         let spec_ensures_fn = TraitItemFn {
@@ -96,7 +93,6 @@ impl Config {
                         new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
                         new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
                         new_trait_items.push(TraitItem::Fn(spec_requires_fn));
-                        new_trait_items.push(TraitItem::Fn(spec_maintains_fn));
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
                     }
 
@@ -218,14 +214,10 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         let spec_requires_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
                             sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
-                            block: Self::build_precondition_fn_body(&fn_spec.requires),
-                            vis: Visibility::Inherited,
-                            defaultness: None,
-                        };
-                        let spec_maintains_fn = ImplItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_maintains", &func.sig),
-                            block: Self::build_precondition_fn_body(&fn_spec.maintains),
+                            block: Self::build_precondition_fn_body(
+                                &fn_spec.requires,
+                                &fn_spec.maintains,
+                            ),
                             vis: Visibility::Inherited,
                             defaultness: None,
                         };
@@ -243,7 +235,6 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
 
                         new_items.push(ImplItem::Const(spec_qualifiers_const));
                         new_items.push(ImplItem::Fn(spec_requires_fn));
-                        new_items.push(ImplItem::Fn(spec_maintains_fn));
                         new_items.push(ImplItem::Fn(spec_ensures_fn));
                     }
 

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -72,7 +72,7 @@ impl Config {
                         );
                         let spec_requires_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
+                            sig: Self::build_requires_fn_sig("__anodized_fn_requires", &func.sig),
                             default: Some(Self::build_precondition_fn_body(
                                 &fn_spec.requires,
                                 &fn_spec.maintains,
@@ -81,8 +81,9 @@ impl Config {
                         };
                         let spec_ensures_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
-                            default: Some(Self::build_poscondition_fn_body(
+                            sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &func.sig),
+                            default: Some(Self::build_postcondition_fn_body(
+                                &fn_spec.maintains,
                                 &fn_spec.captures,
                                 &fn_spec.ensures,
                                 &func.sig.output,
@@ -213,7 +214,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         );
                         let spec_requires_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_requires", &func.sig),
+                            sig: Self::build_requires_fn_sig("__anodized_fn_requires", &func.sig),
                             block: Self::build_precondition_fn_body(
                                 &fn_spec.requires,
                                 &fn_spec.maintains,
@@ -223,8 +224,9 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         };
                         let spec_ensures_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_spec_fn_sig("__anodized_fn_ensures", &func.sig),
-                            block: Self::build_poscondition_fn_body(
+                            sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &func.sig),
+                            block: Self::build_postcondition_fn_body(
+                                &fn_spec.maintains,
                                 &fn_spec.captures,
                                 &fn_spec.ensures,
                                 &func.sig.output,

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -72,7 +72,10 @@ impl Config {
                         );
                         let spec_requires_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_requires_fn_sig("__anodized_fn_requires", &func.sig),
+                            sig: Self::build_precondition_fn_sig(
+                                "__anodized_fn_requires",
+                                &func.sig,
+                            ),
                             default: Some(Self::build_precondition_fn_body(
                                 &fn_spec.requires,
                                 &fn_spec.maintains,
@@ -81,7 +84,10 @@ impl Config {
                         };
                         let spec_ensures_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &func.sig),
+                            sig: Self::build_postcondition_fn_sig(
+                                "__anodized_fn_ensures",
+                                &func.sig,
+                            ),
                             default: Some(Self::build_postcondition_fn_body(
                                 &fn_spec.maintains,
                                 &fn_spec.captures,
@@ -214,7 +220,10 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         );
                         let spec_requires_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_requires_fn_sig("__anodized_fn_requires", &func.sig),
+                            sig: Self::build_precondition_fn_sig(
+                                "__anodized_fn_requires",
+                                &func.sig,
+                            ),
                             block: Self::build_precondition_fn_body(
                                 &fn_spec.requires,
                                 &fn_spec.maintains,
@@ -224,7 +233,10 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         };
                         let spec_ensures_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
-                            sig: Self::build_ensures_fn_sig("__anodized_fn_ensures", &func.sig),
+                            sig: Self::build_postcondition_fn_sig(
+                                "__anodized_fn_ensures",
+                                &func.sig,
+                            ),
                             block: Self::build_postcondition_fn_body(
                                 &fn_spec.maintains,
                                 &fn_spec.captures,

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -34,21 +34,19 @@ fn embed_spec_item_trait() {
 
             #[doc(hidden)]
             #[allow(warnings)]
-            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | -> bool { COND_1 };
+            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
+                let __anodized_clause_1 = | | -> bool { COND_1 };
+                let __anodized_clause_2 = | | -> bool { COND_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
-            fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | -> bool { COND_2 };
-            }
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_ouput: &RET_TYPE) -> bool {
+                let __anodized_clause_1 = | | -> bool { COND_2 };
                 let () = ();
-                let _ = |PAT_1: &RET_TYPE| -> bool { COND_3 };
+                let __anodized_clause_2 = |PAT_1: &RET_TYPE| -> bool { COND_3 };
+                __anodized_clause_1() && __anodized_clause_2(__anodized_output)
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
@@ -89,21 +87,19 @@ fn embed_spec_item_impl_trait() {
 
             #[doc(hidden)]
             #[allow(warnings)]
-            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | -> bool { COND_1 };
+            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
+                let __anodized_clause_1 = | | -> bool { COND_1 };
+                let __anodized_clause_2 = | | -> bool { COND_2 };
+                __anodized_clause_1() && __anodized_clause_2()
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
-            fn __anodized_fn_maintains_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
-                let _ = | | -> bool { COND_2 };
-            }
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) {
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
+                let __anodized_clause_1 = | | -> bool { COND_2 };
                 let () = ();
-                let _ = |PAT_1: &RET_TYPE| -> bool { COND_3 };
+                let __anodized_clause_2 = |PAT_1: &RET_TYPE| -> bool { COND_3 };
+                __anodized_clause_1() && __anodized_clause_2(__anodized_output)
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -42,7 +42,7 @@ fn embed_spec_item_trait() {
 
             #[doc(hidden)]
             #[allow(warnings)]
-            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_ouput: &RET_TYPE) -> bool {
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
                 let __anodized_clause_1 = | | -> bool { COND_2 };
                 let () = ();
                 let __anodized_clause_2 = |PAT_1: &RET_TYPE| -> bool { COND_3 };

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -35,18 +35,18 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = | | -> bool { COND_1 };
-                let __anodized_clause_2 = | | -> bool { COND_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { COND_1 })();
+                let __anodized_clause_2 = (| | -> bool { COND_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
-                let __anodized_clause_1 = | | -> bool { COND_2 };
+                let __anodized_clause_1 = (| | -> bool { COND_2 })();
                 let () = ();
-                let __anodized_clause_2 = |PAT_1: &RET_TYPE| -> bool { COND_3 };
-                __anodized_clause_1() && __anodized_clause_2(__anodized_output)
+                let __anodized_clause_2 = (|PAT_1: &RET_TYPE| -> bool { COND_3 })(__anodized_output);
+                __anodized_clause_1 && __anodized_clause_2
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
@@ -88,18 +88,18 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = | | -> bool { COND_1 };
-                let __anodized_clause_2 = | | -> bool { COND_2 };
-                __anodized_clause_1() && __anodized_clause_2()
+                let __anodized_clause_1 = (| | -> bool { COND_1 })();
+                let __anodized_clause_2 = (| | -> bool { COND_2 })();
+                __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
-                let __anodized_clause_1 = | | -> bool { COND_2 };
+                let __anodized_clause_1 = (| | -> bool { COND_2 })();
                 let () = ();
-                let __anodized_clause_2 = |PAT_1: &RET_TYPE| -> bool { COND_3 };
-                __anodized_clause_1() && __anodized_clause_2(__anodized_output)
+                let __anodized_clause_2 = (|PAT_1: &RET_TYPE| -> bool { COND_3 })(__anodized_output);
+                __anodized_clause_1 && __anodized_clause_2
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {


### PR DESCRIPTION
- Embed each predicate as `Fn(*) -> bool` (instead of `Fn(*) -> ()`).
- Embed a `fn` spec as only `requires` and `ensures` predicates.
- Embed a loop spec in a way that will support multiple `decreases` values if necessary.