### PR TITLE
[anodized-core] refactor: instrumentation config

### DIFF
--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -67,8 +67,8 @@ impl Config {
 
         // Instrument function body.
         self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
-        item_fn.to_tokens(&mut tokens);
 
+        item_fn.to_tokens(&mut tokens);
         Ok(tokens)
     }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -97,22 +97,19 @@ impl Config {
 
 #[cfg(test)]
 impl Config {
-    pub(crate) const DEFAULT: Config = Config {
-        embed_spec: true,
-        emit_print: false,
-        emit_panic: false,
+    pub(crate) const DEFAULT: RuntimeConfig = RuntimeConfig {
+        does_print: false,
+        does_panic: false,
     };
 
-    pub(crate) const PRINT: Config = Config {
-        embed_spec: true,
-        emit_print: true,
-        emit_panic: false,
+    pub(crate) const PRINT: RuntimeConfig = RuntimeConfig {
+        does_print: true,
+        does_panic: false,
     };
 
-    pub(crate) const PANIC: Config = Config {
-        embed_spec: true,
-        emit_print: true,
-        emit_panic: true,
+    pub(crate) const PRINT_AND_PANIC: RuntimeConfig = RuntimeConfig {
+        does_print: true,
+        does_panic: true,
     };
 }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -93,17 +93,22 @@ impl Config {
 
 #[cfg(test)]
 impl Config {
-    pub(crate) const DEFAULT: RuntimeConfig = RuntimeConfig {
+    pub(crate) const DEFAULT: Self = Self::Dynamic(RuntimeConfig::DEFAULT);
+}
+
+#[cfg(test)]
+impl RuntimeConfig {
+    pub(crate) const DEFAULT: Self = Self {
         does_print: false,
         does_panic: false,
     };
 
-    pub(crate) const PRINT: RuntimeConfig = RuntimeConfig {
+    pub(crate) const PRINT: Self = Self {
         does_print: true,
         does_panic: false,
     };
 
-    pub(crate) const PRINT_AND_PANIC: RuntimeConfig = RuntimeConfig {
+    pub(crate) const PRINT_AND_PANIC: Self = Self {
         does_print: true,
         does_panic: true,
     };

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -12,12 +12,12 @@ pub mod traits;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Config {
     Nothing,
-    Dynamic(Check),
+    Dynamic(RuntimeConfig),
     Static,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Check {
+pub struct RuntimeConfig {
     pub does_print: bool,
     pub does_panic: bool,
 }

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -11,13 +11,16 @@ pub mod traits;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Config {
-    Nothing,
-    Dynamic(RuntimeConfig),
-    Static,
+    /// Make no changes to the code.
+    ChangeNothing,
+    /// Inject code to enable compile-time and/or runtime checks.
+    InjectChecks(CheckConfig),
+    /// Embed spec elements as new items without changing existing code.
+    EmbedSpecs,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RuntimeConfig {
+pub struct CheckConfig {
     pub does_print: bool,
     pub does_panic: bool,
 }
@@ -26,7 +29,7 @@ impl Config {
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        if let Self::Static = self {
+        if let Self::EmbedSpecs = self {
             // Embed `spec` elements as `__anodized_fn_*` items.
             let attrs: [Attribute; 2] = [
                 parse_quote!(#[doc(hidden)]),
@@ -93,11 +96,11 @@ impl Config {
 
 #[cfg(test)]
 impl Config {
-    pub(crate) const DEFAULT: Self = Self::Dynamic(RuntimeConfig::DEFAULT);
+    pub(crate) const DEFAULT: Self = Self::InjectChecks(CheckConfig::DEFAULT);
 }
 
 #[cfg(test)]
-impl RuntimeConfig {
+impl CheckConfig {
     pub(crate) const DEFAULT: Self = Self {
         does_print: false,
         does_panic: false,

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -23,54 +23,55 @@ pub struct RuntimeConfig {
 }
 
 impl Config {
-    pub fn has_effect(&self) -> bool {
-        !matches!(self, Self::Nothing)
-    }
-
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        if let Config::Static = self {
-            let attrs: [Attribute; 2] = [
-                parse_quote!(#[doc(hidden)]),
-                parse_quote!(#[allow(warnings)]),
-            ];
+        match self {
+            Self::Nothing => {}
+            Self::Dynamic(_) => {
+                // Instrument function body.
+                self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
+            }
+            Self::Static => {
+                // Embed `spec` elements as `__anodized_fn_*` items.
+                let attrs: [Attribute; 2] = [
+                    parse_quote!(#[doc(hidden)]),
+                    parse_quote!(#[allow(warnings)]),
+                ];
 
-            // Embed `spec` elements as `__anodized_fn_*` items.
-            let spec_qualifiers_const: ItemConst = Self::build_qualifier_const_item(
-                &attrs,
-                "__anodized_fn_qualifiers",
-                spec.qualifiers,
-                &item_fn.sig.ident,
-            );
-            let spec_requires_fn = ItemFn {
-                attrs: attrs.to_vec(),
-                vis: syn::Visibility::Inherited,
-                sig: Self::build_precondition_fn_sig("__anodized_fn_requires", &item_fn.sig),
-                block: Box::new(Self::build_precondition_fn_body(
-                    &spec.requires,
-                    &spec.maintains,
-                )),
-            };
-            let spec_ensures_fn = ItemFn {
-                attrs: attrs.to_vec(),
-                vis: syn::Visibility::Inherited,
-                sig: Self::build_postcondition_fn_sig("__anodized_fn_ensures", &item_fn.sig),
-                block: Box::new(Self::build_postcondition_fn_body(
-                    &spec.maintains,
-                    &spec.captures,
-                    &spec.ensures,
-                    &item_fn.sig.output,
-                )?),
-            };
+                let spec_qualifiers_const: ItemConst = Self::build_qualifier_const_item(
+                    &attrs,
+                    "__anodized_fn_qualifiers",
+                    spec.qualifiers,
+                    &item_fn.sig.ident,
+                );
+                let spec_requires_fn = ItemFn {
+                    attrs: attrs.to_vec(),
+                    vis: syn::Visibility::Inherited,
+                    sig: Self::build_precondition_fn_sig("__anodized_fn_requires", &item_fn.sig),
+                    block: Box::new(Self::build_precondition_fn_body(
+                        &spec.requires,
+                        &spec.maintains,
+                    )),
+                };
+                let spec_ensures_fn = ItemFn {
+                    attrs: attrs.to_vec(),
+                    vis: syn::Visibility::Inherited,
+                    sig: Self::build_postcondition_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+                    block: Box::new(Self::build_postcondition_fn_body(
+                        &spec.maintains,
+                        &spec.captures,
+                        &spec.ensures,
+                        &item_fn.sig.output,
+                    )?),
+                };
 
-            spec_qualifiers_const.to_tokens(&mut tokens);
-            spec_requires_fn.to_tokens(&mut tokens);
-            spec_ensures_fn.to_tokens(&mut tokens);
+                spec_qualifiers_const.to_tokens(&mut tokens);
+                spec_requires_fn.to_tokens(&mut tokens);
+                spec_ensures_fn.to_tokens(&mut tokens);
+            }
         }
 
-        // Instrument function body.
-        self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
         item_fn.to_tokens(&mut tokens);
 
         Ok(tokens)

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -26,52 +26,47 @@ impl Config {
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        match self {
-            Self::Nothing => {}
-            Self::Dynamic(_) => {
-                // Instrument function body.
-                self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
-            }
-            Self::Static => {
-                // Embed `spec` elements as `__anodized_fn_*` items.
-                let attrs: [Attribute; 2] = [
-                    parse_quote!(#[doc(hidden)]),
-                    parse_quote!(#[allow(warnings)]),
-                ];
+        if let Self::Static = self {
+            // Embed `spec` elements as `__anodized_fn_*` items.
+            let attrs: [Attribute; 2] = [
+                parse_quote!(#[doc(hidden)]),
+                parse_quote!(#[allow(warnings)]),
+            ];
 
-                let spec_qualifiers_const: ItemConst = Self::build_qualifier_const_item(
-                    &attrs,
-                    "__anodized_fn_qualifiers",
-                    spec.qualifiers,
-                    &item_fn.sig.ident,
-                );
-                let spec_requires_fn = ItemFn {
-                    attrs: attrs.to_vec(),
-                    vis: syn::Visibility::Inherited,
-                    sig: Self::build_precondition_fn_sig("__anodized_fn_requires", &item_fn.sig),
-                    block: Box::new(Self::build_precondition_fn_body(
-                        &spec.requires,
-                        &spec.maintains,
-                    )),
-                };
-                let spec_ensures_fn = ItemFn {
-                    attrs: attrs.to_vec(),
-                    vis: syn::Visibility::Inherited,
-                    sig: Self::build_postcondition_fn_sig("__anodized_fn_ensures", &item_fn.sig),
-                    block: Box::new(Self::build_postcondition_fn_body(
-                        &spec.maintains,
-                        &spec.captures,
-                        &spec.ensures,
-                        &item_fn.sig.output,
-                    )?),
-                };
+            let spec_qualifiers_const: ItemConst = Self::build_qualifier_const_item(
+                &attrs,
+                "__anodized_fn_qualifiers",
+                spec.qualifiers,
+                &item_fn.sig.ident,
+            );
+            let spec_requires_fn = ItemFn {
+                attrs: attrs.to_vec(),
+                vis: syn::Visibility::Inherited,
+                sig: Self::build_precondition_fn_sig("__anodized_fn_requires", &item_fn.sig),
+                block: Box::new(Self::build_precondition_fn_body(
+                    &spec.requires,
+                    &spec.maintains,
+                )),
+            };
+            let spec_ensures_fn = ItemFn {
+                attrs: attrs.to_vec(),
+                vis: syn::Visibility::Inherited,
+                sig: Self::build_postcondition_fn_sig("__anodized_fn_ensures", &item_fn.sig),
+                block: Box::new(Self::build_postcondition_fn_body(
+                    &spec.maintains,
+                    &spec.captures,
+                    &spec.ensures,
+                    &item_fn.sig.output,
+                )?),
+            };
 
-                spec_qualifiers_const.to_tokens(&mut tokens);
-                spec_requires_fn.to_tokens(&mut tokens);
-                spec_ensures_fn.to_tokens(&mut tokens);
-            }
+            spec_qualifiers_const.to_tokens(&mut tokens);
+            spec_requires_fn.to_tokens(&mut tokens);
+            spec_ensures_fn.to_tokens(&mut tokens);
         }
 
+        // Instrument function body.
+        self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
         item_fn.to_tokens(&mut tokens);
 
         Ok(tokens)

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -9,21 +9,28 @@ pub mod fns;
 pub mod loops;
 pub mod traits;
 
-pub struct Config {
-    pub embed_spec: bool,
-    pub emit_print: bool,
-    pub emit_panic: bool,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Config {
+    Nothing,
+    Dynamic(Check),
+    Static,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Check {
+    pub does_print: bool,
+    pub does_panic: bool,
 }
 
 impl Config {
     pub fn has_effect(&self) -> bool {
-        self.embed_spec || self.emit_print || self.emit_panic
+        !matches!(self, Self::Nothing)
     }
 
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        if self.embed_spec {
+        if let Config::Static = self {
             let attrs: [Attribute; 2] = [
                 parse_quote!(#[doc(hidden)]),
                 parse_quote!(#[allow(warnings)]),

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -10,24 +10,24 @@ pub mod loops;
 pub mod traits;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Config {
+pub enum Mode {
     /// Make no changes to the code.
     ChangeNothing,
     /// Inject code to enable compile-time and/or runtime checks.
-    InjectChecks(CheckConfig),
+    InjectChecks(CheckSettings),
     /// Embed spec elements as new items without changing existing code.
     EmbedSpecs,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CheckConfig {
+pub struct CheckSettings {
     pub does_print: bool,
     pub does_panic: bool,
 }
 
-impl Config {
+impl Mode {
     pub fn changes_anything(&self) -> bool {
-        !matches!(self, Self::ChangeNothing)
+        !matches!(self, Mode::ChangeNothing)
     }
 
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
@@ -99,12 +99,12 @@ impl Config {
 }
 
 #[cfg(test)]
-impl Config {
-    pub(crate) const DEFAULT: Self = Self::InjectChecks(CheckConfig::DEFAULT);
+impl Mode {
+    pub(crate) const DEFAULT: Self = Mode::InjectChecks(CheckSettings::DEFAULT);
 }
 
 #[cfg(test)]
-impl CheckConfig {
+impl CheckSettings {
     pub(crate) const DEFAULT: Self = Self {
         does_print: false,
         does_panic: false,

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -26,6 +26,10 @@ pub struct CheckConfig {
 }
 
 impl Config {
+    pub fn changes_anything(&self) -> bool {
+        !matches!(self, Self::ChangeNothing)
+    }
+
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -16,13 +16,13 @@ impl Config {
     ) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
-        let ident = &item_struct.ident;
-        let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
-        let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;
-
         item_struct.to_tokens(&mut tokens);
 
-        if let Self::Static = self {
+        if !matches!(self, Self::Nothing) {
+            let ident = &item_struct.ident;
+            let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
+            let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;
+
             let spec_impl: ItemImpl = parse_quote! {
                 #[doc(hidden)]
                 #[allow(warnings)]

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -22,7 +22,7 @@ impl Config {
 
         item_struct.to_tokens(&mut tokens);
 
-        if self.embed_spec {
+        if let Self::Static = self {
             let spec_impl: ItemImpl = parse_quote! {
                 #[doc(hidden)]
                 #[allow(warnings)]
@@ -47,7 +47,7 @@ impl Config {
 
         item_enum.to_tokens(&mut tokens);
 
-        if self.embed_spec {
+        if let Self::Static = self {
             let spec_impl: ItemImpl = parse_quote! {
                 #[doc(hidden)]
                 #[allow(warnings)]

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -6,9 +6,9 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{ItemEnum, ItemImpl, ItemStruct, Result, parse_quote};
 
-use crate::{DataSpec, instrument::Config};
+use crate::{DataSpec, instrument::Mode};
 
-impl Config {
+impl Mode {
     pub fn instrument_item_struct(
         &self,
         spec: DataSpec,
@@ -47,7 +47,7 @@ impl Config {
 
         item_enum.to_tokens(&mut tokens);
 
-        if let Self::EmbedSpecs = self {
+        if let Mode::EmbedSpecs = self {
             let spec_impl: ItemImpl = parse_quote! {
                 #[doc(hidden)]
                 #[allow(warnings)]

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -18,7 +18,7 @@ impl Config {
 
         item_struct.to_tokens(&mut tokens);
 
-        if !matches!(self, Self::Nothing) {
+        if !matches!(self, Self::ChangeNothing) {
             let ident = &item_struct.ident;
             let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
             let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;
@@ -47,7 +47,7 @@ impl Config {
 
         item_enum.to_tokens(&mut tokens);
 
-        if let Self::Static = self {
+        if let Self::EmbedSpecs = self {
             let spec_impl: ItemImpl = parse_quote! {
                 #[doc(hidden)]
                 #[allow(warnings)]

--- a/crates/anodized-core/src/instrument/data.rs
+++ b/crates/anodized-core/src/instrument/data.rs
@@ -18,7 +18,7 @@ impl Config {
 
         item_struct.to_tokens(&mut tokens);
 
-        if !matches!(self, Self::ChangeNothing) {
+        if self.changes_anything() {
             let ident = &item_struct.ident;
             let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
             let statements = Self::build_precondition_fn_body(&[], &spec.maintains).stmts;

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -1,4 +1,4 @@
-use crate::{DataSpec, instrument::Config, test_util::assert_tokens_eq};
+use crate::{DataSpec, instrument::Mode, test_util::assert_tokens_eq};
 
 use proc_macro2::TokenStream;
 use syn::{ItemEnum, ItemStruct, parse_quote};
@@ -46,7 +46,7 @@ fn embed_spec_item_struct() {
         }
     };
 
-    let observed = Config::EmbedSpecs
+    let observed = Mode::EmbedSpecs
         .instrument_item_struct(struct_spec, item_struct)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -98,7 +98,7 @@ fn embed_spec_item_enum() {
         }
     };
 
-    let observed = Config::EmbedSpecs
+    let observed = Mode::EmbedSpecs
         .instrument_item_enum(struct_spec, item_enum)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -46,7 +46,7 @@ fn embed_spec_item_struct() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Config::Static
         .instrument_item_struct(struct_spec, item_struct)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -98,7 +98,7 @@ fn embed_spec_item_enum() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Config::Static
         .instrument_item_enum(struct_spec, item_enum)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -46,7 +46,7 @@ fn embed_spec_item_struct() {
         }
     };
 
-    let observed = Config::Static
+    let observed = Config::EmbedSpecs
         .instrument_item_struct(struct_spec, item_struct)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -98,7 +98,7 @@ fn embed_spec_item_enum() {
         }
     };
 
-    let observed = Config::Static
+    let observed = Config::EmbedSpecs
         .instrument_item_enum(struct_spec, item_enum)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -11,12 +11,18 @@ use syn::{
 };
 
 use crate::{
-    Capture, PostCondition, PreCondition, Spec, instrument::Config, qualifiers::FnQualifiers,
+    Capture, PostCondition, PreCondition, Spec,
+    instrument::{Config, RuntimeConfig},
+    qualifiers::FnQualifiers,
 };
 
 impl Config {
     pub fn instrument_fn(&self, spec: &Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
         self.instrument_loops_in_fn_body(body)?;
+
+        let Self::Dynamic(check_config) = self else {
+            return Ok(());
+        };
 
         let is_async = sig.asyncness.is_some();
 
@@ -27,7 +33,7 @@ impl Config {
         };
 
         // Generate the new, instrumented function body.
-        let new_body = self.instrument_fn_body(spec, body, is_async, &return_type)?;
+        let new_body = check_config.instrument_fn_body(spec, body, is_async, &return_type)?;
 
         // Replace the old function body with the new one.
         *body = new_body;
@@ -204,7 +210,9 @@ impl Config {
             }
         })
     }
+}
 
+impl RuntimeConfig {
     fn instrument_fn_body(
         &self,
         spec: &Spec,
@@ -212,11 +220,6 @@ impl Config {
         is_async: bool,
         return_type: &syn::Type,
     ) -> Result<Block> {
-        // Exit early when all instrumentation is off.
-        if !self.has_effect() {
-            return Ok(original_body.clone());
-        }
-
         // The identifier for the return value binding.
         let output_ident = Pat::Ident(PatIdent {
             attrs: vec![],
@@ -307,7 +310,7 @@ impl Config {
             postcondition_clauses.push(parse_quote!(true));
         }
 
-        let do_run_checks = self.emit_print || self.emit_panic;
+        let do_run_checks = self.does_print || self.does_panic;
         let precond_fail_action = self.build_fail_action("precondition failed");
         let postcond_fail_action = self.build_fail_action("postcondition failed");
 
@@ -334,7 +337,7 @@ impl Config {
     }
 
     fn build_clause_eval(&self, cfg: Option<&Meta>, expr: &Expr, repr: &str) -> Expr {
-        if self.emit_print {
+        if self.does_print {
             let br_and_repr = format!("\n    {repr}");
             let cfg_guard = match cfg {
                 Some(meta) => quote! { !cfg!(#meta) || },
@@ -348,7 +351,7 @@ impl Config {
 
     fn build_fail_action(&self, message: &str) -> Option<Stmt> {
         let message_and_errors = format!("{message}:{{__anodized_errors}}");
-        match (self.emit_print, self.emit_panic) {
+        match (self.does_print, self.does_panic) {
             (true, true) => Some(parse_quote! { panic!(#message_and_errors); }),
             (true, false) => Some(parse_quote! { eprintln!(#message_and_errors); }),
             (false, true) => Some(parse_quote! { panic!(#message); }),

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -12,7 +12,7 @@ use syn::{
 
 use crate::{
     Capture, PostCondition, PreCondition, Spec,
-    instrument::{Config, RuntimeConfig},
+    instrument::{CheckConfig, Config},
     qualifiers::FnQualifiers,
 };
 
@@ -20,7 +20,7 @@ impl Config {
     pub fn instrument_fn(&self, spec: &Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
         self.instrument_loops_in_fn_body(body)?;
 
-        let Self::Dynamic(check_config) = self else {
+        let Self::InjectChecks(check_config) = self else {
             return Ok(());
         };
 
@@ -212,7 +212,7 @@ impl Config {
     }
 }
 
-impl RuntimeConfig {
+impl CheckConfig {
     fn instrument_fn_body(
         &self,
         spec: &Spec,

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -12,15 +12,15 @@ use syn::{
 
 use crate::{
     Capture, PostCondition, PreCondition, Spec,
-    instrument::{CheckConfig, Config},
+    instrument::{CheckSettings, Mode},
     qualifiers::FnQualifiers,
 };
 
-impl Config {
+impl Mode {
     pub fn instrument_fn(&self, spec: &Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
         self.instrument_loops_in_fn_body(body)?;
 
-        let Self::InjectChecks(check_config) = self else {
+        let Mode::InjectChecks(check_config) = self else {
             return Ok(());
         };
 
@@ -212,7 +212,7 @@ impl Config {
     }
 }
 
-impl CheckConfig {
+impl CheckSettings {
     fn instrument_fn_body(
         &self,
         spec: &Spec,

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -4,9 +4,8 @@ use super::*;
 use proc_macro2::TokenStream;
 use syn::{Block, ItemFn, Type, parse_quote};
 
-#[test]
-fn embed_spec_item_fn() {
-    let fn_spec: Spec = parse_quote! {
+fn make_complex_spec() -> Spec {
+    parse_quote! {
         requires: COND_1,
         #[cfg(META_1)]
         requires: [COND_2, COND_3],
@@ -24,7 +23,12 @@ fn embed_spec_item_fn() {
             COND_8,
             |PAT_2: TYPE| COND_9,
         ],
-    };
+    }
+}
+
+#[test]
+fn embed_spec_item_fn() {
+    let fn_spec = make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY
@@ -73,6 +77,54 @@ fn embed_spec_item_fn() {
     assert_tokens_eq(&observed, &expected);
 }
 
+#[test]
+fn default_instrument_item_fn() {
+    let fn_spec = make_complex_spec();
+    let item_fn: ItemFn = parse_quote! {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            if false {
+                let mut __anodized_errors = String::new();
+                let __anodized_precond = (|| -> bool { COND_1 })()
+                    & (|| -> bool { COND_2 })()
+                    & (|| -> bool { COND_3 })()
+                    & (|| -> bool { COND_4 })()
+                    & (|| -> bool { COND_5 })()
+                    & (|| -> bool { COND_6 })();
+                if !__anodized_precond {}
+            }
+            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output): (_, _, RET_TYPE) = (
+                (|| EXPR_1)(),
+                (|| EXPR_2)(),
+                (|| {
+                    BODY
+                })(),
+            );
+            if false {
+                let mut __anodized_errors = String::new();
+                let __anodized_postcond = (|| -> bool { COND_4 })()
+                    & (|| -> bool { COND_5 })()
+                    & (|| -> bool { COND_6 })()
+                    & (|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
+                    & (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
+                    & (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output);
+                if !__anodized_postcond {}
+            }
+            __anodized_output
+        }
+    };
+
+    let observed = Config::DEFAULT
+        .instrument_item_fn(fn_spec, item_fn)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
 fn make_fn_body() -> Block {
     parse_quote! {
         {
@@ -116,7 +168,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -131,7 +183,7 @@ fn requires_disable_runtime_checks() {
     let ret_type = make_return_type();
     let is_async = false;
 
-    let observed = Config::DEFAULT
+    let observed = RuntimeConfig::DEFAULT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     let expected: Block = parse_quote! {
@@ -184,7 +236,7 @@ fn requires_no_panic_runtime() {
         }
     };
 
-    let observed = Config::PRINT
+    let observed = RuntimeConfig::PRINT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -222,7 +274,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -259,7 +311,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -300,7 +352,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -339,7 +391,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -380,7 +432,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -424,7 +476,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -468,7 +520,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -520,7 +572,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -558,7 +610,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -606,7 +658,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -654,7 +706,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -708,7 +760,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -776,7 +828,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -824,7 +876,7 @@ fn captures() {
         }
     };
 
-    let observed = Config::PRINT_AND_PANIC
+    let observed = RuntimeConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -73,7 +73,7 @@ fn embed_spec_item_fn() {
         }
     };
 
-    let observed = Config::EmbedSpecs
+    let observed = Mode::EmbedSpecs
         .instrument_item_fn(fn_spec, item_fn)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -121,9 +121,7 @@ fn default_instrument_item_fn() {
         }
     };
 
-    let observed = Config::DEFAULT
-        .instrument_item_fn(fn_spec, item_fn)
-        .unwrap();
+    let observed = Mode::DEFAULT.instrument_item_fn(fn_spec, item_fn).unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -170,7 +168,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -185,7 +183,7 @@ fn requires_disable_runtime_checks() {
     let ret_type = make_return_type();
     let is_async = false;
 
-    let observed = CheckConfig::DEFAULT
+    let observed = CheckSettings::DEFAULT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     let expected: Block = parse_quote! {
@@ -238,7 +236,7 @@ fn requires_no_panic_runtime() {
         }
     };
 
-    let observed = CheckConfig::PRINT
+    let observed = CheckSettings::PRINT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -276,7 +274,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -313,7 +311,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -354,7 +352,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -393,7 +391,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -434,7 +432,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -478,7 +476,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -522,7 +520,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -574,7 +572,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -612,7 +610,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -660,7 +658,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -708,7 +706,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -762,7 +760,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -830,7 +828,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -878,7 +876,7 @@ fn captures() {
         }
     };
 
-    let observed = CheckConfig::PRINT_AND_PANIC
+    let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -96,9 +96,7 @@ fn embed_spec_item_fn() {
         }
     };
 
-    let observed = Config::DEFAULT
-        .instrument_item_fn(fn_spec, item_fn)
-        .unwrap();
+    let observed = Config::Static.instrument_item_fn(fn_spec, item_fn).unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -145,7 +143,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -251,7 +249,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -288,7 +286,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -329,7 +327,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -368,7 +366,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -409,7 +407,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -453,7 +451,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -497,7 +495,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -549,7 +547,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -587,7 +585,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -635,7 +633,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -683,7 +681,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -737,7 +735,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -805,7 +803,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -853,7 +851,7 @@ fn captures() {
         }
     };
 
-    let observed = Config::PANIC
+    let observed = Config::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -73,7 +73,9 @@ fn embed_spec_item_fn() {
         }
     };
 
-    let observed = Config::Static.instrument_item_fn(fn_spec, item_fn).unwrap();
+    let observed = Config::EmbedSpecs
+        .instrument_item_fn(fn_spec, item_fn)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
@@ -168,7 +170,7 @@ fn simple_requires() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -183,7 +185,7 @@ fn requires_disable_runtime_checks() {
     let ret_type = make_return_type();
     let is_async = false;
 
-    let observed = RuntimeConfig::DEFAULT
+    let observed = CheckConfig::DEFAULT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     let expected: Block = parse_quote! {
@@ -236,7 +238,7 @@ fn requires_no_panic_runtime() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT
+    let observed = CheckConfig::PRINT
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -274,7 +276,7 @@ fn simple_maintains() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -311,7 +313,7 @@ fn simple_ensures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -352,7 +354,7 @@ fn simple_requires_and_maintains() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -391,7 +393,7 @@ fn simple_requires_and_ensures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -432,7 +434,7 @@ fn simple_maintains_and_ensures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -476,7 +478,7 @@ fn simple_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -520,7 +522,7 @@ fn simple_async_requires_maintains_and_ensures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -572,7 +574,7 @@ fn multiple_conditions_in_clauses() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -610,7 +612,7 @@ fn binds_parameter() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -658,7 +660,7 @@ fn ensures_with_mixed_conditions() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -706,7 +708,7 @@ fn cfg_attributes() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -760,7 +762,7 @@ fn cfg_on_single_and_list_conditions() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -828,7 +830,7 @@ fn complex_mixed_conditions() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -876,7 +878,7 @@ fn captures() {
         }
     };
 
-    let observed = RuntimeConfig::PRINT_AND_PANIC
+    let observed = CheckConfig::PRINT_AND_PANIC
         .instrument_fn_body(&spec, &body, is_async, &ret_type)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -65,34 +65,7 @@ fn embed_spec_item_fn() {
         }
 
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            if false {
-                let mut __anodized_errors = String::new();
-                let __anodized_precond = (|| -> bool { COND_1 })()
-                    & (|| -> bool { COND_2 })()
-                    & (|| -> bool { COND_3 })()
-                    & (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })();
-                if !__anodized_precond {}
-            }
-            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output): (_, _, RET_TYPE) = (
-                (|| EXPR_1)(),
-                (|| EXPR_2)(),
-                (|| {
-                    BODY
-                })(),
-            );
-            if false {
-                let mut __anodized_errors = String::new();
-                let __anodized_postcond = (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })()
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
-                    & (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output);
-                if !__anodized_postcond {}
-            }
-            __anodized_output
+            BODY
         }
     };
 

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -30,7 +30,7 @@ impl Config {
     }
 
     fn instrument_loop_body(&self, spec: LoopSpec, stmts: &mut Vec<Stmt>) {
-        if let Self::Static = self {
+        if let Self::EmbedSpecs = self {
             let maintains_block = Self::build_precondition_fn_body(&[], &spec.maintains);
             stmts.insert(
                 0,

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -30,7 +30,7 @@ impl Config {
     }
 
     fn instrument_loop_body(&self, spec: LoopSpec, stmts: &mut Vec<Stmt>) {
-        if self.embed_spec {
+        if let Self::Static = self {
             let maintains_block = Self::build_precondition_fn_body(&[], &spec.maintains);
             stmts.insert(
                 0,

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -11,10 +11,10 @@ use syn::{
 
 use crate::{
     LoopSpec,
-    instrument::{Config, find_spec_attr},
+    instrument::{Mode, find_spec_attr},
 };
 
-impl Config {
+impl Mode {
     pub fn instrument_loops_in_fn_body(&self, body: &mut Block) -> Result<()> {
         let mut visitor = LoopSpecVisitor::new(self);
         visitor.visit_block_mut(body);
@@ -68,12 +68,12 @@ impl Config {
 }
 
 struct LoopSpecVisitor<'a> {
-    config: &'a Config,
+    config: &'a Mode,
     errors: Option<Error>,
 }
 
 impl<'a> LoopSpecVisitor<'a> {
-    fn new(config: &'a Config) -> Self {
+    fn new(config: &'a Mode) -> Self {
         Self {
             config,
             errors: None,

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn::{ExprForLoop, ExprWhile, parse_quote};
 
-use crate::{LoopSpec, instrument::Config, test_util::assert_tokens_eq};
+use crate::{LoopSpec, instrument::Mode, test_util::assert_tokens_eq};
 
 #[test]
 fn embed_spec_expr_while() {
@@ -33,7 +33,7 @@ fn embed_spec_expr_while() {
         }
     };
 
-    Config::EmbedSpecs.instrument_expr_while(while_spec, &mut expr_while);
+    Mode::EmbedSpecs.instrument_expr_while(while_spec, &mut expr_while);
     let observed = expr_while;
 
     assert_tokens_eq(&observed, &expected);
@@ -65,7 +65,7 @@ fn embed_spec_expr_for() {
         }
     };
 
-    Config::EmbedSpecs.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
+    Mode::EmbedSpecs.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
     let observed = expr_for_loop;
 
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -33,7 +33,7 @@ fn embed_spec_expr_while() {
         }
     };
 
-    Config::Static.instrument_expr_while(while_spec, &mut expr_while);
+    Config::EmbedSpecs.instrument_expr_while(while_spec, &mut expr_while);
     let observed = expr_while;
 
     assert_tokens_eq(&observed, &expected);
@@ -65,7 +65,7 @@ fn embed_spec_expr_for() {
         }
     };
 
-    Config::Static.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
+    Config::EmbedSpecs.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
     let observed = expr_for_loop;
 
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -33,7 +33,7 @@ fn embed_spec_expr_while() {
         }
     };
 
-    Config::DEFAULT.instrument_expr_while(while_spec, &mut expr_while);
+    Config::Static.instrument_expr_while(while_spec, &mut expr_while);
     let observed = expr_while;
 
     assert_tokens_eq(&observed, &expected);
@@ -65,7 +65,7 @@ fn embed_spec_expr_for() {
         }
     };
 
-    Config::DEFAULT.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
+    Config::Static.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
     let observed = expr_for_loop;
 
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -51,80 +51,85 @@ impl Config {
                         None => Spec::empty(),
                     };
 
-                    match self {
-                        Self::Nothing => {}
-                        Self::Static => {
-                            let attrs: [Attribute; 2] = [
-                                parse_quote!(#[doc(hidden)]),
-                                parse_quote!(#[allow(warnings)]),
-                            ];
+                    let attrs: [Attribute; 2] = [
+                        parse_quote!(#[doc(hidden)]),
+                        parse_quote!(#[allow(warnings)]),
+                    ];
 
-                            // Embed `spec` elements as `__anodized_fn_*` items.
-                            let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
-                                &attrs,
-                                "__anodized_fn_qualifiers_trait",
-                                fn_spec.qualifiers,
-                                &func.sig.ident,
-                            );
-                            let spec_qualifiers_const = Self::build_qualifier_const_item(
-                                &attrs,
-                                "__anodized_fn_qualifiers",
-                                fn_spec.qualifiers,
-                                &func.sig.ident,
-                            );
-                            let spec_requires_fn = TraitItemFn {
-                                attrs: attrs.to_vec(),
-                                sig: Self::build_precondition_fn_sig(
-                                    "__anodized_fn_requires",
-                                    &func.sig,
-                                ),
-                                default: Some(Self::build_precondition_fn_body(
-                                    &fn_spec.requires,
-                                    &fn_spec.maintains,
-                                )),
-                                semi_token: None,
-                            };
-                            let spec_ensures_fn = TraitItemFn {
-                                attrs: attrs.to_vec(),
-                                sig: Self::build_postcondition_fn_sig(
-                                    "__anodized_fn_ensures",
-                                    &func.sig,
-                                ),
-                                default: Some(Self::build_postcondition_fn_body(
-                                    &fn_spec.maintains,
-                                    &fn_spec.captures,
-                                    &fn_spec.ensures,
-                                    &func.sig.output,
-                                )?),
-                                semi_token: None,
-                            };
+                    if let Self::Static = self {
+                        // Embed `spec` elements as `__anodized_fn_*` items.
+                        let spec_requires_fn = TraitItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_precondition_fn_sig(
+                                "__anodized_fn_requires",
+                                &func.sig,
+                            ),
+                            default: Some(Self::build_precondition_fn_body(
+                                &fn_spec.requires,
+                                &fn_spec.maintains,
+                            )),
+                            semi_token: None,
+                        };
+                        let spec_ensures_fn = TraitItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_postcondition_fn_sig(
+                                "__anodized_fn_ensures",
+                                &func.sig,
+                            ),
+                            default: Some(Self::build_postcondition_fn_body(
+                                &fn_spec.maintains,
+                                &fn_spec.captures,
+                                &fn_spec.ensures,
+                                &func.sig.output,
+                            )?),
+                            semi_token: None,
+                        };
 
-                            new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
-                            new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
-                            new_trait_items.push(TraitItem::Fn(spec_requires_fn));
-                            new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
-                        }
-                        Self::Dynamic(_) => {
-                            let mangled_ident = mangle_ident(&func.sig.ident);
+                        new_trait_items.push(TraitItem::Fn(spec_requires_fn));
+                        new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
+                    }
 
-                            let mut mangled_fn = func.clone();
-                            mangled_fn.sig.ident = mangled_ident.clone();
-                            mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
-                            mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
-                            new_trait_items.push(TraitItem::Fn(mangled_fn));
+                    if !matches!(self, Self::Nothing) {
+                        let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers_trait",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
+                        new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
+                        new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
+                    }
 
-                            let call_args = build_call_args(&func.sig.inputs)?;
-                            let forwarding_body: Block = parse_quote!({
-                                Self::#mangled_ident(#(#call_args),*)
-                            });
-                            func.default = Some(forwarding_body);
-                            func.semi_token = None;
+                    if let Some(default_body) = &mut func.default {
+                        // Handle loop specs in the body of the default impl, without any checks.
+                        let empty_spec = Spec::empty();
+                        self.instrument_fn(&empty_spec, &func.sig, default_body)?;
+                    }
 
-                            if let Some(default_body) = &mut func.default {
-                                // NOTE: Needed to handle loop specs in the body of the default impl.
-                                self.instrument_fn(&fn_spec, &func.sig, default_body)?;
-                            }
-                        }
+                    if let Self::Dynamic(_) = self {
+                        let mangled_ident = mangle_ident(&func.sig.ident);
+
+                        let mut mangled_fn = func.clone();
+                        mangled_fn.sig.ident = mangled_ident.clone();
+                        mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
+                        mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
+                        new_trait_items.push(TraitItem::Fn(mangled_fn));
+
+                        let call_args = build_call_args(&func.sig.inputs)?;
+                        let mut forwarding_body: Block = parse_quote!({
+                            Self::#mangled_ident(#(#call_args),*)
+                        });
+
+                        self.instrument_fn(&fn_spec, &func.sig, &mut forwarding_body)?;
+
+                        func.default = Some(forwarding_body);
+                        func.semi_token = None;
                     }
 
                     new_trait_items.push(TraitItem::Fn(func));
@@ -206,76 +211,78 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         None => Spec::empty(),
                     };
 
-                    match self {
-                        Self::Nothing => {}
-                        Self::Static => {
-                            let attrs: [Attribute; 2] = [
-                                parse_quote!(#[doc(hidden)]),
-                                parse_quote!(#[allow(warnings)]),
-                            ];
+                    let attrs: [Attribute; 2] = [
+                        parse_quote!(#[doc(hidden)]),
+                        parse_quote!(#[allow(warnings)]),
+                    ];
 
-                            // Embed `spec` elements as `__anodized_fn_*` items.
-                            let spec_qualifiers_const = Self::build_qualifier_const_item(
-                                &attrs,
-                                "__anodized_fn_qualifiers",
-                                fn_spec.qualifiers,
+                    if let Self::Static = self {
+                        // Embed `spec` elements as `__anodized_fn_*` items.
+                        let spec_requires_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_precondition_fn_sig(
+                                "__anodized_fn_requires",
+                                &func.sig,
+                            ),
+                            block: Self::build_precondition_fn_body(
+                                &fn_spec.requires,
+                                &fn_spec.maintains,
+                            ),
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+                        let spec_ensures_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_postcondition_fn_sig(
+                                "__anodized_fn_ensures",
+                                &func.sig,
+                            ),
+                            block: Self::build_postcondition_fn_body(
+                                &fn_spec.maintains,
+                                &fn_spec.captures,
+                                &fn_spec.ensures,
+                                &func.sig.output,
+                            )?,
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+
+                        new_items.push(ImplItem::Fn(spec_requires_fn));
+                        new_items.push(ImplItem::Fn(spec_ensures_fn));
+                    }
+
+                    if !matches!(self, Self::Nothing) {
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers",
+                            fn_spec.qualifiers,
+                            &func.sig.ident,
+                        );
+                        new_items.push(ImplItem::Const(spec_qualifiers_const));
+                    }
+
+                    if let Self::Dynamic(_) = self {
+                        self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
+
+                        // Add a compile-time check to the body.
+                        func.block.stmts.insert(
+                            0,
+                            Self::build_qualifier_check_stmt(
                                 &func.sig.ident,
-                            );
-                            let spec_requires_fn = ImplItemFn {
-                                attrs: attrs.to_vec(),
-                                sig: Self::build_precondition_fn_sig(
-                                    "__anodized_fn_requires",
-                                    &func.sig,
-                                ),
-                                block: Self::build_precondition_fn_body(
-                                    &fn_spec.requires,
-                                    &fn_spec.maintains,
-                                ),
-                                vis: Visibility::Inherited,
-                                defaultness: None,
-                            };
-                            let spec_ensures_fn = ImplItemFn {
-                                attrs: attrs.to_vec(),
-                                sig: Self::build_postcondition_fn_sig(
-                                    "__anodized_fn_ensures",
-                                    &func.sig,
-                                ),
-                                block: Self::build_postcondition_fn_body(
-                                    &fn_spec.maintains,
-                                    &fn_spec.captures,
-                                    &fn_spec.ensures,
-                                    &func.sig.output,
-                                )?,
-                                vis: Visibility::Inherited,
-                                defaultness: None,
-                            };
+                                &the_impl.self_ty,
+                                trait_path,
+                            ),
+                        );
 
-                            new_items.push(ImplItem::Const(spec_qualifiers_const));
-                            new_items.push(ImplItem::Fn(spec_requires_fn));
-                            new_items.push(ImplItem::Fn(spec_ensures_fn));
-                        }
-                        Self::Dynamic(_) => {
-                            self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
+                        func.sig.ident = mangle_ident(&func.sig.ident);
 
-                            // Add a compile-time check to the body.
-                            func.block.stmts.insert(
-                                0,
-                                Self::build_qualifier_check_stmt(
-                                    &func.sig.ident,
-                                    &the_impl.self_ty,
-                                    trait_path,
-                                ),
-                            );
-
-                            func.sig.ident = mangle_ident(&func.sig.ident);
-
-                            // Add a default `#[inline]` attribute unless one is already there.
-                            // The caller can supress this with `#[inline(never)]`
-                            if !has_inline_attr(&func.attrs) {
-                                func.attrs.push(parse_quote!(#[inline]));
-                            }
+                        // Add a default `#[inline]` attribute unless one is already there.
+                        // The caller can supress this with `#[inline(never)]`
+                        if !has_inline_attr(&func.attrs) {
+                            func.attrs.push(parse_quote!(#[inline]));
                         }
                     }
+
                     new_items.push(ImplItem::Fn(func));
                 }
                 ImplItem::Const(mut const_item) => {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -51,7 +51,7 @@ impl Config {
                         None => Spec::empty(),
                     };
 
-                    if self.embed_spec {
+                    if let Self::Static = self {
                         let attrs: [Attribute; 2] = [
                             parse_quote!(#[doc(hidden)]),
                             parse_quote!(#[allow(warnings)]),
@@ -205,7 +205,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         None => Spec::empty(),
                     };
 
-                    if self.embed_spec {
+                    if let Self::Static = self {
                         let attrs: [Attribute; 2] = [
                             parse_quote!(#[doc(hidden)]),
                             parse_quote!(#[allow(warnings)]),
@@ -254,7 +254,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
 
                     self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
-                    if self.embed_spec {
+                    if let Self::Static = self {
                         // Add a compile-time check to the body.
                         func.block.stmts.insert(
                             0,

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -39,93 +39,94 @@ impl Config {
             match item {
                 TraitItem::Fn(mut func) => {
                     let (spec_attr, other_attrs) = find_spec_attr(func.attrs)?;
+                    func.attrs = other_attrs;
                     // NOTE: We have no way of knowing which attributes are
                     //   "external" - meant for the interface and belong on the wrapper,
                     //   "internal" - meant for the mangled implementation.
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
-                    func.attrs = other_attrs.clone();
 
                     let fn_spec: Spec = match spec_attr {
                         Some(spec_attr) => spec_attr.parse_args()?,
                         None => Spec::empty(),
                     };
 
-                    if let Self::Static = self {
-                        let attrs: [Attribute; 2] = [
-                            parse_quote!(#[doc(hidden)]),
-                            parse_quote!(#[allow(warnings)]),
-                        ];
+                    match self {
+                        Self::Nothing => {}
+                        Self::Static => {
+                            let attrs: [Attribute; 2] = [
+                                parse_quote!(#[doc(hidden)]),
+                                parse_quote!(#[allow(warnings)]),
+                            ];
 
-                        // Embed `spec` elements as `__anodized_fn_*` items.
-                        let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
-                            &attrs,
-                            "__anodized_fn_qualifiers_trait",
-                            fn_spec.qualifiers,
-                            &func.sig.ident,
-                        );
-                        let spec_qualifiers_const = Self::build_qualifier_const_item(
-                            &attrs,
-                            "__anodized_fn_qualifiers",
-                            fn_spec.qualifiers,
-                            &func.sig.ident,
-                        );
-                        let spec_requires_fn = TraitItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_precondition_fn_sig(
-                                "__anodized_fn_requires",
-                                &func.sig,
-                            ),
-                            default: Some(Self::build_precondition_fn_body(
-                                &fn_spec.requires,
-                                &fn_spec.maintains,
-                            )),
-                            semi_token: None,
-                        };
-                        let spec_ensures_fn = TraitItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_postcondition_fn_sig(
-                                "__anodized_fn_ensures",
-                                &func.sig,
-                            ),
-                            default: Some(Self::build_postcondition_fn_body(
-                                &fn_spec.maintains,
-                                &fn_spec.captures,
-                                &fn_spec.ensures,
-                                &func.sig.output,
-                            )?),
-                            semi_token: None,
-                        };
+                            // Embed `spec` elements as `__anodized_fn_*` items.
+                            let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
+                                &attrs,
+                                "__anodized_fn_qualifiers_trait",
+                                fn_spec.qualifiers,
+                                &func.sig.ident,
+                            );
+                            let spec_qualifiers_const = Self::build_qualifier_const_item(
+                                &attrs,
+                                "__anodized_fn_qualifiers",
+                                fn_spec.qualifiers,
+                                &func.sig.ident,
+                            );
+                            let spec_requires_fn = TraitItemFn {
+                                attrs: attrs.to_vec(),
+                                sig: Self::build_precondition_fn_sig(
+                                    "__anodized_fn_requires",
+                                    &func.sig,
+                                ),
+                                default: Some(Self::build_precondition_fn_body(
+                                    &fn_spec.requires,
+                                    &fn_spec.maintains,
+                                )),
+                                semi_token: None,
+                            };
+                            let spec_ensures_fn = TraitItemFn {
+                                attrs: attrs.to_vec(),
+                                sig: Self::build_postcondition_fn_sig(
+                                    "__anodized_fn_ensures",
+                                    &func.sig,
+                                ),
+                                default: Some(Self::build_postcondition_fn_body(
+                                    &fn_spec.maintains,
+                                    &fn_spec.captures,
+                                    &fn_spec.ensures,
+                                    &func.sig.output,
+                                )?),
+                                semi_token: None,
+                            };
 
-                        new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
-                        new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
-                        new_trait_items.push(TraitItem::Fn(spec_requires_fn));
-                        new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
+                            new_trait_items.push(TraitItem::Const(spec_trait_qualifiers_const));
+                            new_trait_items.push(TraitItem::Const(spec_qualifiers_const));
+                            new_trait_items.push(TraitItem::Fn(spec_requires_fn));
+                            new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
+                        }
+                        Self::Dynamic(_) => {
+                            let mangled_ident = mangle_ident(&func.sig.ident);
+
+                            let mut mangled_fn = func.clone();
+                            mangled_fn.sig.ident = mangled_ident.clone();
+                            mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
+                            mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
+                            new_trait_items.push(TraitItem::Fn(mangled_fn));
+
+                            let call_args = build_call_args(&func.sig.inputs)?;
+                            let forwarding_body: Block = parse_quote!({
+                                Self::#mangled_ident(#(#call_args),*)
+                            });
+                            func.default = Some(forwarding_body);
+                            func.semi_token = None;
+
+                            if let Some(default_body) = &mut func.default {
+                                // NOTE: Needed to handle loop specs in the body of the default impl.
+                                self.instrument_fn(&fn_spec, &func.sig, default_body)?;
+                            }
+                        }
                     }
 
-                    if self.has_effect() {
-                        let mangled_ident = mangle_ident(&func.sig.ident);
-
-                        let mut mangled_fn = func.clone();
-                        mangled_fn.sig.ident = mangled_ident.clone();
-                        mangled_fn.attrs.retain(|attr| !attr.path().is_ident("doc"));
-                        mangled_fn.attrs.push(parse_quote!(#[doc(hidden)]));
-                        new_trait_items.push(TraitItem::Fn(mangled_fn));
-
-                        let call_args = build_call_args(&func.sig.inputs)?;
-                        let forwarding_body: Block = parse_quote!({
-                            Self::#mangled_ident(#(#call_args),*)
-                        });
-                        func.default = Some(forwarding_body);
-                        func.semi_token = None;
-                    }
-
-                    func.attrs = other_attrs;
-
-                    if let Some(default_body) = &mut func.default {
-                        // NOTE: Needed to handle loop specs in the body of the default impl.
-                        self.instrument_fn(&fn_spec, &func.sig, default_body)?;
-                    }
                     new_trait_items.push(TraitItem::Fn(func));
                 }
                 TraitItem::Const(mut const_item) => {
@@ -205,74 +206,74 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         None => Spec::empty(),
                     };
 
-                    if let Self::Static = self {
-                        let attrs: [Attribute; 2] = [
-                            parse_quote!(#[doc(hidden)]),
-                            parse_quote!(#[allow(warnings)]),
-                        ];
+                    match self {
+                        Self::Nothing => {}
+                        Self::Static => {
+                            let attrs: [Attribute; 2] = [
+                                parse_quote!(#[doc(hidden)]),
+                                parse_quote!(#[allow(warnings)]),
+                            ];
 
-                        // Embed `spec` elements as `__anodized_fn_*` items.
-                        let spec_qualifiers_const = Self::build_qualifier_const_item(
-                            &attrs,
-                            "__anodized_fn_qualifiers",
-                            fn_spec.qualifiers,
-                            &func.sig.ident,
-                        );
-                        let spec_requires_fn = ImplItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_precondition_fn_sig(
-                                "__anodized_fn_requires",
-                                &func.sig,
-                            ),
-                            block: Self::build_precondition_fn_body(
-                                &fn_spec.requires,
-                                &fn_spec.maintains,
-                            ),
-                            vis: Visibility::Inherited,
-                            defaultness: None,
-                        };
-                        let spec_ensures_fn = ImplItemFn {
-                            attrs: attrs.to_vec(),
-                            sig: Self::build_postcondition_fn_sig(
-                                "__anodized_fn_ensures",
-                                &func.sig,
-                            ),
-                            block: Self::build_postcondition_fn_body(
-                                &fn_spec.maintains,
-                                &fn_spec.captures,
-                                &fn_spec.ensures,
-                                &func.sig.output,
-                            )?,
-                            vis: Visibility::Inherited,
-                            defaultness: None,
-                        };
-
-                        new_items.push(ImplItem::Const(spec_qualifiers_const));
-                        new_items.push(ImplItem::Fn(spec_requires_fn));
-                        new_items.push(ImplItem::Fn(spec_ensures_fn));
-                    }
-
-                    self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
-
-                    if let Self::Static = self {
-                        // Add a compile-time check to the body.
-                        func.block.stmts.insert(
-                            0,
-                            Self::build_qualifier_check_stmt(
+                            // Embed `spec` elements as `__anodized_fn_*` items.
+                            let spec_qualifiers_const = Self::build_qualifier_const_item(
+                                &attrs,
+                                "__anodized_fn_qualifiers",
+                                fn_spec.qualifiers,
                                 &func.sig.ident,
-                                &the_impl.self_ty,
-                                trait_path,
-                            ),
-                        );
-                    }
+                            );
+                            let spec_requires_fn = ImplItemFn {
+                                attrs: attrs.to_vec(),
+                                sig: Self::build_precondition_fn_sig(
+                                    "__anodized_fn_requires",
+                                    &func.sig,
+                                ),
+                                block: Self::build_precondition_fn_body(
+                                    &fn_spec.requires,
+                                    &fn_spec.maintains,
+                                ),
+                                vis: Visibility::Inherited,
+                                defaultness: None,
+                            };
+                            let spec_ensures_fn = ImplItemFn {
+                                attrs: attrs.to_vec(),
+                                sig: Self::build_postcondition_fn_sig(
+                                    "__anodized_fn_ensures",
+                                    &func.sig,
+                                ),
+                                block: Self::build_postcondition_fn_body(
+                                    &fn_spec.maintains,
+                                    &fn_spec.captures,
+                                    &fn_spec.ensures,
+                                    &func.sig.output,
+                                )?,
+                                vis: Visibility::Inherited,
+                                defaultness: None,
+                            };
 
-                    if self.has_effect() {
-                        func.sig.ident = mangle_ident(&func.sig.ident);
+                            new_items.push(ImplItem::Const(spec_qualifiers_const));
+                            new_items.push(ImplItem::Fn(spec_requires_fn));
+                            new_items.push(ImplItem::Fn(spec_ensures_fn));
+                        }
+                        Self::Dynamic(_) => {
+                            self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
-                        // Add a default `#[inline]` attribute unless one is already there.
-                        // The caller can supress this with `#[inline(never)]`
-                        if !has_inline_attr(&func.attrs) {
-                            func.attrs.push(parse_quote!(#[inline]));
+                            // Add a compile-time check to the body.
+                            func.block.stmts.insert(
+                                0,
+                                Self::build_qualifier_check_stmt(
+                                    &func.sig.ident,
+                                    &the_impl.self_ty,
+                                    trait_path,
+                                ),
+                            );
+
+                            func.sig.ident = mangle_ident(&func.sig.ident);
+
+                            // Add a default `#[inline]` attribute unless one is already there.
+                            // The caller can supress this with `#[inline(never)]`
+                            if !has_inline_attr(&func.attrs) {
+                                func.attrs.push(parse_quote!(#[inline]));
+                            }
                         }
                     }
                     new_items.push(ImplItem::Fn(func));

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -56,7 +56,7 @@ impl Config {
                         parse_quote!(#[allow(warnings)]),
                     ];
 
-                    if let Self::Static = self {
+                    if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.
                         let spec_requires_fn = TraitItemFn {
                             attrs: attrs.to_vec(),
@@ -89,7 +89,7 @@ impl Config {
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
                     }
 
-                    if !matches!(self, Self::Nothing) {
+                    if !matches!(self, Self::ChangeNothing) {
                         let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
                             "__anodized_fn_qualifiers_trait",
@@ -111,7 +111,7 @@ impl Config {
                         self.instrument_loops_in_fn_body(default_body)?;
                     }
 
-                    if let Self::Dynamic(_) = self {
+                    if let Self::InjectChecks(_) = self {
                         let mangled_ident = mangle_ident(&func.sig.ident);
 
                         let mut mangled_fn = func.clone();
@@ -215,7 +215,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         parse_quote!(#[allow(warnings)]),
                     ];
 
-                    if let Self::Static = self {
+                    if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.
                         let spec_requires_fn = ImplItemFn {
                             attrs: attrs.to_vec(),
@@ -250,7 +250,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         new_items.push(ImplItem::Fn(spec_ensures_fn));
                     }
 
-                    if !matches!(self, Self::Nothing) {
+                    if !matches!(self, Self::ChangeNothing) {
                         let spec_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
                             "__anodized_fn_qualifiers",
@@ -260,7 +260,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         new_items.push(ImplItem::Const(spec_qualifiers_const));
                     }
 
-                    if let Self::Dynamic(_) = self {
+                    if let Self::InjectChecks(_) = self {
                         self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
                         // Add a compile-time check to the body.

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -89,7 +89,7 @@ impl Config {
                         new_trait_items.push(TraitItem::Fn(spec_ensures_fn));
                     }
 
-                    if !matches!(self, Self::ChangeNothing) {
+                    if self.changes_anything() {
                         let spec_trait_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
                             "__anodized_fn_qualifiers_trait",
@@ -250,7 +250,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         new_items.push(ImplItem::Fn(spec_ensures_fn));
                     }
 
-                    if !matches!(self, Self::ChangeNothing) {
+                    if self.changes_anything() {
                         let spec_qualifiers_const = Self::build_qualifier_const_item(
                             &attrs,
                             "__anodized_fn_qualifiers",

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -10,10 +10,10 @@ use syn::{
 
 use crate::{
     DataSpec, Spec,
-    instrument::{Config, find_spec_attr, make_item_error},
+    instrument::{Mode, find_spec_attr, make_item_error},
 };
 
-impl Config {
+impl Mode {
     /// Expand trait items by mangling each method and adding a wrapper default impl.
     ///
     /// Mangling a function involves the following:
@@ -111,7 +111,7 @@ impl Config {
                         self.instrument_loops_in_fn_body(default_body)?;
                     }
 
-                    if let Self::InjectChecks(_) = self {
+                    if let Mode::InjectChecks(_) = self {
                         let mangled_ident = mangle_ident(&func.sig.ident);
 
                         let mut mangled_fn = func.clone();
@@ -260,7 +260,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         new_items.push(ImplItem::Const(spec_qualifiers_const));
                     }
 
-                    if let Self::InjectChecks(_) = self {
+                    if let Mode::InjectChecks(_) = self {
                         self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
 
                         // Add a compile-time check to the body.

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -107,9 +107,8 @@ impl Config {
                     }
 
                     if let Some(default_body) = &mut func.default {
-                        // Handle loop specs in the body of the default impl, without any checks.
-                        let empty_spec = Spec::empty();
-                        self.instrument_fn(&empty_spec, &func.sig, default_body)?;
+                        // Handle loop specs in the body of the default impl.
+                        self.instrument_loops_in_fn_body(default_body)?;
                     }
 
                     if let Self::Dynamic(_) = self {

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -26,14 +26,6 @@ fn embed_spec_item_trait() {
         trait TRAIT {
             #[doc(hidden)]
             #[allow(warnings)]
-            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
-
-            #[doc(hidden)]
-            #[allow(warnings)]
-            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
-
-            #[doc(hidden)]
-            #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
                 let __anodized_clause_1 = (| | -> bool { COND_1 })();
                 let __anodized_clause_2 = (| | -> bool { COND_2 })();
@@ -48,6 +40,14 @@ fn embed_spec_item_trait() {
                 let __anodized_clause_2 = (|PAT_1: &RET_TYPE| -> bool { COND_3 })(__anodized_output);
                 __anodized_clause_1 && __anodized_clause_2
             }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 BODY
@@ -83,10 +83,6 @@ fn embed_spec_item_impl_trait() {
         impl TRAIT for IMPL_TYPE {
             #[doc(hidden)]
             #[allow(warnings)]
-            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
-
-            #[doc(hidden)]
-            #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
                 let __anodized_clause_1 = (| | -> bool { COND_1 })();
                 let __anodized_clause_2 = (| | -> bool { COND_2 })();
@@ -101,6 +97,10 @@ fn embed_spec_item_impl_trait() {
                 let __anodized_clause_2 = (|PAT_1: &RET_TYPE| -> bool { COND_3 })(__anodized_output);
                 __anodized_clause_1 && __anodized_clause_2
             }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 BODY

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -55,7 +55,7 @@ fn embed_spec_item_trait() {
         }
     };
 
-    let observed = Config::Static
+    let observed = Config::EmbedSpecs
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -168,7 +168,7 @@ fn embed_spec_item_impl_trait() {
         }
     };
 
-    let observed = Config::Static
+    let observed = Config::EmbedSpecs
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -62,6 +62,66 @@ fn embed_spec_item_trait() {
 }
 
 #[test]
+fn default_instrument_item_trait() {
+    let trait_spec = DataSpec::empty();
+    let item_trait: ItemTrait = parse_quote! {
+        trait TRAIT {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let qualifier_bits = FnQualifiers::empty().bits();
+    let expected: TokenStream = parse_quote! {
+        trait TRAIT {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = (|| -> bool { COND_1 })()
+                        & (|| -> bool { COND_2 })();
+                    if !__anodized_precond {}
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
+                })());
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = (|| -> bool { COND_2 })()
+                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
+                    if !__anodized_postcond {}
+                }
+                __anodized_output
+            }
+        }
+    };
+
+    let observed = Config::DEFAULT
+        .instrument_item_trait(trait_spec, item_trait)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
 fn embed_spec_item_impl_trait() {
     let trait_spec = DataSpec::empty();
     let item_impl: ItemImpl = parse_quote! {
@@ -109,6 +169,66 @@ fn embed_spec_item_impl_trait() {
     };
 
     let observed = Config::Static
+        .instrument_item_trait_impl(trait_spec, item_impl)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
+fn default_instrument_item_impl_trait() {
+    let trait_spec = DataSpec::empty();
+    let item_impl: ItemImpl = parse_quote! {
+        impl TRAIT for IMPL_TYPE {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let qualifier_bits = FnQualifiers::empty().bits();
+    let expected: TokenStream = parse_quote! {
+        impl TRAIT for IMPL_TYPE {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
+            #[inline]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                const {
+                    assert!(
+                        Self::__anodized_fn_qualifiers_FUNC ==
+                            Self::__anodized_fn_qualifiers_trait_FUNC |
+                            Self::__anodized_fn_qualifiers_FUNC,
+                        "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
+                    );
+                };
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = (|| -> bool { COND_1 })()
+                        & (|| -> bool { COND_2 })();
+                    if !__anodized_precond {}
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    BODY
+                })());
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = (|| -> bool { COND_2 })()
+                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
+                    if !__anodized_postcond {}
+                }
+                __anodized_output
+            }
+        }
+    };
+
+    let observed = Config::DEFAULT
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -49,28 +49,8 @@ fn embed_spec_item_trait() {
                 __anodized_clause_1 && __anodized_clause_2
             }
 
-            #[doc(hidden)]
-            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                BODY
-            }
-
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                if false {
-                    let mut __anodized_errors = String::new();
-                    let __anodized_precond = (|| -> bool { COND_1 })()
-                        & (|| -> bool { COND_2 })();
-                    if !__anodized_precond {}
-                }
-                let (__anodized_output): (RET_TYPE) = ((|| {
-                    Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
-                })());
-                if false {
-                    let mut __anodized_errors = String::new();
-                    let __anodized_postcond = (|| -> bool { COND_2 })()
-                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
-                    if !__anodized_postcond {}
-                }
-                __anodized_output
+                BODY
             }
         }
     };
@@ -122,32 +102,8 @@ fn embed_spec_item_impl_trait() {
                 __anodized_clause_1 && __anodized_clause_2
             }
 
-            #[inline]
-            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                const {
-                    assert!(
-                        Self::__anodized_fn_qualifiers_FUNC ==
-                            Self::__anodized_fn_qualifiers_trait_FUNC |
-                            Self::__anodized_fn_qualifiers_FUNC,
-                        "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
-                    );
-                };
-                if false {
-                    let mut __anodized_errors = String::new();
-                    let __anodized_precond = (|| -> bool { COND_1 })()
-                        & (|| -> bool { COND_2 })();
-                    if !__anodized_precond {}
-                }
-                let (__anodized_output): (RET_TYPE) = ((|| {
-                    BODY
-                })());
-                if false {
-                    let mut __anodized_errors = String::new();
-                    let __anodized_postcond = (|| -> bool { COND_2 })()
-                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
-                    if !__anodized_postcond {}
-                }
-                __anodized_output
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
             }
         }
     };

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -55,7 +55,7 @@ fn embed_spec_item_trait() {
         }
     };
 
-    let observed = Config::EmbedSpecs
+    let observed = Mode::EmbedSpecs
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -115,7 +115,7 @@ fn default_instrument_item_trait() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Mode::DEFAULT
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -168,7 +168,7 @@ fn embed_spec_item_impl_trait() {
         }
     };
 
-    let observed = Config::EmbedSpecs
+    let observed = Mode::EmbedSpecs
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -228,7 +228,7 @@ fn default_instrument_item_impl_trait() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Mode::DEFAULT
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -75,7 +75,7 @@ fn embed_spec_item_trait() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Config::Static
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -152,7 +152,7 @@ fn embed_spec_item_impl_trait() {
         }
     };
 
-    let observed = Config::DEFAULT
+    let observed = Config::Static
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -5,13 +5,13 @@ use syn::{Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
     DataSpec, Spec,
-    instrument::{Config, RuntimeConfig, make_item_error},
+    instrument::{CheckConfig, Config, make_item_error},
 };
 
 const CONFIG: Config = if cfg!(anodized_discard_specs) {
-    Config::Nothing
+    Config::ChangeNothing
 } else {
-    Config::Dynamic(RuntimeConfig {
+    Config::InjectChecks(CheckConfig {
         does_print: cfg!(anodized_print),
         does_panic: cfg!(anodized_panic),
     })

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -5,13 +5,16 @@ use syn::{Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
     DataSpec, Spec,
-    instrument::{Config, make_item_error},
+    instrument::{Config, RuntimeConfig, make_item_error},
 };
 
-const CONFIG: Config = Config {
-    embed_spec: cfg!(not(anodized_discard_specs)),
-    emit_print: cfg!(anodized_print),
-    emit_panic: cfg!(anodized_panic),
+const CONFIG: Config = if cfg!(anodized_discard_specs) {
+    Config::Nothing
+} else {
+    Config::Dynamic(RuntimeConfig {
+        does_print: cfg!(anodized_print),
+        does_panic: cfg!(anodized_panic),
+    })
 };
 
 /// Attaches a specification to supported program elements.

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -5,13 +5,13 @@ use syn::{Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
     DataSpec, Spec,
-    instrument::{CheckConfig, Config, make_item_error},
+    instrument::{CheckSettings, Mode, make_item_error},
 };
 
-const CONFIG: Config = if cfg!(anodized_discard_specs) {
-    Config::ChangeNothing
+const CONFIG: Mode = if cfg!(anodized_discard_specs) {
+    Mode::ChangeNothing
 } else {
-    Config::InjectChecks(CheckConfig {
+    Mode::InjectChecks(CheckSettings {
         does_print: cfg!(anodized_print),
         does_panic: cfg!(anodized_panic),
     })


### PR DESCRIPTION
- Refactor `instrumentation::Config` into mutually-exclusive modes and mode-specific settings.