### PR TITLE
[anodized-core] feat: split fn checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
         include:
           - cfg: ""
           - cfg: '--config ''build.rustflags=["--cfg","anodized_discard_specs"]'''
-          - cfg: '--config ''build.rustflags=["--cfg","anodized_panic"]'''
           - cfg: '--config ''build.rustflags=["--cfg","anodized_print"]'''
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_panic"]'''
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_print","--cfg","anodized_panic"]'''
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_print","--cfg","anodized_panic","--cfg","anodized_split_func"]'''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -113,10 +113,9 @@ impl Mode {
             FnArg::Typed(pat_type) => pat_type.pat.to_token_stream(),
         });
 
-        let maybe_self = if is_impl {
-            quote::quote!(Self::)
-        } else {
-            quote::quote!()
+        let maybe_self = match is_impl {
+            true => quote::quote!(Self::),
+            false => quote::quote!(),
         };
 
         let maybe_await = match &sig.asyncness {

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -73,6 +73,9 @@ impl Mode {
             spec_ensures_fn.to_tokens(&mut tokens);
         }
 
+        // Instrument function body.
+        self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
+
         if let Self::InjectChecks(settings) = self
             && settings.split_func
         {
@@ -96,11 +99,13 @@ impl Mode {
 
             // Mangle the name and return type of the original function.
             item_fn.sig.ident = mangled_ident;
+            // Extract the return type from the function signature
+            item_fn.sig.output = match item_fn.sig.output {
+                syn::ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                syn::ReturnType::Type(ra, ty) => parse_quote!(#ra Result<#ty, (bool, String)>),
+            };
             item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
         }
-
-        // Instrument function body.
-        self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
 
         item_fn.to_tokens(&mut tokens);
         Ok(tokens)

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -134,8 +134,10 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
     }
 
     fn build_split_fn(is_impl: bool, sig: &mut Signature, body: &mut Block) -> Ident {
-        let mangled_ident =
-            Ident::new(&format!("__anodized_split_{}", sig.ident), sig.ident.span());
+        let mangled_ident = Ident::new(
+            &format!("__anodized_fn_split_{}", sig.ident),
+            sig.ident.span(),
+        );
 
         Self::build_wrapper_fn_signature(sig);
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -73,6 +73,32 @@ impl Mode {
             spec_ensures_fn.to_tokens(&mut tokens);
         }
 
+        if let Self::InjectChecks(settings) = self
+            && settings.split_func
+        {
+            // Split function into two entry points for e.g. fuzzing.
+            let mangled_ident = syn::Ident::new(
+                &format!("__anodized_split_{}", item_fn.sig.ident),
+                item_fn.sig.ident.span(),
+            );
+
+            let mut wrapper_fn = item_fn.clone();
+            wrapper_fn.block = parse_quote! {
+                {
+                    match #mangled_ident() {
+                        Ok(output) => output,
+                        Err((false, errors)) => panic!("precondition failed:{errors}"),
+                        Err((true, errors)) => panic!("postcondition failed:{errors}"),
+                    }
+                }
+            };
+            wrapper_fn.to_tokens(&mut tokens);
+
+            // Mangle the name and return type of the original function.
+            item_fn.sig.ident = mangled_ident;
+            item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
+        }
+
         // Instrument function body.
         self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -82,13 +82,14 @@ impl Mode {
         if let Self::InjectChecks(settings) = self
             && settings.split_func
         {
-            // Split function into two entry points for e.g. fuzzing.
+            // Build a wrapper that forwards to the "split" function.
             let mut wrapper_fn = item_fn.clone();
             let mangled_ident =
                 Self::build_split_fn(false, &mut wrapper_fn.sig, wrapper_fn.block.as_mut());
             wrapper_fn.to_tokens(&mut tokens);
 
-            // Mangle the name and return type of the original function.
+            // "Split" the original function by mangling its return type.
+            // The "split" entry point is used for e.g. fuzzing and PBT.
             item_fn.sig.ident = mangled_ident;
             item_fn.sig.output = match item_fn.sig.output {
                 ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use syn::{
     Attribute, Block, FnArg, Ident, ItemConst, ItemFn, ItemImpl, ItemTrait, Result, ReturnType,
     Signature, parse_quote,
@@ -24,8 +24,15 @@ pub enum Mode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckSettings {
+    /// Print errors about violated clauses.
     pub does_print: bool,
-    pub does_panic: bool,
+    /// Panic on a violated pre/postcondition or invariant.
+    pub does_panic: Option<PanicSettings>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PanicSettings {
+    /// Generate an entry point that defers the panic. Used for fuzzing, PBT, etc.
     pub split_func: bool,
 }
 
@@ -79,8 +86,9 @@ impl Mode {
         // Instrument function body.
         self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
 
-        if let Self::InjectChecks(settings) = self
-            && settings.split_func
+        if let Self::InjectChecks(check_settings) = self
+            && let Some(panic_settings) = check_settings.does_panic
+            && panic_settings.split_func
         {
             // Build a wrapper that forwards to the "split" function.
             let mut wrapper_fn = item_fn.clone();
@@ -114,13 +122,13 @@ impl Mode {
         });
 
         let maybe_self = match is_impl {
-            true => quote::quote!(Self::),
-            false => quote::quote!(),
+            true => quote!(Self::),
+            false => quote!(),
         };
 
         let maybe_await = match &sig.asyncness {
-            Some(_) => quote::quote!(.await),
-            None => quote::quote!(),
+            Some(_) => quote!(.await),
+            None => quote!(),
         };
 
         *body = parse_quote! {
@@ -177,26 +185,22 @@ impl Mode {
 impl CheckSettings {
     pub(crate) const DEFAULT: Self = Self {
         does_print: false,
-        does_panic: false,
-        split_func: false,
+        does_panic: None,
     };
 
     pub(crate) const PRINT: Self = Self {
         does_print: true,
-        does_panic: false,
-        split_func: false,
+        does_panic: None,
     };
 
     pub(crate) const PRINT_AND_PANIC: Self = Self {
         does_print: true,
-        does_panic: true,
-        split_func: false,
+        does_panic: Some(PanicSettings { split_func: false }),
     };
 
     pub(crate) const PRINT_AND_SPLIT_PANIC: Self = Self {
         does_print: true,
-        does_panic: true,
-        split_func: true,
+        does_panic: Some(PanicSettings { split_func: true }),
     };
 }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -9,6 +9,7 @@ use crate::{DataSpec, Spec};
 
 pub mod data;
 pub mod fns;
+pub mod impls;
 pub mod loops;
 pub mod traits;
 
@@ -57,6 +58,14 @@ impl Mode {
 
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
+
+        if item_fn.sig.ident.to_string().starts_with("__anodized_") {
+            return Err(syn::Error::new_spanned(
+                item_fn.sig.ident,
+                r#"An item with the `__anodized_` prefix is internal. Do not implement it directly.
+Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or impl block."#,
+            ));
+        }
 
         if let Self::EmbedSpecs = self {
             // Embed `spec` elements as `__anodized_fn_*` items.
@@ -169,6 +178,11 @@ impl Mode {
                 }
             }
         }
+    }
+
+    pub fn instrument_item_impl(&self, spec: DataSpec, item_impl: ItemImpl) -> Result<TokenStream> {
+        let new_impl = self.instrument_impl(spec, item_impl)?;
+        Ok(new_impl.to_token_stream())
     }
 
     pub fn instrument_item_trait(

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -12,7 +12,7 @@ pub mod fns;
 pub mod loops;
 pub mod traits;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Mode {
     /// Make no changes to the code.
     ChangeNothing,
@@ -22,7 +22,7 @@ pub enum Mode {
     EmbedSpecs,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct CheckSettings {
     /// Print errors about violated clauses.
     pub does_print: bool,
@@ -30,7 +30,7 @@ pub struct CheckSettings {
     pub does_panic: Option<PanicSettings>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct PanicSettings {
     /// Generate an entry point that defers the panic. Used for fuzzing, PBT, etc.
     pub split_func: bool,
@@ -39,6 +39,20 @@ pub struct PanicSettings {
 impl Mode {
     pub fn changes_anything(&self) -> bool {
         !matches!(self, Mode::ChangeNothing)
+    }
+
+    pub fn with_split_func(&self, value: bool) -> Self {
+        match self {
+            Mode::ChangeNothing => Mode::ChangeNothing,
+            Mode::InjectChecks(check_settings) => {
+                let mut check_settings = check_settings.clone();
+                if let Some(panic_settings) = &mut check_settings.does_panic {
+                    panic_settings.split_func = value;
+                };
+                Mode::InjectChecks(check_settings)
+            }
+            Mode::EmbedSpecs => Mode::EmbedSpecs,
+        }
     }
 
     pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
@@ -87,7 +101,7 @@ impl Mode {
         self.instrument_fn(&spec, &item_fn.sig, &mut item_fn.block)?;
 
         if let Self::InjectChecks(check_settings) = self
-            && let Some(panic_settings) = check_settings.does_panic
+            && let Some(ref panic_settings) = check_settings.does_panic
             && panic_settings.split_func
         {
             // Build a wrapper that forwards to the "split" function.

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -113,15 +113,20 @@ impl Mode {
             FnArg::Typed(pat_type) => pat_type.pat.to_token_stream(),
         });
 
-        let self_type = if is_impl {
+        let maybe_self = if is_impl {
             quote::quote!(Self::)
         } else {
             quote::quote!()
         };
 
+        let maybe_await = match &sig.asyncness {
+            Some(_) => quote::quote!(.await),
+            None => quote::quote!(),
+        };
+
         *body = parse_quote! {
             {
-                match #self_type #mangled_ident(#(#args),*) {
+                match #maybe_self #mangled_ident(#(#args),*) #maybe_await {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -23,6 +23,7 @@ pub enum Mode {
 pub struct CheckSettings {
     pub does_print: bool,
     pub does_panic: bool,
+    pub split_func: bool,
 }
 
 impl Mode {
@@ -108,21 +109,25 @@ impl CheckSettings {
     pub(crate) const DEFAULT: Self = Self {
         does_print: false,
         does_panic: false,
+        split_func: false,
     };
 
     pub(crate) const PRINT: Self = Self {
         does_print: true,
         does_panic: false,
+        split_func: false,
     };
 
     pub(crate) const PRINT_AND_PANIC: Self = Self {
         does_print: true,
         does_panic: true,
+        split_func: false,
     };
 
     pub(crate) const PRINT_AND_SPLIT_PANIC: Self = Self {
         does_print: true,
         does_panic: true,
+        split_func: true,
     };
 }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -1,6 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{Attribute, ItemConst, ItemFn, ItemImpl, ItemTrait, Result, parse_quote};
+use syn::{
+    Attribute, FnArg, Ident, ItemConst, ItemFn, ItemImpl, ItemTrait, Result, ReturnType, Signature,
+    parse_quote,
+};
 
 use crate::{DataSpec, Spec};
 
@@ -80,15 +83,20 @@ impl Mode {
             && settings.split_func
         {
             // Split function into two entry points for e.g. fuzzing.
-            let mangled_ident = syn::Ident::new(
+            let mangled_ident = Ident::new(
                 &format!("__anodized_split_{}", item_fn.sig.ident),
                 item_fn.sig.ident.span(),
             );
 
             let mut wrapper_fn = item_fn.clone();
+            wrapper_fn.sig = Self::build_wrapper_fn_signature(wrapper_fn.sig);
+            let args = wrapper_fn.sig.inputs.iter().map(|arg| match arg {
+                FnArg::Receiver(receiver) => receiver.self_token.to_token_stream(),
+                FnArg::Typed(pat_type) => pat_type.pat.to_token_stream(),
+            });
             wrapper_fn.block = parse_quote! {
                 {
-                    match #mangled_ident() {
+                    match #mangled_ident(#(#args),*) {
                         Ok(output) => output,
                         Err((false, errors)) => panic!("precondition failed:{errors}"),
                         Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -99,16 +107,29 @@ impl Mode {
 
             // Mangle the name and return type of the original function.
             item_fn.sig.ident = mangled_ident;
-            // Extract the return type from the function signature
             item_fn.sig.output = match item_fn.sig.output {
-                syn::ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
-                syn::ReturnType::Type(ra, ty) => parse_quote!(#ra Result<#ty, (bool, String)>),
+                ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                ReturnType::Type(ra, ty) => parse_quote!(#ra Result<#ty, (bool, String)>),
             };
             item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
         }
 
         item_fn.to_tokens(&mut tokens);
         Ok(tokens)
+    }
+
+    fn build_wrapper_fn_signature(mut sig: Signature) -> Signature {
+        use syn::spanned::Spanned;
+        for (i, arg) in sig.inputs.iter_mut().enumerate() {
+            match arg {
+                FnArg::Receiver(_) => {}
+                FnArg::Typed(pat_type) => {
+                    let name = Ident::new(&format!("arg_{i}"), pat_type.span());
+                    pat_type.pat = parse_quote!(#name);
+                }
+            }
+        }
+        sig
     }
 
     pub fn instrument_item_trait(

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -119,6 +119,11 @@ impl CheckSettings {
         does_print: true,
         does_panic: true,
     };
+
+    pub(crate) const PRINT_AND_SPLIT_PANIC: Self = Self {
+        does_print: true,
+        does_panic: true,
+    };
 }
 
 /// Make an error message to say that some item is unsupported.

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
-    Attribute, FnArg, Ident, ItemConst, ItemFn, ItemImpl, ItemTrait, Result, ReturnType, Signature,
-    parse_quote,
+    Attribute, Block, FnArg, Ident, ItemConst, ItemFn, ItemImpl, ItemTrait, Result, ReturnType,
+    Signature, parse_quote,
 };
 
 use crate::{DataSpec, Spec};
@@ -83,26 +83,9 @@ impl Mode {
             && settings.split_func
         {
             // Split function into two entry points for e.g. fuzzing.
-            let mangled_ident = Ident::new(
-                &format!("__anodized_split_{}", item_fn.sig.ident),
-                item_fn.sig.ident.span(),
-            );
-
             let mut wrapper_fn = item_fn.clone();
-            wrapper_fn.sig = Self::build_wrapper_fn_signature(wrapper_fn.sig);
-            let args = wrapper_fn.sig.inputs.iter().map(|arg| match arg {
-                FnArg::Receiver(receiver) => receiver.self_token.to_token_stream(),
-                FnArg::Typed(pat_type) => pat_type.pat.to_token_stream(),
-            });
-            wrapper_fn.block = parse_quote! {
-                {
-                    match #mangled_ident(#(#args),*) {
-                        Ok(output) => output,
-                        Err((false, errors)) => panic!("precondition failed:{errors}"),
-                        Err((true, errors)) => panic!("postcondition failed:{errors}"),
-                    }
-                }
-            };
+            let mangled_ident =
+                Self::build_split_fn(false, &mut wrapper_fn.sig, wrapper_fn.block.as_mut());
             wrapper_fn.to_tokens(&mut tokens);
 
             // Mangle the name and return type of the original function.
@@ -118,18 +101,47 @@ impl Mode {
         Ok(tokens)
     }
 
-    fn build_wrapper_fn_signature(mut sig: Signature) -> Signature {
+    fn build_split_fn(is_impl: bool, sig: &mut Signature, body: &mut Block) -> Ident {
+        let mangled_ident =
+            Ident::new(&format!("__anodized_split_{}", sig.ident), sig.ident.span());
+
+        Self::build_wrapper_fn_signature(sig);
+
+        let args = sig.inputs.iter().map(|arg| match arg {
+            FnArg::Receiver(receiver) => receiver.self_token.to_token_stream(),
+            FnArg::Typed(pat_type) => pat_type.pat.to_token_stream(),
+        });
+
+        let self_type = if is_impl {
+            quote::quote!(Self::)
+        } else {
+            quote::quote!()
+        };
+
+        *body = parse_quote! {
+            {
+                match #self_type #mangled_ident(#(#args),*) {
+                    Ok(output) => output,
+                    Err((false, errors)) => panic!("precondition failed:{errors}"),
+                    Err((true, errors)) => panic!("postcondition failed:{errors}"),
+                }
+            }
+        };
+
+        mangled_ident
+    }
+
+    fn build_wrapper_fn_signature(sig: &mut Signature) {
         use syn::spanned::Spanned;
         for (i, arg) in sig.inputs.iter_mut().enumerate() {
             match arg {
                 FnArg::Receiver(_) => {}
                 FnArg::Typed(pat_type) => {
-                    let name = Ident::new(&format!("arg_{i}"), pat_type.span());
+                    let name = Ident::new(&format!("input_{i}"), pat_type.span());
                     pat_type.pat = parse_quote!(#name);
                 }
             }
         }
-        sig
     }
 
     pub fn instrument_item_trait(

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -123,8 +123,10 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
             // The "split" entry point is used for e.g. fuzzing and PBT.
             item_fn.sig.ident = mangled_ident;
             item_fn.sig.output = match item_fn.sig.output {
-                ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
-                ReturnType::Type(ra, ty) => parse_quote!(#ra Result<#ty, (bool, String)>),
+                ReturnType::Default => parse_quote!(-> Result<(), (bool, ::std::string::String)>),
+                ReturnType::Type(ra, ty) => {
+                    parse_quote!(#ra ::core::result::Result<#ty, (bool, ::std::string::String)>)
+                }
             };
             item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -312,22 +312,22 @@ impl CheckSettings {
 
         let do_run_checks = self.does_print || self.does_panic.is_some();
 
-        let (output_expr, precond_fail_action, postcond_fail_action) = if let Some(panic_settings) =
-            self.does_panic
-            && panic_settings.split_func
-        {
-            (
-                quote! { Ok(#output_ident) },
-                Some(parse_quote! { return Err((false, __anodized_errors)); }),
-                Some(parse_quote! { return Err((true, __anodized_errors)); }),
-            )
-        } else {
-            (
-                quote! { #output_ident },
-                self.build_fail_action("precondition failed"),
-                self.build_fail_action("postcondition failed"),
-            )
-        };
+        let (output_expr, precond_fail_action, postcond_fail_action) =
+            if let Some(ref panic_settings) = self.does_panic
+                && panic_settings.split_func
+            {
+                (
+                    quote! { Ok(#output_ident) },
+                    Some(parse_quote! { return Err((false, __anodized_errors)); }),
+                    Some(parse_quote! { return Err((true, __anodized_errors)); }),
+                )
+            } else {
+                (
+                    quote! { #output_ident },
+                    self.build_fail_action("precondition failed"),
+                    self.build_fail_action("postcondition failed"),
+                )
+            };
 
         Ok(parse_quote! {
             {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -332,7 +332,7 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = #(#precondition_clauses)&*;
                     if !__anodized_precond {
                         #precond_fail_action
@@ -340,7 +340,7 @@ impl CheckSettings {
                 }
                 #body_and_captures
                 if #do_run_checks {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = #(#postcondition_clauses)&*;
                     if !__anodized_postcond {
                         #postcond_fail_action

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -310,9 +310,12 @@ impl CheckSettings {
             postcondition_clauses.push(parse_quote!(true));
         }
 
-        let do_run_checks = self.does_print || self.does_panic;
+        let do_run_checks = self.does_print || self.does_panic.is_some();
 
-        let (output_expr, precond_fail_action, postcond_fail_action) = if self.split_func {
+        let (output_expr, precond_fail_action, postcond_fail_action) = if let Some(panic_settings) =
+            self.does_panic
+            && panic_settings.split_func
+        {
             (
                 quote! { Ok(#output_ident) },
                 Some(parse_quote! { return Err((false, __anodized_errors)); }),
@@ -363,7 +366,7 @@ impl CheckSettings {
 
     fn build_fail_action(&self, message: &str) -> Option<Stmt> {
         let message_and_errors = format!("{message}:{{__anodized_errors}}");
-        match (self.does_print, self.does_panic) {
+        match (self.does_print, self.does_panic.is_some()) {
             (true, true) => Some(parse_quote! { panic!(#message_and_errors); }),
             (true, false) => Some(parse_quote! { eprintln!(#message_and_errors); }),
             (false, true) => Some(parse_quote! { panic!(#message); }),

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -311,8 +311,20 @@ impl CheckSettings {
         }
 
         let do_run_checks = self.does_print || self.does_panic;
-        let precond_fail_action = self.build_fail_action("precondition failed");
-        let postcond_fail_action = self.build_fail_action("postcondition failed");
+
+        let (output_expr, precond_fail_action, postcond_fail_action) = if self.split_func {
+            (
+                quote! { Ok(#output_ident) },
+                Some(parse_quote! { return Err((false, __anodized_errors)); }),
+                Some(parse_quote! { return Err((true, __anodized_errors)); }),
+            )
+        } else {
+            (
+                quote! { #output_ident },
+                self.build_fail_action("precondition failed"),
+                self.build_fail_action("postcondition failed"),
+            )
+        };
 
         Ok(parse_quote! {
             {
@@ -331,7 +343,7 @@ impl CheckSettings {
                         #postcond_fail_action
                     }
                 }
-                #output_ident
+                #output_expr
             }
         })
     }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -91,7 +91,7 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = (|| -> bool { COND_1 })()
                     & (|| -> bool { COND_2 })()
                     & (|| -> bool { COND_3 })()
@@ -108,7 +108,7 @@ fn default_instrument_item_fn() {
                 })(),
             );
             if false {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = (|| -> bool { COND_4 })()
                     & (|| -> bool { COND_5 })()
                     & (|| -> bool { COND_6 })()
@@ -146,10 +146,10 @@ fn split_panic_instrument_item_fn() {
         #[doc(hidden)]
         #[inline]
         fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
-            -> Result<RET_TYPE, (bool, String)>
+            -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { COND_1 })()
                         || __anodized_errors.push_str("\n    COND_1") != ())
                     & (!cfg!(META_1) || (|| -> bool { COND_2 })()
@@ -174,7 +174,7 @@ fn split_panic_instrument_item_fn() {
                 })(),
             );
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { COND_4 })()
                         || __anodized_errors.push_str("\n    COND_4") != ())
                     & ((|| -> bool { COND_5 })()
@@ -226,7 +226,7 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -235,7 +235,7 @@ fn simple_requires() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -266,13 +266,13 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = (|| -> bool { CONDITION_1 })();
                 if !__anodized_precond {}
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if false {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {}
             }
@@ -294,7 +294,7 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -303,7 +303,7 @@ fn requires_no_panic_runtime() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
                     eprintln!("postcondition failed:{__anodized_errors}");
@@ -331,7 +331,7 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -340,7 +340,7 @@ fn simple_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
@@ -369,7 +369,7 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -377,7 +377,7 @@ fn simple_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ());
                 if !__anodized_postcond {
@@ -407,7 +407,7 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|| -> bool { CONDITION_2 })()
@@ -418,7 +418,7 @@ fn simple_requires_and_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
@@ -448,7 +448,7 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -457,7 +457,7 @@ fn simple_requires_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
@@ -487,7 +487,7 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -496,7 +496,7 @@ fn simple_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
@@ -529,7 +529,7 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|| -> bool { CONDITION_2 })()
@@ -540,7 +540,7 @@ fn simple_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
@@ -573,7 +573,7 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|| -> bool { CONDITION_2 })()
@@ -584,7 +584,7 @@ fn simple_async_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((async || #body)().await);
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
@@ -617,7 +617,7 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|| -> bool { CONDITION_2 })()
@@ -632,7 +632,7 @@ fn multiple_conditions_in_clauses() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_3 })()
                     || __anodized_errors.push_str("\n    CONDITION_3") != ())
                     & ((|| -> bool { CONDITION_4 })()
@@ -668,7 +668,7 @@ fn binds_parameter() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -676,7 +676,7 @@ fn binds_parameter() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
                     || __anodized_errors.push_str("\n    | OUTPUT_PATTERN | CONDITION_1") != ());
                 if !__anodized_postcond {
@@ -710,7 +710,7 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -718,7 +718,7 @@ fn ensures_with_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ())
                     & ((|PATTERN_1: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
@@ -758,7 +758,7 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = (!cfg!(SETTING_1) || (|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (!cfg!(SETTING_2) || (|| -> bool { CONDITION_2 })()
@@ -769,7 +769,7 @@ fn cfg_attributes() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = (!cfg!(SETTING_2) || (|| -> bool { CONDITION_2 })()
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (!cfg!(SETTING_3)
@@ -805,7 +805,7 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = (!cfg!(SETTING_1) || (|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & ((|| -> bool { CONDITION_2 })()
@@ -818,7 +818,7 @@ fn cfg_on_single_and_list_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & ((|| -> bool { CONDITION_3 })()
@@ -863,7 +863,7 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (!cfg!(SETTING_1) || (|| -> bool { CONDITION_2 })()
@@ -882,7 +882,7 @@ fn complex_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|| -> bool { CONDITION_4 })()
                     || __anodized_errors.push_str("\n    CONDITION_4") != ())
                     & ((|| -> bool { CONDITION_5 })()
@@ -931,7 +931,7 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = ((|| -> bool { CONDITION_1 })()
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
@@ -940,7 +940,7 @@ fn captures() {
             }
             let (ALIAS_1, ALIAS_2, __anodized_output): (_, _, #ret_type) = ((| | EXPR_1) (), (| | EXPR_2) (), (|| #body)());
             if true {
-                let mut __anodized_errors = String::new();
+                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ())
                     & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -150,12 +150,18 @@ fn split_instrument_item_fn() {
         {
             if true {
                 let mut __anodized_errors = String::new();
-                let __anodized_precond = (|| -> bool { COND_1 })()
-                    & (|| -> bool { COND_2 })()
-                    & (|| -> bool { COND_3 })()
-                    & (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })();
+                let __anodized_precond = ((|| -> bool { COND_1 })()
+                        || __anodized_errors.push_str("\n    COND_1") != ())
+                    & (!cfg!(META_1) || (|| -> bool { COND_2 })()
+                        || __anodized_errors.push_str("\n    COND_2") != ())
+                    & (!cfg!(META_1) || (|| -> bool { COND_3 })()
+                        || __anodized_errors.push_str("\n    COND_3") != ())
+                    & ((|| -> bool { COND_4 })()
+                        || __anodized_errors.push_str("\n    COND_4") != ())
+                    & ((|| -> bool { COND_5 })()
+                        || __anodized_errors.push_str("\n    COND_5") != ())
+                    & (!cfg!(META_2) || (|| -> bool { COND_6 })()
+                        || __anodized_errors.push_str("\n    COND_6") != ());
                 if !__anodized_precond {
                     return Err((false, __anodized_errors));
                 }
@@ -169,12 +175,19 @@ fn split_instrument_item_fn() {
             );
             if true {
                 let mut __anodized_errors = String::new();
-                let __anodized_postcond = (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })()
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
-                    & (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output);
+                let __anodized_postcond = ((|| -> bool { COND_4 })()
+                        || __anodized_errors.push_str("\n    COND_4") != ())
+                    & ((|| -> bool { COND_5 })()
+                        || __anodized_errors.push_str("\n    COND_5") != ())
+                    & (!cfg!(META_2) || (|| -> bool { COND_6 })()
+                        || __anodized_errors.push_str("\n    COND_6") != ())
+                    & ((|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
+                        || __anodized_errors.push_str("\n    | PAT_1 | COND_7") != ())
+                    & (!cfg!(META_3)
+                        || (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
+                        || __anodized_errors.push_str("\n    | PAT_1 | COND_8") != ())
+                    & (!cfg!(META_3) || (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output)
+                        || __anodized_errors.push_str("\n    | PAT_2 : TYPE | COND_9") != ());
                 if !__anodized_postcond {
                     return Err((true, __anodized_errors));
                 }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -126,7 +126,7 @@ fn default_instrument_item_fn() {
 }
 
 #[test]
-fn split_instrument_item_fn() {
+fn split_panic_instrument_item_fn() {
     let fn_spec = make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -125,6 +125,70 @@ fn default_instrument_item_fn() {
     assert_tokens_eq(&observed, &expected);
 }
 
+#[test]
+fn split_instrument_item_fn() {
+    let fn_spec = make_complex_spec();
+    let item_fn: ItemFn = parse_quote! {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            match Self::__anodized_split_FUNC(self, PARAM_1, PARAM_2) {
+                Ok(output) => output,
+                Err((false, errors)) => panic!("precondition failed:{errors}"),
+                Err((true, errors)) => panic!("postcondition failed:{errors}"),
+            }
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            -> Result<RET_TYPE, (bool, String)>
+        {
+            if true {
+                let mut __anodized_errors = String::new();
+                let __anodized_precond = (|| -> bool { COND_1 })()
+                    & (|| -> bool { COND_2 })()
+                    & (|| -> bool { COND_3 })()
+                    & (|| -> bool { COND_4 })()
+                    & (|| -> bool { COND_5 })()
+                    & (|| -> bool { COND_6 })();
+                if !__anodized_precond {
+                    return Err((false, __anodized_errors));
+                }
+            }
+            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output): (_, _, RET_TYPE) = (
+                (|| EXPR_1)(),
+                (|| EXPR_2)(),
+                (|| {
+                    BODY
+                })(),
+            );
+            if true {
+                let mut __anodized_errors = String::new();
+                let __anodized_postcond = (|| -> bool { COND_4 })()
+                    & (|| -> bool { COND_5 })()
+                    & (|| -> bool { COND_6 })()
+                    & (|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
+                    & (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
+                    & (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output);
+                if !__anodized_postcond {
+                    return Err((true, __anodized_errors));
+                }
+            }
+            Ok(__anodized_output)
+        }
+    };
+
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+        .instrument_item_fn(fn_spec, item_fn)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
 fn make_fn_body() -> Block {
     parse_quote! {
         {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -136,7 +136,7 @@ fn split_panic_instrument_item_fn() {
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-            match __anodized_split_FUNC(self, input_1, input_2) {
+            match __anodized_fn_split_FUNC(self, input_1, input_2) {
                 Ok(output) => output,
                 Err((false, errors)) => panic!("precondition failed:{errors}"),
                 Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -145,7 +145,7 @@ fn split_panic_instrument_item_fn() {
 
         #[doc(hidden)]
         #[inline]
-        fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+        fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
             -> Result<RET_TYPE, (bool, String)>
         {
             if true {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -135,8 +135,8 @@ fn split_instrument_item_fn() {
     };
 
     let expected: TokenStream = parse_quote! {
-        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            match Self::__anodized_split_FUNC(self, PARAM_1, PARAM_2) {
+        fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
+            match __anodized_split_FUNC(self, input_1, input_2) {
                 Ok(output) => output,
                 Err((false, errors)) => panic!("precondition failed:{errors}"),
                 Err((true, errors)) => panic!("postcondition failed:{errors}"),

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -110,9 +110,11 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         // The "split" entry point is used for e.g. fuzzing and PBT.
                         item_fn.sig.ident = mangled_ident;
                         item_fn.sig.output = match item_fn.sig.output {
-                            ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                            ReturnType::Default => {
+                                parse_quote!(-> Result<(), (bool, ::std::string::String)>)
+                            }
                             ReturnType::Type(ra, ty) => {
-                                parse_quote!(#ra Result<#ty, (bool, String)>)
+                                parse_quote!(#ra ::core::result::Result<#ty, (bool, ::std::string::String)>)
                             }
                         };
                         item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -1,0 +1,156 @@
+#[cfg(test)]
+#[path = "impls_tests.rs"]
+mod impls_tests;
+
+use syn::{Attribute, ImplItem, ImplItemFn, ReturnType, Visibility, parse_quote};
+
+use crate::{
+    DataSpec, Spec,
+    instrument::{Mode, find_spec_attr, make_item_error},
+};
+
+impl Mode {
+    /// Expand impl items.
+    pub fn instrument_impl(
+        &self,
+        spec: DataSpec,
+        mut the_impl: syn::ItemImpl,
+    ) -> syn::Result<syn::ItemImpl> {
+        if the_impl.trait_.is_some() {
+            return Err(make_item_error(&the_impl, "trait impl"));
+        };
+
+        if !spec.is_empty() {
+            return Err(spec.spec_err("Unsupported spec element on inherent impl."));
+        }
+
+        let mut new_items = Vec::with_capacity(the_impl.items.len() * 4);
+
+        for item in the_impl.items.into_iter() {
+            match item {
+                ImplItem::Fn(mut item_fn) => {
+                    let (spec_attr, func_attrs) = find_spec_attr(item_fn.attrs)?;
+                    item_fn.attrs = func_attrs;
+
+                    if item_fn.sig.ident.to_string().starts_with("__anodized_") {
+                        return Err(syn::Error::new_spanned(
+                            item_fn.sig.ident,
+                            r#"An item with the `__anodized_` prefix is internal. Do not implement it directly.
+Instead, ensure that both the impl block and the fn have a `#[spec]` annotation."#,
+                        ));
+                    }
+
+                    let fn_spec: Spec = match spec_attr {
+                        Some(spec_attr) => spec_attr.parse_args()?,
+                        None => Spec::empty(),
+                    };
+
+                    if let Self::EmbedSpecs = self {
+                        // Embed `spec` elements as `__anodized_fn_*` items.
+                        let attrs: [Attribute; 2] = [
+                            parse_quote!(#[doc(hidden)]),
+                            parse_quote!(#[allow(warnings)]),
+                        ];
+
+                        let spec_qualifiers_const = Self::build_qualifier_const_item(
+                            &attrs,
+                            "__anodized_fn_qualifiers",
+                            fn_spec.qualifiers,
+                            &item_fn.sig.ident,
+                        );
+                        let spec_requires_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_precondition_fn_sig(
+                                "__anodized_fn_requires",
+                                &item_fn.sig,
+                            ),
+                            block: Self::build_precondition_fn_body(
+                                &fn_spec.requires,
+                                &fn_spec.maintains,
+                            ),
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+                        let spec_ensures_fn = ImplItemFn {
+                            attrs: attrs.to_vec(),
+                            sig: Self::build_postcondition_fn_sig(
+                                "__anodized_fn_ensures",
+                                &item_fn.sig,
+                            ),
+                            block: Self::build_postcondition_fn_body(
+                                &fn_spec.maintains,
+                                &fn_spec.captures,
+                                &fn_spec.ensures,
+                                &item_fn.sig.output,
+                            )?,
+                            vis: Visibility::Inherited,
+                            defaultness: None,
+                        };
+
+                        new_items.push(ImplItem::Const(spec_qualifiers_const));
+                        new_items.push(ImplItem::Fn(spec_requires_fn));
+                        new_items.push(ImplItem::Fn(spec_ensures_fn));
+                    }
+
+                    // Instrument function body.
+                    self.instrument_fn(&fn_spec, &item_fn.sig, &mut item_fn.block)?;
+
+                    if let Self::InjectChecks(check_settings) = self
+                        && let Some(ref panic_settings) = check_settings.does_panic
+                        && panic_settings.split_func
+                    {
+                        // Build a wrapper that forwards to the "split" function.
+                        let mut wrapper_fn = item_fn.clone();
+                        let mangled_ident =
+                            Self::build_split_fn(false, &mut wrapper_fn.sig, &mut wrapper_fn.block);
+                        new_items.push(ImplItem::Fn(wrapper_fn));
+
+                        // "Split" the original function by mangling its return type.
+                        // The "split" entry point is used for e.g. fuzzing and PBT.
+                        item_fn.sig.ident = mangled_ident;
+                        item_fn.sig.output = match item_fn.sig.output {
+                            ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                            ReturnType::Type(ra, ty) => {
+                                parse_quote!(#ra Result<#ty, (bool, String)>)
+                            }
+                        };
+                        item_fn.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
+                    }
+
+                    new_items.push(ImplItem::Fn(item_fn));
+                }
+                ImplItem::Const(mut const_item) => {
+                    let (spec, attrs) = find_spec_attr(const_item.attrs)?;
+                    if let Some(ref spec_attr) = spec {
+                        return Err(make_item_error(&spec_attr, "trait impl const"));
+                    }
+                    const_item.attrs = attrs;
+                    new_items.push(ImplItem::Const(const_item));
+                }
+                ImplItem::Type(mut type_item) => {
+                    let (spec, attrs) = find_spec_attr(type_item.attrs)?;
+                    if let Some(ref spec_attr) = spec {
+                        return Err(make_item_error(&spec_attr, "trait impl type"));
+                    }
+                    type_item.attrs = attrs;
+                    new_items.push(ImplItem::Type(type_item));
+                }
+                ImplItem::Macro(mut macro_item) => {
+                    let (spec, attrs) = find_spec_attr(macro_item.attrs)?;
+                    if let Some(ref spec_attr) = spec {
+                        return Err(make_item_error(&spec_attr, "trait impl macro"));
+                    }
+                    macro_item.attrs = attrs;
+                    new_items.push(ImplItem::Macro(macro_item));
+                }
+                ImplItem::Verbatim(token_stream) => {
+                    new_items.push(ImplItem::Verbatim(token_stream))
+                }
+                _ => unimplemented!(),
+            };
+        }
+
+        the_impl.items = new_items;
+        Ok(the_impl)
+    }
+}

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -15,7 +15,7 @@ impl Mode {
     /// Expand items inside an inherent impl.
     ///
     /// Reasons why impl functions must be treated differently from free-standing functions:
-    /// - The `__anodized_split_*` function must be qualified as `Self::` inside an impl.
+    /// - The `__anodized_fn_split_*` function must be qualified as `Self::` inside an impl.
     pub fn instrument_impl(&self, spec: DataSpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
         if the_impl.trait_.is_some() {
             return Err(make_item_error(&the_impl, "trait impl"));

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -2,7 +2,9 @@
 #[path = "impls_tests.rs"]
 mod impls_tests;
 
-use syn::{Attribute, ImplItem, ImplItemFn, ReturnType, Visibility, parse_quote};
+use syn::{
+    Attribute, Error, ImplItem, ImplItemFn, ItemImpl, Result, ReturnType, Visibility, parse_quote,
+};
 
 use crate::{
     DataSpec, Spec,
@@ -11,11 +13,7 @@ use crate::{
 
 impl Mode {
     /// Expand impl items.
-    pub fn instrument_impl(
-        &self,
-        spec: DataSpec,
-        mut the_impl: syn::ItemImpl,
-    ) -> syn::Result<syn::ItemImpl> {
+    pub fn instrument_impl(&self, spec: DataSpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
         if the_impl.trait_.is_some() {
             return Err(make_item_error(&the_impl, "trait impl"));
         };
@@ -33,7 +31,7 @@ impl Mode {
                     item_fn.attrs = func_attrs;
 
                     if item_fn.sig.ident.to_string().starts_with("__anodized_") {
-                        return Err(syn::Error::new_spanned(
+                        return Err(Error::new_spanned(
                             item_fn.sig.ident,
                             r#"An item with the `__anodized_` prefix is internal. Do not implement it directly.
 Instead, ensure that both the impl block and the fn have a `#[spec]` annotation."#,
@@ -102,7 +100,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         // Build a wrapper that forwards to the "split" function.
                         let mut wrapper_fn = item_fn.clone();
                         let mangled_ident =
-                            Self::build_split_fn(false, &mut wrapper_fn.sig, &mut wrapper_fn.block);
+                            Self::build_split_fn(true, &mut wrapper_fn.sig, &mut wrapper_fn.block);
                         new_items.push(ImplItem::Fn(wrapper_fn));
 
                         // "Split" the original function by mangling its return type.
@@ -122,7 +120,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                 ImplItem::Const(mut const_item) => {
                     let (spec, attrs) = find_spec_attr(const_item.attrs)?;
                     if let Some(ref spec_attr) = spec {
-                        return Err(make_item_error(&spec_attr, "trait impl const"));
+                        return Err(make_item_error(&spec_attr, "impl const"));
                     }
                     const_item.attrs = attrs;
                     new_items.push(ImplItem::Const(const_item));
@@ -130,7 +128,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                 ImplItem::Type(mut type_item) => {
                     let (spec, attrs) = find_spec_attr(type_item.attrs)?;
                     if let Some(ref spec_attr) = spec {
-                        return Err(make_item_error(&spec_attr, "trait impl type"));
+                        return Err(make_item_error(&spec_attr, "impl type"));
                     }
                     type_item.attrs = attrs;
                     new_items.push(ImplItem::Type(type_item));
@@ -138,7 +136,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                 ImplItem::Macro(mut macro_item) => {
                     let (spec, attrs) = find_spec_attr(macro_item.attrs)?;
                     if let Some(ref spec_attr) = spec {
-                        return Err(make_item_error(&spec_attr, "trait impl macro"));
+                        return Err(make_item_error(&spec_attr, "impl macro"));
                     }
                     macro_item.attrs = attrs;
                     new_items.push(ImplItem::Macro(macro_item));

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 
 impl Mode {
-    /// Expand impl items.
+    /// Expand items inside an inherent impl.
+    ///
+    /// Reasons why impl functions must be treated differently from free-standing functions:
+    /// - The `__anodized_split_*` function must be qualified as `Self::` inside an impl.
     pub fn instrument_impl(&self, spec: DataSpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
         if the_impl.trait_.is_some() {
             return Err(make_item_error(&the_impl, "trait impl"));

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -1,0 +1,170 @@
+use crate::{instrument::CheckSettings, qualifiers::FnQualifiers, test_util::assert_tokens_eq};
+
+use super::*;
+use proc_macro2::TokenStream;
+use syn::{ItemImpl, parse_quote};
+
+#[test]
+fn embed_spec_item_impl() {
+    let impl_spec = DataSpec::empty();
+    let item_impl: ItemImpl = parse_quote! {
+        impl IMPL_TYPE {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let qualifier_bits = FnQualifiers::empty().bits();
+    let expected: TokenStream = parse_quote! {
+        impl IMPL_TYPE {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
+                let __anodized_clause_1 = (| | -> bool { COND_1 })();
+                let __anodized_clause_2 = (| | -> bool { COND_2 })();
+                __anodized_clause_1 && __anodized_clause_2
+            }
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: &RET_TYPE) -> bool {
+                let __anodized_clause_1 = (| | -> bool { COND_2 })();
+                let () = ();
+                let __anodized_clause_2 = (|PAT_1: &RET_TYPE| -> bool { COND_3 })(__anodized_output);
+                __anodized_clause_1 && __anodized_clause_2
+            }
+
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let observed = Mode::EmbedSpecs
+        .instrument_item_impl(impl_spec, item_impl)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
+fn default_instrument_item_impl() {
+    let impl_spec = DataSpec::empty();
+    let item_impl: ItemImpl = parse_quote! {
+        impl IMPL_TYPE {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        impl IMPL_TYPE {
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = (|| -> bool { COND_1 })()
+                        & (|| -> bool { COND_2 })();
+                    if !__anodized_precond {}
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    BODY
+                })());
+                if false {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = (|| -> bool { COND_2 })()
+                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
+                    if !__anodized_postcond {}
+                }
+                __anodized_output
+            }
+        }
+    };
+
+    let observed = Mode::DEFAULT
+        .instrument_item_impl(impl_spec, item_impl)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
+fn split_panic_instrument_item_impl() {
+    let impl_spec = DataSpec::empty();
+    let item_impl: ItemImpl = parse_quote! {
+        impl IMPL_TYPE {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let expected: TokenStream = parse_quote! {
+        impl IMPL_TYPE {
+            fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
+                match __anodized_split_FUNC(self, input_1, input_2) {
+                    Ok(output) => output,
+                    Err((false, errors)) => panic!("precondition failed:{errors}"),
+                    Err((true, errors)) => panic!("postcondition failed:{errors}"),
+                }
+            }
+
+            #[doc(hidden)]
+            #[inline]
+            fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+                -> Result<RET_TYPE, (bool, String)>
+            {
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = ((|| -> bool { COND_1 })()
+                            || __anodized_errors.push_str("\n    COND_1") != ())
+                        & ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ());
+                    if !__anodized_precond {
+                        return Err((false, __anodized_errors));
+                    }
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    BODY
+                })());
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ())
+                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
+                            || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
+                    if !__anodized_postcond {
+                        return Err((true, __anodized_errors));
+                    }
+                }
+                Ok(__anodized_output)
+            }
+        }
+    };
+
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+        .instrument_item_impl(impl_spec, item_impl)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -78,7 +78,7 @@ fn default_instrument_item_impl() {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = (|| -> bool { COND_1 })()
                         & (|| -> bool { COND_2 })();
                     if !__anodized_precond {}
@@ -87,7 +87,7 @@ fn default_instrument_item_impl() {
                     BODY
                 })());
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = (|| -> bool { COND_2 })()
                         & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
                     if !__anodized_postcond {}
@@ -134,10 +134,10 @@ fn split_panic_instrument_item_impl() {
             #[doc(hidden)]
             #[inline]
             fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
-                -> Result<RET_TYPE, (bool, String)>
+                -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = ((|| -> bool { COND_1 })()
                             || __anodized_errors.push_str("\n    COND_1") != ())
                         & ((|| -> bool { COND_2 })()
@@ -150,7 +150,7 @@ fn split_panic_instrument_item_impl() {
                     BODY
                 })());
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = ((|| -> bool { COND_2 })()
                             || __anodized_errors.push_str("\n    COND_2") != ())
                         & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -114,7 +114,8 @@ fn split_panic_instrument_item_impl() {
                 binds: PAT_1,
                 ensures: COND_3,
             )]
-            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            // An associated `fn` (no receiver) is syntactically identical to a free-standing `fn`.
+            fn FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 BODY
             }
         }
@@ -122,8 +123,8 @@ fn split_panic_instrument_item_impl() {
 
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
-            fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-                match Self::__anodized_split_FUNC(self, input_1, input_2) {
+            fn FUNC(input_0: TYPE_1, input_1: TYPE_2) -> RET_TYPE {
+                match Self::__anodized_split_FUNC(input_0, input_1) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -132,7 +133,7 @@ fn split_panic_instrument_item_impl() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            fn __anodized_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> Result<RET_TYPE, (bool, String)>
             {
                 if true {

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -123,7 +123,7 @@ fn split_panic_instrument_item_impl() {
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
             fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-                match __anodized_split_FUNC(self, input_1, input_2) {
+                match Self::__anodized_split_FUNC(self, input_1, input_2) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -124,7 +124,7 @@ fn split_panic_instrument_item_impl() {
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
             fn FUNC(input_0: TYPE_1, input_1: TYPE_2) -> RET_TYPE {
-                match Self::__anodized_split_FUNC(input_0, input_1) {
+                match Self::__anodized_fn_split_FUNC(input_0, input_1) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -133,7 +133,7 @@ fn split_panic_instrument_item_impl() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> Result<RET_TYPE, (bool, String)>
             {
                 if true {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -132,7 +132,7 @@ impl Mode {
                     }
 
                     if let Self::InjectChecks(check_settings) = self
-                        && let Some(panic_settings) = check_settings.does_panic
+                        && let Some(ref panic_settings) = check_settings.does_panic
                         && panic_settings.split_func
                     {
                         // Build a wrapper that forwards to the "split" function.
@@ -285,7 +285,11 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     }
 
                     if let Mode::InjectChecks(_) = self {
-                        self.instrument_fn(&fn_spec, &func.sig, &mut func.block)?;
+                        self.with_split_func(false).instrument_fn(
+                            &fn_spec,
+                            &func.sig,
+                            &mut func.block,
+                        )?;
 
                         // Add a compile-time check to the body.
                         func.block.stmts.insert(

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -147,9 +147,11 @@ impl Mode {
                         // The "split" entry point is used for e.g. fuzzing and PBT.
                         func.sig.ident = mangled_ident;
                         func.sig.output = match func.sig.output {
-                            ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                            ReturnType::Default => {
+                                parse_quote!(-> Result<(), (bool, ::std::string::String)>)
+                            }
                             ReturnType::Type(ra, ty) => {
-                                parse_quote!(#ra Result<#ty, (bool, String)>)
+                                parse_quote!(#ra ::core::result::Result<#ty, (bool, ::std::string::String)>)
                             }
                         };
                         func.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -4,8 +4,8 @@ mod traits_tests;
 
 use quote::quote;
 use syn::{
-    Attribute, Block, FnArg, ImplItem, ImplItemFn, Pat, TraitItem, TraitItemFn, Visibility,
-    parse_quote,
+    Attribute, Block, FnArg, ImplItem, ImplItemFn, Pat, ReturnType, TraitItem, TraitItemFn,
+    Visibility, parse_quote,
 };
 
 use crate::{
@@ -129,6 +129,30 @@ impl Mode {
 
                         func.default = Some(forwarding_body);
                         func.semi_token = None;
+                    }
+
+                    if let Self::InjectChecks(check_settings) = self
+                        && let Some(panic_settings) = check_settings.does_panic
+                        && panic_settings.split_func
+                    {
+                        // Build a wrapper that forwards to the "split" function.
+                        let mut wrapper_func = func.clone();
+                        let mut wrapper_body: Block = parse_quote!({});
+                        let mangled_ident =
+                            Self::build_split_fn(true, &mut wrapper_func.sig, &mut wrapper_body);
+                        wrapper_func.default = Some(wrapper_body);
+                        new_trait_items.push(TraitItem::Fn(wrapper_func));
+
+                        // "Split" the original function by mangling its return type.
+                        // The "split" entry point is used for e.g. fuzzing and PBT.
+                        func.sig.ident = mangled_ident;
+                        func.sig.output = match func.sig.output {
+                            ReturnType::Default => parse_quote!(-> Result<(), (bool, String)>),
+                            ReturnType::Type(ra, ty) => {
+                                parse_quote!(#ra Result<#ty, (bool, String)>)
+                            }
+                        };
+                        func.attrs = vec![parse_quote!(#[doc(hidden)]), parse_quote!(#[inline])];
                     }
 
                     new_trait_items.push(TraitItem::Fn(func));

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -1,4 +1,4 @@
-use crate::{qualifiers::FnQualifiers, test_util::assert_tokens_eq};
+use crate::{instrument::CheckSettings, qualifiers::FnQualifiers, test_util::assert_tokens_eq};
 
 use super::*;
 use proc_macro2::TokenStream;
@@ -116,6 +116,86 @@ fn default_instrument_item_trait() {
     };
 
     let observed = Mode::DEFAULT
+        .instrument_item_trait(trait_spec, item_trait)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}
+
+#[test]
+fn split_panic_instrument_item_trait() {
+    let trait_spec = DataSpec::empty();
+    let item_trait: ItemTrait = parse_quote! {
+        trait TRAIT {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let qualifier_bits = FnQualifiers::empty().bits();
+    let expected: TokenStream = parse_quote! {
+        trait TRAIT {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_trait_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
+            #[doc(hidden)]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+
+            fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
+                match Self::__anodized_split_FUNC(self, input_1, input_2) {
+                    Ok(output) => output,
+                    Err((false, errors)) => panic!("precondition failed:{errors}"),
+                    Err((true, errors)) => panic!("postcondition failed:{errors}"),
+                }
+            }
+
+            #[doc(hidden)]
+            #[inline]
+            fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+                -> Result<RET_TYPE, (bool, String)>
+            {
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = ((|| -> bool { COND_1 })()
+                            || __anodized_errors.push_str("\n    COND_1") != ())
+                        & ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ());
+                    if !__anodized_precond {
+                        return Err((false, __anodized_errors));
+                    }
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
+                })());
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ())
+                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
+                            || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
+                    if !__anodized_postcond {
+                        return Err((true, __anodized_errors));
+                    }
+                }
+                Ok(__anodized_output)
+            }
+        }
+    };
+
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -313,3 +313,71 @@ fn default_instrument_item_impl_trait() {
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
+
+#[test]
+fn split_panic_instrument_item_impl_trait() {
+    let trait_spec = DataSpec::empty();
+    let item_impl: ItemImpl = parse_quote! {
+        impl TRAIT for IMPL_TYPE {
+            #[spec(
+                requires: COND_1,
+                maintains: COND_2,
+                binds: PAT_1,
+                ensures: COND_3,
+            )]
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                BODY
+            }
+        }
+    };
+
+    let qualifier_bits = FnQualifiers::empty().bits();
+    let expected: TokenStream = parse_quote! {
+        impl TRAIT for IMPL_TYPE {
+            #[doc(hidden)]
+            #[allow(warnings)]
+            const __anodized_fn_qualifiers_FUNC: u32 = #qualifier_bits;
+
+            #[inline]
+            fn __anodized_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                const {
+                    assert!(
+                        Self::__anodized_fn_qualifiers_FUNC ==
+                            Self::__anodized_fn_qualifiers_trait_FUNC |
+                            Self::__anodized_fn_qualifiers_FUNC,
+                        "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
+                    );
+                };
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_precond = ((|| -> bool { COND_1 })()
+                            || __anodized_errors.push_str("\n    COND_1") != ())
+                        & ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ());
+                    if !__anodized_precond {
+                        panic!("precondition failed:{__anodized_errors}");
+                    }
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| {
+                    BODY
+                })());
+                if true {
+                    let mut __anodized_errors = String::new();
+                    let __anodized_postcond = ((|| -> bool { COND_2 })()
+                            || __anodized_errors.push_str("\n    COND_2") != ())
+                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
+                            || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
+                    if !__anodized_postcond {
+                        panic!("postcondition failed:{__anodized_errors}");
+                    }
+                }
+                __anodized_output
+            }
+        }
+    };
+
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+        .instrument_item_trait_impl(trait_spec, item_impl)
+        .unwrap();
+    assert_tokens_eq(&observed, &expected);
+}

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -155,7 +155,7 @@ fn split_panic_instrument_item_trait() {
             }
 
             fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-                match Self::__anodized_split_FUNC(self, input_1, input_2) {
+                match Self::__anodized_fn_split_FUNC(self, input_1, input_2) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -164,7 +164,7 @@ fn split_panic_instrument_item_trait() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> Result<RET_TYPE, (bool, String)>
             {
                 if true {

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -96,7 +96,7 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = (|| -> bool { COND_1 })()
                         & (|| -> bool { COND_2 })();
                     if !__anodized_precond {}
@@ -105,7 +105,7 @@ fn default_instrument_item_trait() {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = (|| -> bool { COND_2 })()
                         & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
                     if !__anodized_postcond {}
@@ -165,10 +165,10 @@ fn split_panic_instrument_item_trait() {
             #[doc(hidden)]
             #[inline]
             fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
-                -> Result<RET_TYPE, (bool, String)>
+                -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = ((|| -> bool { COND_1 })()
                             || __anodized_errors.push_str("\n    COND_1") != ())
                         & ((|| -> bool { COND_2 })()
@@ -181,7 +181,7 @@ fn split_panic_instrument_item_trait() {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = ((|| -> bool { COND_2 })()
                             || __anodized_errors.push_str("\n    COND_2") != ())
                         & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
@@ -289,7 +289,7 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = (|| -> bool { COND_1 })()
                         & (|| -> bool { COND_2 })();
                     if !__anodized_precond {}
@@ -298,7 +298,7 @@ fn default_instrument_item_impl_trait() {
                     BODY
                 })());
                 if false {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = (|| -> bool { COND_2 })()
                         & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
                     if !__anodized_postcond {}
@@ -349,7 +349,7 @@ fn split_panic_instrument_item_impl_trait() {
                     );
                 };
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = ((|| -> bool { COND_1 })()
                             || __anodized_errors.push_str("\n    COND_1") != ())
                         & ((|| -> bool { COND_2 })()
@@ -362,7 +362,7 @@ fn split_panic_instrument_item_impl_trait() {
                     BODY
                 })());
                 if true {
-                    let mut __anodized_errors = String::new();
+                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = ((|| -> bool { COND_2 })()
                             || __anodized_errors.push_str("\n    COND_2") != ())
                         & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)

--- a/crates/anodized-macros/Cargo.toml
+++ b/crates/anodized-macros/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 proc-macro = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)", "cfg(anodized_split_func)"] }
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -46,8 +46,9 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
             let spec = parse_macro_input!(args as DataSpec);
             CONFIG.instrument_item_trait_impl(spec, the_impl)
         }
-        Item::Impl(ref the_impl) if the_impl.trait_.is_none() => {
-            Err(make_item_error(&item, "inherent impl"))
+        Item::Impl(the_impl) if the_impl.trait_.is_none() => {
+            let spec = parse_macro_input!(args as DataSpec);
+            CONFIG.instrument_item_impl(spec, the_impl)
         }
         Item::Const(_) => Err(make_item_error(&item, "const")),
         Item::Enum(the_enum) => {

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -14,6 +14,7 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
     Mode::InjectChecks(CheckSettings {
         does_print: cfg!(anodized_print),
         does_panic: cfg!(anodized_panic),
+        split_func: cfg!(anodized_split_func),
     })
 };
 

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -5,7 +5,7 @@ use syn::{Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
     DataSpec, Spec,
-    instrument::{CheckSettings, Mode, make_item_error},
+    instrument::{CheckSettings, Mode, PanicSettings, make_item_error},
 };
 
 const CONFIG: Mode = if cfg!(anodized_discard_specs) {
@@ -13,8 +13,13 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
 } else {
     Mode::InjectChecks(CheckSettings {
         does_print: cfg!(anodized_print),
-        does_panic: cfg!(anodized_panic),
-        split_func: cfg!(anodized_split_func),
+        does_panic: if cfg!(anodized_panic) {
+            Some(PanicSettings {
+                split_func: cfg!(anodized_split_func),
+            })
+        } else {
+            None
+        },
     })
 };
 

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 license.workspace = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)", "cfg(anodized_split_func)"] }
 
 [dependencies]
 anodized-logic.workspace = true

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -12,6 +12,7 @@ struct Job {
     state: State,
 }
 
+#[spec]
 impl Job {
     #[spec(
         requires: matches!(self.state, State::Idle),

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -143,6 +143,7 @@ fn precondition_runs_before_captures() {
         counter: u32,
     }
 
+    #[spec]
     impl TestStruct {
         #[spec(
             requires: self.counter < 100,

--- a/crates/anodized/tests/captures_feature.rs
+++ b/crates/anodized/tests/captures_feature.rs
@@ -18,6 +18,7 @@ struct Container {
     capacity: usize,
 }
 
+#[spec]
 impl Container {
     fn new() -> Self {
         Container {

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -6,6 +6,7 @@ struct Validator {
     valid: bool,
 }
 
+#[spec]
 impl Validator {
     fn is_valid(&self) -> bool {
         self.valid

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -6,6 +6,7 @@ struct Counter {
     capacity: u32,
 }
 
+#[spec]
 impl Counter {
     #[spec(
         maintains: self.count <= self.capacity,

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -7,6 +7,7 @@ struct SafeBuffer<T> {
     locked: bool,
 }
 
+#[spec]
 impl<T> SafeBuffer<T> {
     #[spec(
         requires: [


### PR DESCRIPTION
- Introduce `cfg(anodized_split_func)` to enable fuzzing and property-based testing (PBT).
- Expected to be used with `anodized_print` and `anodized_panic`.
- The generated `__anodized_fn_split_*` variant returns `Result<$OUTPUT, (bool, String)>` to defer panicking on pre/postcondition failure. The `bool` is precondition pass/fail, the `String` is error details.
- Among other uses, this allows a fuzzing or PBT harness to filter out inputs that fail the precondition.
- Treat a `fn` inside an inherent `impl` separately to correctly handle associated `fn`s.
- Extend `anodized-core` unit tests and update `anodized` integration tests.
- Extend CI to test the new setting.