### PR TITLE
feat: strict conditions

### DIFF
--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -5,7 +5,8 @@ mod fns_tests;
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Block, Expr, Ident, Meta, Pat, PatIdent, Path, ReturnType, Signature, Stmt, Type,
+    Attribute, Block, Expr, ExprClosure, Ident, Meta, Pat, PatIdent, Path, ReturnType, Signature,
+    Stmt, Type,
     parse::{Parse, Result},
     parse_quote,
 };
@@ -233,7 +234,7 @@ impl CheckSettings {
         let mut precondition_clauses: Vec<Expr> = vec![];
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let closure = &condition.closure;
-            let expr = parse_quote! { __anodized_eval_pre(&#closure) };
+            let expr = parse_quote! { __anodized_eval_pre(#closure) };
             let repr = condition.closure.body.to_token_stream().to_string();
             let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
             precondition_clauses.push(clause);
@@ -284,7 +285,7 @@ impl CheckSettings {
         let mut postcondition_clauses: Vec<Expr> = vec![];
         for condition in &spec.maintains {
             let closure = condition.closure.to_token_stream();
-            let expr = parse_quote! { __anodized_eval_inv(&#closure) };
+            let expr = parse_quote! { __anodized_eval_inv(#closure) };
             let repr = condition.closure.body.to_token_stream().to_string();
             let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
             postcondition_clauses.push(clause);
@@ -294,13 +295,14 @@ impl CheckSettings {
             let input = &closure.inputs.first().unwrap();
             let output = &closure.output;
             let body = &closure.body;
-            let expr = match input {
-                Pat::Type(_) => parse_quote! { __anodized_eval_post(&#closure, &#output_ident) },
+            let closure_expr = match input {
+                Pat::Type(_) => closure.clone(),
                 _ => parse_quote! {
                     // If the closure's input doesn't have a type ascription, add one.
-                    __anodized_eval_post(&|#input: &#return_type| #output { #body }, &#output_ident)
+                    |#input: &#return_type| #output { #body }
                 },
             };
+            let expr = parse_quote! { __anodized_eval_post(#closure_expr, &#output_ident) };
             // Omit the closure's return type for brevity.
             let repr = quote! { |#input| #body }.to_string();
             let clause = self.build_clause_eval(postcondition.cfg.as_ref(), &expr, &repr);
@@ -332,7 +334,7 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
-                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = #(#precondition_clauses)&*;
                     if !__anodized_precond {
@@ -341,8 +343,8 @@ impl CheckSettings {
                 }
                 #body_and_captures
                 if #do_run_checks {
-                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = #(#postcondition_clauses)&*;
                     if !__anodized_postcond {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -5,8 +5,7 @@ mod fns_tests;
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Block, Expr, ExprClosure, Ident, Meta, Pat, PatIdent, Path, ReturnType, Signature,
-    Stmt, Type,
+    Attribute, Block, Expr, Ident, Meta, Pat, PatIdent, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
     parse_quote,
 };

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -233,7 +233,7 @@ impl CheckSettings {
         let mut precondition_clauses: Vec<Expr> = vec![];
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let closure = &condition.closure;
-            let expr = parse_quote! { (#closure)() };
+            let expr = parse_quote! { __anodized_eval_pre(&#closure) };
             let repr = condition.closure.body.to_token_stream().to_string();
             let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
             precondition_clauses.push(clause);
@@ -284,7 +284,7 @@ impl CheckSettings {
         let mut postcondition_clauses: Vec<Expr> = vec![];
         for condition in &spec.maintains {
             let closure = condition.closure.to_token_stream();
-            let expr = parse_quote! { (#closure)() };
+            let expr = parse_quote! { __anodized_eval_inv(&#closure) };
             let repr = condition.closure.body.to_token_stream().to_string();
             let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
             postcondition_clauses.push(clause);
@@ -295,10 +295,10 @@ impl CheckSettings {
             let output = &closure.output;
             let body = &closure.body;
             let expr = match input {
-                Pat::Type(_) => parse_quote! { (#closure)(&#output_ident) },
+                Pat::Type(_) => parse_quote! { __anodized_eval_post(&#closure, &#output_ident) },
                 _ => parse_quote! {
                     // If the closure's input doesn't have a type ascription, add one.
-                    (|#input: &#return_type| #output { #body })(&#output_ident)
+                    __anodized_eval_post(&|#input: &#return_type| #output { #body }, &#output_ident)
                 },
             };
             // Omit the closure's return type for brevity.
@@ -332,6 +332,7 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
+                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = #(#precondition_clauses)&*;
                     if !__anodized_precond {
@@ -340,6 +341,8 @@ impl CheckSettings {
                 }
                 #body_and_captures
                 if #do_run_checks {
+                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = #(#postcondition_clauses)&*;
                     if !__anodized_postcond {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -91,14 +91,14 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
-                    & __anodized_eval_pre(&|| -> bool { COND_2 })
-                    & __anodized_eval_pre(&|| -> bool { COND_3 })
-                    & __anodized_eval_pre(&|| -> bool { COND_4 })
-                    & __anodized_eval_pre(&|| -> bool { COND_5 })
-                    & __anodized_eval_pre(&|| -> bool { COND_6 });
+                let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
+                    & __anodized_eval_pre(|| -> bool { COND_2 })
+                    & __anodized_eval_pre(|| -> bool { COND_3 })
+                    & __anodized_eval_pre(|| -> bool { COND_4 })
+                    & __anodized_eval_pre(|| -> bool { COND_5 })
+                    & __anodized_eval_pre(|| -> bool { COND_6 });
                 if !__anodized_precond {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output): (_, _, RET_TYPE) = (
@@ -109,15 +109,15 @@ fn default_instrument_item_fn() {
                 })(),
             );
             if false {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_4 })
-                    & __anodized_eval_inv(&|| -> bool { COND_5 })
-                    & __anodized_eval_inv(&|| -> bool { COND_6 })
-                    & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
-                    & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
-                    & __anodized_eval_post(&|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output);
+                let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_4 })
+                    & __anodized_eval_inv(|| -> bool { COND_5 })
+                    & __anodized_eval_inv(|| -> bool { COND_6 })
+                    & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
+                    & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
+                    & __anodized_eval_post(|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output);
                 if !__anodized_postcond {}
             }
             __anodized_output
@@ -152,19 +152,19 @@ fn split_panic_instrument_item_fn() {
             -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
                         || __anodized_errors.push_str("\n    COND_1") != ())
-                    & (!cfg!(META_1) || __anodized_eval_pre(&|| -> bool { COND_2 })
+                    & (!cfg!(META_1) || __anodized_eval_pre(|| -> bool { COND_2 })
                         || __anodized_errors.push_str("\n    COND_2") != ())
-                    & (!cfg!(META_1) || __anodized_eval_pre(&|| -> bool { COND_3 })
+                    & (!cfg!(META_1) || __anodized_eval_pre(|| -> bool { COND_3 })
                         || __anodized_errors.push_str("\n    COND_3") != ())
-                    & (__anodized_eval_pre(&|| -> bool { COND_4 })
+                    & (__anodized_eval_pre(|| -> bool { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (__anodized_eval_pre(&|| -> bool { COND_5 })
+                    & (__anodized_eval_pre(|| -> bool { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || __anodized_eval_pre(&|| -> bool { COND_6 })
+                    & (!cfg!(META_2) || __anodized_eval_pre(|| -> bool { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ());
                 if !__anodized_precond {
                     return Err((false, __anodized_errors));
@@ -178,21 +178,21 @@ fn split_panic_instrument_item_fn() {
                 })(),
             );
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_4 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (__anodized_eval_inv(&|| -> bool { COND_5 })
+                    & (__anodized_eval_inv(|| -> bool { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || __anodized_eval_inv(&|| -> bool { COND_6 })
+                    & (!cfg!(META_2) || __anodized_eval_inv(|| -> bool { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ())
-                    & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
+                    & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_1 | COND_7") != ())
                     & (!cfg!(META_3)
-                        || __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
+                        || __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_1 | COND_8") != ())
-                    & (!cfg!(META_3) || __anodized_eval_post(&|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output)
+                    & (!cfg!(META_3) || __anodized_eval_post(|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_2 : TYPE | COND_9") != ());
                 if !__anodized_postcond {
                     return Err((true, __anodized_errors));
@@ -232,9 +232,9 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -242,8 +242,8 @@ fn simple_requires() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -275,15 +275,15 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = __anodized_eval_pre(&|| -> bool { CONDITION_1 });
+                let __anodized_precond = __anodized_eval_pre(|| -> bool { CONDITION_1 });
                 if !__anodized_precond {}
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if false {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {}
@@ -306,9 +306,9 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     eprintln!("precondition failed:{__anodized_errors}");
@@ -316,8 +316,8 @@ fn requires_no_panic_runtime() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -346,9 +346,9 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -356,10 +356,10 @@ fn simple_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -387,7 +387,7 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -396,10 +396,10 @@ fn simple_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -428,11 +428,11 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -440,10 +440,10 @@ fn simple_requires_and_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -472,9 +472,9 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -482,10 +482,10 @@ fn simple_requires_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -514,9 +514,9 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -524,12 +524,12 @@ fn simple_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -559,11 +559,11 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -571,12 +571,12 @@ fn simple_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -606,11 +606,11 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -618,12 +618,12 @@ fn simple_async_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((async || #body)().await);
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -653,15 +653,15 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_3 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_4 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -669,16 +669,16 @@ fn multiple_conditions_in_clauses() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_3 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_3 })
                     || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_inv(&|| -> bool { CONDITION_4 })
+                    & (__anodized_eval_inv(|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_5") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_6 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_6 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_6") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -707,7 +707,7 @@ fn binds_parameter() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -716,10 +716,10 @@ fn binds_parameter() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(&|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | OUTPUT_PATTERN | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -752,7 +752,7 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -761,16 +761,16 @@ fn ensures_with_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ())
-                    & (__anodized_eval_post(&|PATTERN_1: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                    & (__anodized_eval_post(|PATTERN_1: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_1 | CONDITION_2") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ())
-                    & (__anodized_eval_post(&|PATTERN_2: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
+                    & (__anodized_eval_post(|PATTERN_2: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_2 | CONDITION_4") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -803,11 +803,11 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (!cfg!(SETTING_2) || __anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -815,13 +815,13 @@ fn cfg_attributes() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (!cfg!(SETTING_2) || __anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (!cfg!(SETTING_2) || __anodized_eval_inv(|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                        || __anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -853,13 +853,13 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_3 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -867,18 +867,18 @@ fn cfg_on_single_and_list_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_inv(&|| -> bool { CONDITION_3 })
+                    & (__anodized_eval_inv(|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
                     & (!cfg!(SETTING_2)
-                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
+                        || __anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_4") != ())
                     & (!cfg!(SETTING_2)
-                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
+                        || __anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_5") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -914,19 +914,19 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_2 })
+                    & (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_3 })
+                    & (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_4 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_pre(&|| -> bool { CONDITION_5 })
+                    & (__anodized_eval_pre(|| -> bool { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_pre(&|| -> bool { CONDITION_6 })
+                    & (!cfg!(SETTING_2) || __anodized_eval_pre(|| -> bool { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -934,22 +934,22 @@ fn complex_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_4 })
+                let __anodized_postcond = (__anodized_eval_inv(|| -> bool { CONDITION_4 })
                     || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_inv(&|| -> bool { CONDITION_5 })
+                    & (__anodized_eval_inv(|| -> bool { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_inv(&|| -> bool { CONDITION_6 })
+                    & (!cfg!(SETTING_2) || __anodized_eval_inv(|| -> bool { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_7 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_7 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_7") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_8 }, &__anodized_output)
+                        || __anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_8 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_8") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(&|PATTERN_1: &#ret_type| -> bool { CONDITION_9 }, &__anodized_output)
+                        || __anodized_eval_post(|PATTERN_1: &#ret_type| -> bool { CONDITION_9 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_1 | CONDITION_9") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -985,9 +985,9 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -995,13 +995,12 @@ fn captures() {
             }
             let (ALIAS_1, ALIAS_2, __anodized_output): (_, _, #ret_type) = ((| | EXPR_1) (), (| | EXPR_2) (), (|| #body)());
             if true {
-                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ())
-                    & (__anodized_eval_post(
-                        &|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                    & (__anodized_eval_post(|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -154,7 +154,7 @@ fn split_panic_instrument_item_fn() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { COND_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
                         || __anodized_errors.push_str("\n    COND_1") != ())
                     & (!cfg!(META_1) || __anodized_eval_pre(&|| -> bool { COND_2 })
                         || __anodized_errors.push_str("\n    COND_2") != ())
@@ -308,7 +308,7 @@ fn requires_no_panic_runtime() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     eprintln!("precondition failed:{__anodized_errors}");
@@ -348,7 +348,7 @@ fn simple_maintains() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -359,7 +359,7 @@ fn simple_maintains() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -399,7 +399,7 @@ fn simple_ensures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -430,7 +430,7 @@ fn simple_requires_and_maintains() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
@@ -443,7 +443,7 @@ fn simple_requires_and_maintains() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -474,7 +474,7 @@ fn simple_requires_and_ensures() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -485,7 +485,7 @@ fn simple_requires_and_ensures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -516,7 +516,7 @@ fn simple_maintains_and_ensures() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -527,7 +527,7 @@ fn simple_maintains_and_ensures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
@@ -561,7 +561,7 @@ fn simple_requires_maintains_and_ensures() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
@@ -574,7 +574,7 @@ fn simple_requires_maintains_and_ensures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
@@ -608,7 +608,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
@@ -621,7 +621,7 @@ fn simple_async_requires_maintains_and_ensures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
@@ -655,7 +655,7 @@ fn multiple_conditions_in_clauses() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
@@ -672,7 +672,7 @@ fn multiple_conditions_in_clauses() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_3 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_3 })
                     || __anodized_errors.push_str("\n    CONDITION_3") != ())
                     & (__anodized_eval_inv(&|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
@@ -719,7 +719,7 @@ fn binds_parameter() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_post(&|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(&|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | OUTPUT_PATTERN | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -764,7 +764,7 @@ fn ensures_with_mixed_conditions() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ())
                     & (__anodized_eval_post(&|PATTERN_1: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_1 | CONDITION_2") != ())
@@ -870,7 +870,7 @@ fn cfg_on_single_and_list_conditions() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (__anodized_eval_inv(&|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
@@ -916,7 +916,7 @@ fn complex_mixed_conditions() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
                     & (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
@@ -937,7 +937,7 @@ fn complex_mixed_conditions() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_4 })
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { CONDITION_4 })
                     || __anodized_errors.push_str("\n    CONDITION_4") != ())
                     & (__anodized_eval_inv(&|| -> bool { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
@@ -987,7 +987,7 @@ fn captures() {
             if true {
                 fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -998,7 +998,7 @@ fn captures() {
                 fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
                 fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
+                let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ())
                     & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -1000,7 +1000,8 @@ fn captures() {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ())
-                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
+                    & (__anodized_eval_post(
+                        &|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -91,13 +91,14 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (|| -> bool { COND_1 })()
-                    & (|| -> bool { COND_2 })()
-                    & (|| -> bool { COND_3 })()
-                    & (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })();
+                let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
+                    & __anodized_eval_pre(&|| -> bool { COND_2 })
+                    & __anodized_eval_pre(&|| -> bool { COND_3 })
+                    & __anodized_eval_pre(&|| -> bool { COND_4 })
+                    & __anodized_eval_pre(&|| -> bool { COND_5 })
+                    & __anodized_eval_pre(&|| -> bool { COND_6 });
                 if !__anodized_precond {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output): (_, _, RET_TYPE) = (
@@ -108,13 +109,15 @@ fn default_instrument_item_fn() {
                 })(),
             );
             if false {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (|| -> bool { COND_4 })()
-                    & (|| -> bool { COND_5 })()
-                    & (|| -> bool { COND_6 })()
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
-                    & (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
-                    & (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output);
+                let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_4 })
+                    & __anodized_eval_inv(&|| -> bool { COND_5 })
+                    & __anodized_eval_inv(&|| -> bool { COND_6 })
+                    & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
+                    & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
+                    & __anodized_eval_post(&|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output);
                 if !__anodized_postcond {}
             }
             __anodized_output
@@ -149,18 +152,19 @@ fn split_panic_instrument_item_fn() {
             -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { COND_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { COND_1 })
                         || __anodized_errors.push_str("\n    COND_1") != ())
-                    & (!cfg!(META_1) || (|| -> bool { COND_2 })()
+                    & (!cfg!(META_1) || __anodized_eval_pre(&|| -> bool { COND_2 })
                         || __anodized_errors.push_str("\n    COND_2") != ())
-                    & (!cfg!(META_1) || (|| -> bool { COND_3 })()
+                    & (!cfg!(META_1) || __anodized_eval_pre(&|| -> bool { COND_3 })
                         || __anodized_errors.push_str("\n    COND_3") != ())
-                    & ((|| -> bool { COND_4 })()
+                    & (__anodized_eval_pre(&|| -> bool { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & ((|| -> bool { COND_5 })()
+                    & (__anodized_eval_pre(&|| -> bool { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || (|| -> bool { COND_6 })()
+                    & (!cfg!(META_2) || __anodized_eval_pre(&|| -> bool { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ());
                 if !__anodized_precond {
                     return Err((false, __anodized_errors));
@@ -174,19 +178,21 @@ fn split_panic_instrument_item_fn() {
                 })(),
             );
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { COND_4 })()
+                let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & ((|| -> bool { COND_5 })()
+                    & (__anodized_eval_inv(&|| -> bool { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || (|| -> bool { COND_6 })()
+                    & (!cfg!(META_2) || __anodized_eval_inv(&|| -> bool { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ())
-                    & ((|PAT_1: &RET_TYPE| -> bool { COND_7 })(&__anodized_output)
+                    & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_7 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_1 | COND_7") != ())
                     & (!cfg!(META_3)
-                        || (|PAT_1: &RET_TYPE| -> bool { COND_8 })(&__anodized_output)
+                        || __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_8 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_1 | COND_8") != ())
-                    & (!cfg!(META_3) || (|PAT_2: TYPE| -> bool { COND_9 })(&__anodized_output)
+                    & (!cfg!(META_3) || __anodized_eval_post(&|PAT_2: TYPE| -> bool { COND_9 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PAT_2 : TYPE | COND_9") != ());
                 if !__anodized_postcond {
                     return Err((true, __anodized_errors));
@@ -226,8 +232,9 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = (__anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -235,6 +242,8 @@ fn simple_requires() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -266,12 +275,15 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (|| -> bool { CONDITION_1 })();
+                let __anodized_precond = __anodized_eval_pre(&|| -> bool { CONDITION_1 });
                 if !__anodized_precond {}
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if false {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {}
@@ -294,8 +306,9 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     eprintln!("precondition failed:{__anodized_errors}");
@@ -303,6 +316,8 @@ fn requires_no_panic_runtime() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -331,8 +346,9 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -340,8 +356,10 @@ fn simple_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -369,6 +387,7 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -377,8 +396,10 @@ fn simple_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
+                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -407,10 +428,11 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|| -> bool { CONDITION_2 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -418,8 +440,10 @@ fn simple_requires_and_maintains() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -448,8 +472,9 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -457,8 +482,10 @@ fn simple_requires_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
+                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -487,8 +514,9 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -496,10 +524,12 @@ fn simple_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -529,10 +559,11 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|| -> bool { CONDITION_2 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -540,10 +571,12 @@ fn simple_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -573,10 +606,11 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|| -> bool { CONDITION_2 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -584,10 +618,12 @@ fn simple_async_requires_maintains_and_ensures() {
             }
             let (__anodized_output): (#ret_type) = ((async || #body)().await);
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -617,14 +653,15 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|| -> bool { CONDITION_2 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & ((|| -> bool { CONDITION_3 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & ((|| -> bool { CONDITION_4 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -632,14 +669,16 @@ fn multiple_conditions_in_clauses() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_3 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_3 })
                     || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & ((|| -> bool { CONDITION_4 })()
+                    & (__anodized_eval_inv(&|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_5 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_5") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_6 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_6 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_6") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -668,6 +707,7 @@ fn binds_parameter() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -676,8 +716,10 @@ fn binds_parameter() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
+                let __anodized_postcond = ( __anodized_eval_post(&|OUTPUT_PATTERN: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | OUTPUT_PATTERN | CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -710,6 +752,7 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -718,14 +761,16 @@ fn ensures_with_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_1 })(&__anodized_output)
+                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_1 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_1") != ())
-                    & ((|PATTERN_1: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
+                    & (__anodized_eval_post(&|PATTERN_1: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_1 | CONDITION_2") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ())
-                    & ((|PATTERN_2: &#ret_type| -> bool { CONDITION_4 })(&__anodized_output)
+                    & (__anodized_eval_post(&|PATTERN_2: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_2 | CONDITION_4") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -758,10 +803,11 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || (|| -> bool { CONDITION_1 })()
+                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_2) || (|| -> bool { CONDITION_2 })()
+                    & (!cfg!(SETTING_2) || __anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -769,11 +815,13 @@ fn cfg_attributes() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (!cfg!(SETTING_2) || (|| -> bool { CONDITION_2 })()
+                let __anodized_postcond = (!cfg!(SETTING_2) || __anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (!cfg!(SETTING_3)
-                        || (|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
+                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -805,12 +853,13 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || (|| -> bool { CONDITION_1 })()
+                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & ((|| -> bool { CONDITION_2 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & ((|| -> bool { CONDITION_3 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -818,16 +867,18 @@ fn cfg_on_single_and_list_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_2 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & ((|| -> bool { CONDITION_3 })()
+                    & (__anodized_eval_inv(&|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
                     & (!cfg!(SETTING_2)
-                        || (|output: &#ret_type| -> bool { CONDITION_4 })(&__anodized_output)
+                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_4 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_4") != ())
                     & (!cfg!(SETTING_2)
-                        || (|output: &#ret_type| -> bool { CONDITION_5 })(&__anodized_output)
+                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_5 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_5") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -863,18 +914,19 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_1) || (|| -> bool { CONDITION_2 })()
+                    & (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (!cfg!(SETTING_1) || (|| -> bool { CONDITION_3 })()
+                    & (!cfg!(SETTING_1) || __anodized_eval_pre(&|| -> bool { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & ((|| -> bool { CONDITION_4 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & ((|| -> bool { CONDITION_5 })()
+                    & (__anodized_eval_pre(&|| -> bool { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || (|| -> bool { CONDITION_6 })()
+                    & (!cfg!(SETTING_2) || __anodized_eval_pre(&|| -> bool { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -882,20 +934,22 @@ fn complex_mixed_conditions() {
             }
             let (__anodized_output): (#ret_type) = ((|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|| -> bool { CONDITION_4 })()
+                let __anodized_postcond = ( __anodized_eval_inv(&|| -> bool { CONDITION_4 })
                     || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & ((|| -> bool { CONDITION_5 })()
+                    & (__anodized_eval_inv(&|| -> bool { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || (|| -> bool { CONDITION_6 })()
+                    & (!cfg!(SETTING_2) || __anodized_eval_inv(&|| -> bool { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_7 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_7 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_7") != ())
                     & (!cfg!(SETTING_3)
-                        || (|output: &#ret_type| -> bool { CONDITION_8 })(&__anodized_output)
+                        || __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_8 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_8") != ())
                     & (!cfg!(SETTING_3)
-                        || (|PATTERN_1: &#ret_type| -> bool { CONDITION_9 })(&__anodized_output)
+                        || __anodized_eval_post(&|PATTERN_1: &#ret_type| -> bool { CONDITION_9 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | PATTERN_1 | CONDITION_9") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -931,8 +985,9 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
+                fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ((|| -> bool { CONDITION_1 })()
+                let __anodized_precond = ( __anodized_eval_pre(&|| -> bool { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -940,10 +995,12 @@ fn captures() {
             }
             let (ALIAS_1, ALIAS_2, __anodized_output): (_, _, #ret_type) = ((| | EXPR_1) (), (| | EXPR_2) (), (|| #body)());
             if true {
+                fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ((|output: &#ret_type| -> bool { CONDITION_2 })(&__anodized_output)
+                let __anodized_postcond = ( __anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_2 }, &__anodized_output)
                     || __anodized_errors.push_str("\n    | output | CONDITION_2") != ())
-                    & ((|output: &#ret_type| -> bool { CONDITION_3 })(&__anodized_output)
+                    & (__anodized_eval_post(&|output: &#ret_type| -> bool { CONDITION_3 }, &__anodized_output)
                         || __anodized_errors.push_str("\n    | output | CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -75,24 +75,27 @@ fn default_instrument_item_impl() {
     };
 
     let expected: TokenStream = parse_quote! {
-        impl IMPL_TYPE {
-            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                if false {
-                    let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (|| -> bool { COND_1 })()
-                        & (|| -> bool { COND_2 })();
-                    if !__anodized_precond {}
-                }
-                let (__anodized_output): (RET_TYPE) = ((|| {
-                    BODY
-                })());
-                if false {
-                    let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (|| -> bool { COND_2 })()
-                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
-                    if !__anodized_postcond {}
-                }
-                __anodized_output
+            impl IMPL_TYPE {
+                fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                    if false {
+                        fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                        let mut __anodized_errors = ::std::string::String::new();
+                        let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
+                            & __anodized_eval_pre(&|| -> bool { COND_2 });
+                        if !__anodized_precond {}
+                    }
+                    let (__anodized_output): (RET_TYPE) = ((|| {
+                        BODY
+                    })());
+                    if false {
+                        fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                        let mut __anodized_errors = ::std::string::String::new();
+                        let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
+                            & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
+                        if !__anodized_postcond {}
+                    }
+                    __anodized_output
             }
         }
     };
@@ -133,30 +136,33 @@ fn split_panic_instrument_item_impl() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
-                -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
-            {
-                if true {
-                    let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ((|| -> bool { COND_1 })()
-                            || __anodized_errors.push_str("\n    COND_1") != ())
-                        & ((|| -> bool { COND_2 })()
-                            || __anodized_errors.push_str("\n    COND_2") != ());
-                    if !__anodized_precond {
-                        return Err((false, __anodized_errors));
+                fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+                    -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
+                {
+                    if true {
+                        fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                        let mut __anodized_errors = ::std::string::String::new();
+                        let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
+                                || __anodized_errors.push_str("\n    COND_1") != ())
+                            & (__anodized_eval_pre(&|| -> bool { COND_2 })
+                                || __anodized_errors.push_str("\n    COND_2") != ());
+                        if !__anodized_precond {
+                            return Err((false, __anodized_errors));
                     }
                 }
-                let (__anodized_output): (RET_TYPE) = ((|| {
-                    BODY
-                })());
-                if true {
-                    let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ((|| -> bool { COND_2 })()
-                            || __anodized_errors.push_str("\n    COND_2") != ())
-                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
-                            || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
-                    if !__anodized_postcond {
-                        return Err((true, __anodized_errors));
+                    let (__anodized_output): (RET_TYPE) = ((|| {
+                        BODY
+                    })());
+                    if true {
+                        fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                        let mut __anodized_errors = ::std::string::String::new();
+                        let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
+                                || __anodized_errors.push_str("\n    COND_2") != ())
+                            & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
+                                || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
+                        if !__anodized_postcond {
+                            return Err((true, __anodized_errors));
                     }
                 }
                 Ok(__anodized_output)

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -78,21 +78,21 @@ fn default_instrument_item_impl() {
             impl IMPL_TYPE {
                 fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                     if false {
-                        fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                         let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
-                            & __anodized_eval_pre(&|| -> bool { COND_2 });
+                        let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
+                            & __anodized_eval_pre(|| -> bool { COND_2 });
                         if !__anodized_precond {}
                     }
                     let (__anodized_output): (RET_TYPE) = ((|| {
                         BODY
                     })());
                     if false {
-                        fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                        fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                        fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                         let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
-                            & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
+                        let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_2 })
+                            & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
                         if !__anodized_postcond {}
                     }
                     __anodized_output
@@ -140,11 +140,11 @@ fn split_panic_instrument_item_impl() {
                     -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
                 {
                     if true {
-                        fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                         let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
+                        let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
                                 || __anodized_errors.push_str("\n    COND_1") != ())
-                            & (__anodized_eval_pre(&|| -> bool { COND_2 })
+                            & (__anodized_eval_pre(|| -> bool { COND_2 })
                                 || __anodized_errors.push_str("\n    COND_2") != ());
                         if !__anodized_precond {
                             return Err((false, __anodized_errors));
@@ -154,12 +154,12 @@ fn split_panic_instrument_item_impl() {
                         BODY
                     })());
                     if true {
-                        fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                        fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                        fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                        fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                         let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
+                        let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_2 })
                                 || __anodized_errors.push_str("\n    COND_2") != ())
-                            & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
+                            & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
                                 || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
                         if !__anodized_postcond {
                             return Err((true, __anodized_errors));

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -75,27 +75,25 @@ fn default_instrument_item_impl() {
     };
 
     let expected: TokenStream = parse_quote! {
-            impl IMPL_TYPE {
-                fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                    if false {
-                        fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
-                        let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
-                            & __anodized_eval_pre(|| -> bool { COND_2 });
-                        if !__anodized_precond {}
-                    }
-                    let (__anodized_output): (RET_TYPE) = ((|| {
-                        BODY
-                    })());
-                    if false {
-                        fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
-                        fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
-                        let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_2 })
-                            & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
-                        if !__anodized_postcond {}
-                    }
-                    __anodized_output
+        impl IMPL_TYPE {
+            fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+                if false {
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
+                    let mut __anodized_errors = ::std::string::String::new();
+                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
+                        & __anodized_eval_pre(|| -> bool { COND_2 });
+                    if !__anodized_precond {}
+                }
+                let (__anodized_output): (RET_TYPE) = ((|| { BODY })());
+                if false {
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    let mut __anodized_errors = ::std::string::String::new();
+                    let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_2 })
+                        & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
+                    if !__anodized_postcond {}
+                }
+                __anodized_output
             }
         }
     };
@@ -136,33 +134,31 @@ fn split_panic_instrument_item_impl() {
 
             #[doc(hidden)]
             #[inline]
-                fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
-                    -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
-                {
-                    if true {
-                        fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
-                        let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
-                                || __anodized_errors.push_str("\n    COND_1") != ())
-                            & (__anodized_eval_pre(|| -> bool { COND_2 })
-                                || __anodized_errors.push_str("\n    COND_2") != ());
-                        if !__anodized_precond {
-                            return Err((false, __anodized_errors));
+            fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+                -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
+            {
+                if true {
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
+                    let mut __anodized_errors = ::std::string::String::new();
+                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
+                            || __anodized_errors.push_str("\n    COND_1") != ())
+                        & (__anodized_eval_pre(|| -> bool { COND_2 })
+                            || __anodized_errors.push_str("\n    COND_2") != ());
+                    if !__anodized_precond {
+                        return Err((false, __anodized_errors));
                     }
                 }
-                    let (__anodized_output): (RET_TYPE) = ((|| {
-                        BODY
-                    })());
-                    if true {
-                        fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
-                        fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
-                        let mut __anodized_errors = ::std::string::String::new();
-                        let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_2 })
-                                || __anodized_errors.push_str("\n    COND_2") != ())
-                            & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
-                                || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
-                        if !__anodized_postcond {
-                            return Err((true, __anodized_errors));
+                let (__anodized_output): (RET_TYPE) = ((|| { BODY })());
+                if true {
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    let mut __anodized_errors = ::std::string::String::new();
+                    let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_2 })
+                            || __anodized_errors.push_str("\n    COND_2") != ())
+                        & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
+                            || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
+                    if !__anodized_postcond {
+                        return Err((true, __anodized_errors));
                     }
                 }
                 Ok(__anodized_output)

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -96,18 +96,21 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
+                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (|| -> bool { COND_1 })()
-                        & (|| -> bool { COND_2 })();
+                    let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
+                        & __anodized_eval_pre(&|| -> bool { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output): (RET_TYPE) = ((|| {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if false {
+                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (|| -> bool { COND_2 })()
-                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
+                    let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
+                        & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -168,10 +171,11 @@ fn split_panic_instrument_item_trait() {
                 -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {
+                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ((|| -> bool { COND_1 })()
+                    let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & ((|| -> bool { COND_2 })()
+                        & (__anodized_eval_pre(&|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         return Err((false, __anodized_errors));
@@ -181,10 +185,12 @@ fn split_panic_instrument_item_trait() {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if true {
+                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ((|| -> bool { COND_2 })()
+                    let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
+                        & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
                             || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
                     if !__anodized_postcond {
                         return Err((true, __anodized_errors));
@@ -289,18 +295,21 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
+                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (|| -> bool { COND_1 })()
-                        & (|| -> bool { COND_2 })();
+                    let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
+                        & __anodized_eval_pre(&|| -> bool { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output): (RET_TYPE) = ((|| {
                     BODY
                 })());
                 if false {
+                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (|| -> bool { COND_2 })()
-                        & (|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output);
+                    let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
+                        & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -349,10 +358,11 @@ fn split_panic_instrument_item_impl_trait() {
                     );
                 };
                 if true {
+                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ((|| -> bool { COND_1 })()
+                    let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & ((|| -> bool { COND_2 })()
+                        & (__anodized_eval_pre(&|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         panic!("precondition failed:{__anodized_errors}");
@@ -362,10 +372,12 @@ fn split_panic_instrument_item_impl_trait() {
                     BODY
                 })());
                 if true {
+                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ((|| -> bool { COND_2 })()
+                    let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & ((|PAT_1: &RET_TYPE| -> bool { COND_3 })(&__anodized_output)
+                        & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
                             || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
                     if !__anodized_postcond {
                         panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -96,21 +96,21 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
-                        & __anodized_eval_pre(&|| -> bool { COND_2 });
+                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
+                        & __anodized_eval_pre(|| -> bool { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output): (RET_TYPE) = ((|| {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if false {
-                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
-                        & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
+                    let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_2 })
+                        & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -171,11 +171,11 @@ fn split_panic_instrument_item_trait() {
                 -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {
-                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
+                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (__anodized_eval_pre(&|| -> bool { COND_2 })
+                        & (__anodized_eval_pre(|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         return Err((false, __anodized_errors));
@@ -185,12 +185,12 @@ fn split_panic_instrument_item_trait() {
                     Self::__anodized_FUNC(self, PARAM_1, PARAM_2)
                 })());
                 if true {
-                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
+                    let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
+                        & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
                             || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
                     if !__anodized_postcond {
                         return Err((true, __anodized_errors));
@@ -295,21 +295,21 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
-                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = __anodized_eval_pre(&|| -> bool { COND_1 })
-                        & __anodized_eval_pre(&|| -> bool { COND_2 });
+                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
+                        & __anodized_eval_pre(|| -> bool { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output): (RET_TYPE) = ((|| {
                     BODY
                 })());
                 if false {
-                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = __anodized_eval_inv(&|| -> bool { COND_2 })
-                        & __anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
+                    let __anodized_postcond = __anodized_eval_inv(|| -> bool { COND_2 })
+                        & __anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output);
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -358,11 +358,11 @@ fn split_panic_instrument_item_impl_trait() {
                     );
                 };
                 if true {
-                    fn __anodized_eval_pre(c: &impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (__anodized_eval_pre(&|| -> bool { COND_1 })
+                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (__anodized_eval_pre(&|| -> bool { COND_2 })
+                        & (__anodized_eval_pre(|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         panic!("precondition failed:{__anodized_errors}");
@@ -372,12 +372,12 @@ fn split_panic_instrument_item_impl_trait() {
                     BODY
                 })());
                 if true {
-                    fn __anodized_eval_inv(c: &impl Fn() -> bool) -> bool { c() }
-                    fn __anodized_eval_post<R>(c: &impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
+                    fn __anodized_eval_inv(c: impl Fn() -> bool) -> bool { c() }
+                    fn __anodized_eval_post<R>(c: impl Fn(&R) -> bool, r: &R) -> bool { c(r) }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (__anodized_eval_inv(&|| -> bool { COND_2 })
+                    let __anodized_postcond = (__anodized_eval_inv(|| -> bool { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (__anodized_eval_post(&|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
+                        & (__anodized_eval_post(|PAT_1: &RET_TYPE| -> bool { COND_3 }, &__anodized_output)
                             || __anodized_errors.push_str("\n    | PAT_1 | COND_3") != ());
                     if !__anodized_postcond {
                         panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized/tests/execution_order.rs
+++ b/crates/anodized/tests/execution_order.rs
@@ -1,6 +1,24 @@
 #![allow(clippy::unit_cmp, clippy::needless_return)]
 
 use anodized::spec;
+use std::cell::RefCell;
+
+struct ExecLog(RefCell<Vec<&'static str>>);
+
+#[allow(unused)]
+impl ExecLog {
+    fn new() -> Self {
+        Self(RefCell::new(Vec::new()))
+    }
+
+    fn push(&self, entry: &'static str) {
+        self.0.borrow_mut().push(entry);
+    }
+
+    fn into_vec(self) -> Vec<&'static str> {
+        self.0.into_inner()
+    }
+}
 
 #[spec(
     requires: [
@@ -21,7 +39,7 @@ use anodized::spec;
     ],
 )]
 #[allow(unused)]
-fn func(log: &mut Vec<&'static str>) {
+fn func(log: &ExecLog) {
     log.push("body");
     return;
 }
@@ -29,12 +47,12 @@ fn func(log: &mut Vec<&'static str>) {
 #[cfg(any(anodized_panic, anodized_print))]
 #[test]
 fn execution_order() {
-    let mut log = Vec::new();
-    func(&mut log);
+    let log = ExecLog::new();
+    func(&log);
 
     // Verify the exact execution order
     assert_eq!(
-        log,
+        log.into_vec(),
         [
             "requires1",
             "requires2",
@@ -70,7 +88,7 @@ fn execution_order() {
     ],
 )]
 #[allow(unused)]
-fn func_all_conditions_fail(log: &mut Vec<&'static str>) {
+fn func_all_conditions_fail(log: &ExecLog) {
     log.push("body");
     return;
 }
@@ -78,12 +96,12 @@ fn func_all_conditions_fail(log: &mut Vec<&'static str>) {
 #[cfg(all(anodized_print, not(anodized_panic)))]
 #[test]
 fn execution_order_print_only() {
-    let mut log = Vec::new();
-    func_all_conditions_fail(&mut log);
+    let log = ExecLog::new();
+    func_all_conditions_fail(&log);
 
     // Verify the exact execution order
     assert_eq!(
-        log,
+        log.into_vec(),
         [
             "requires1",
             "requires2",
@@ -119,7 +137,7 @@ fn execution_order_print_only() {
     ],
 )]
 #[allow(unused)]
-async fn async_func(log: &mut Vec<&'static str>) {
+async fn async_func(log: &ExecLog) {
     log.push("body");
     return;
 }
@@ -127,11 +145,11 @@ async fn async_func(log: &mut Vec<&'static str>) {
 #[cfg(any(anodized_panic, anodized_print))]
 #[test]
 fn async_execution_order() {
-    let mut log = Vec::new();
-    pollster::block_on(async_func(&mut log));
+    let log = ExecLog::new();
+    pollster::block_on(async_func(&log));
 
     assert_eq!(
-        log,
+        log.into_vec(),
         [
             "requires1",
             "requires2",


### PR DESCRIPTION
- Disallow a larger class of mutations inside pre/postconditions by evaluating each as an `Fn() -> bool`.
- Update `anodized-core` unit tests for the new generated pattern.
- Update `anodized` integration tests to conform to the new constraints.