### PR TITLE
refactor: rename `anodized_split_func` to `anodized_try`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - cfg: '--config ''build.rustflags=["--cfg","anodized_print"]'''
           - cfg: '--config ''build.rustflags=["--cfg","anodized_panic"]'''
           - cfg: '--config ''build.rustflags=["--cfg","anodized_print","--cfg","anodized_panic"]'''
-          - cfg: '--config ''build.rustflags=["--cfg","anodized_print","--cfg","anodized_panic","--cfg","anodized_split_func"]'''
+          - cfg: '--config ''build.rustflags=["--cfg","anodized_print","--cfg","anodized_panic","--cfg","anodized_try"]'''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
         run: cargo build
 
       - name: Lint fuzz targets
-        run: cargo clippy --manifest-path ./fuzz/Cargo.toml --all-targets --config 'build.rustflags=["--cfg","anodized_print", "--cfg","anodized_panic", "--cfg","anodized_split_func"]' -- -D warnings
+        run: cargo clippy --manifest-path ./fuzz/Cargo.toml --all-targets --config 'build.rustflags=["--cfg","anodized_print", "--cfg","anodized_panic", "--cfg","anodized_try"]' -- -D warnings
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -34,7 +34,7 @@ pub struct CheckSettings {
 #[derive(Debug, Clone)]
 pub struct PanicSettings {
     /// Generate an entry point that defers the panic. Used for fuzzing, PBT, etc.
-    pub split_func: bool,
+    pub has_try_fn: bool,
 }
 
 impl Mode {
@@ -42,23 +42,23 @@ impl Mode {
         !matches!(self, Mode::ChangeNothing)
     }
 
-    pub fn does_split_func(&self) -> bool {
+    pub fn emits_try_fn(&self) -> bool {
         if let Self::InjectChecks(check_settings) = self
             && let Some(panic_settings) = &check_settings.does_panic
         {
-            panic_settings.split_func
+            panic_settings.has_try_fn
         } else {
             false
         }
     }
 
-    pub fn with_split_func(&self, value: bool) -> Self {
+    pub fn with_try_fn(&self, value: bool) -> Self {
         match self {
             Mode::ChangeNothing => Mode::ChangeNothing,
             Mode::InjectChecks(check_settings) => {
                 let mut check_settings = check_settings.clone();
                 if let Some(panic_settings) = &mut check_settings.does_panic {
-                    panic_settings.split_func = value;
+                    panic_settings.has_try_fn = value;
                 };
                 Mode::InjectChecks(check_settings)
             }
@@ -121,16 +121,15 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
 
         if let Self::InjectChecks(check_settings) = self
             && let Some(ref panic_settings) = check_settings.does_panic
-            && panic_settings.split_func
+            && panic_settings.has_try_fn
         {
-            // Build a wrapper that forwards to the "split" function.
+            // Build a wrapper that forwards to the "try_fn" entry point.
             let mut wrapper_fn = item_fn.clone();
             let mangled_ident =
-                Self::build_split_fn(false, &mut wrapper_fn.sig, wrapper_fn.block.as_mut());
+                Self::build_try_fn(false, &mut wrapper_fn.sig, wrapper_fn.block.as_mut());
             wrapper_fn.to_tokens(&mut tokens);
 
-            // "Split" the original function by mangling its return type.
-            // The "split" entry point is used for e.g. fuzzing and PBT.
+            // Create the "try_fn" entry point for e.g. fuzzing and PBT.
             item_fn.sig.ident = mangled_ident;
             item_fn.sig.output = match item_fn.sig.output {
                 ReturnType::Default => parse_quote!(-> Result<(), (bool, ::std::string::String)>),
@@ -145,7 +144,7 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
         Ok(tokens)
     }
 
-    fn build_split_fn(is_impl: bool, sig: &mut Signature, body: &mut Block) -> Ident {
+    fn build_try_fn(is_impl: bool, sig: &mut Signature, body: &mut Block) -> Ident {
         let mangled_ident = fns::make_try_fn_ident(&sig.ident);
 
         Self::build_wrapper_fn_signature(sig);
@@ -234,12 +233,12 @@ impl CheckSettings {
 
     pub(crate) const PRINT_AND_PANIC: Self = Self {
         does_print: true,
-        does_panic: Some(PanicSettings { split_func: false }),
+        does_panic: Some(PanicSettings { has_try_fn: false }),
     };
 
-    pub(crate) const PRINT_AND_SPLIT_PANIC: Self = Self {
+    pub(crate) const PRINT_AND_TRY: Self = Self {
         does_print: true,
-        does_panic: Some(PanicSettings { split_func: true }),
+        does_panic: Some(PanicSettings { has_try_fn: true }),
     };
 }
 

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -146,7 +146,7 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
     }
 
     fn build_split_fn(is_impl: bool, sig: &mut Signature, body: &mut Block) -> Ident {
-        let mangled_ident = fns::make_split_fn_ident(&sig.ident);
+        let mangled_ident = fns::make_try_fn_ident(&sig.ident);
 
         Self::build_wrapper_fn_signature(sig);
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -380,7 +380,7 @@ impl CheckSettings {
 }
 
 pub(crate) fn make_split_fn_ident(ident: &Ident) -> Ident {
-    Ident::new(&format!("__anodized_fn_split_{ident}"), ident.span())
+    Ident::new(&format!("__anodized_fn_try_{ident}"), ident.span())
 }
 
 pub fn make_try_call(mut expr: Expr) -> Result<Expr> {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -379,7 +379,7 @@ impl CheckSettings {
     }
 }
 
-pub(crate) fn make_split_fn_ident(ident: &Ident) -> Ident {
+pub(crate) fn make_try_fn_ident(ident: &Ident) -> Ident {
     Ident::new(&format!("__anodized_fn_try_{ident}"), ident.span())
 }
 
@@ -390,12 +390,12 @@ pub fn make_try_call(mut expr: Expr) -> Result<Expr> {
                 && (path.qself.is_some() || path.path.segments.len() > 1)
             {
                 let last_segment = path.path.segments.last_mut().expect("last segment");
-                last_segment.ident = make_split_fn_ident(&last_segment.ident);
+                last_segment.ident = make_try_fn_ident(&last_segment.ident);
                 return Ok(expr);
             }
         }
         Expr::MethodCall(method_call) => {
-            method_call.method = make_split_fn_ident(&method_call.method);
+            method_call.method = make_try_fn_ident(&method_call.method);
             return Ok(expr);
         }
         _ => {}

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -315,7 +315,7 @@ impl CheckSettings {
 
         let (output_expr, precond_fail_action, postcond_fail_action) =
             if let Some(ref panic_settings) = self.does_panic
-                && panic_settings.split_func
+                && panic_settings.has_try_fn
             {
                 (
                     quote! { Ok(#output_ident) },

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -139,7 +139,7 @@ fn split_panic_instrument_item_fn() {
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-            match __anodized_fn_split_FUNC(self, input_1, input_2) {
+            match __anodized_fn_try_FUNC(self, input_1, input_2) {
                 Ok(output) => output,
                 Err((false, errors)) => panic!("precondition failed:{errors}"),
                 Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -148,7 +148,7 @@ fn split_panic_instrument_item_fn() {
 
         #[doc(hidden)]
         #[inline]
-        fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+        fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
             -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
         {
             if true {
@@ -1023,7 +1023,7 @@ fn try_call_free_fn() {
     };
 
     let expected: Expr = parse_quote! {
-        module::__anodized_fn_split_FUNC(arg_1, arg_2)
+        module::__anodized_fn_try_FUNC(arg_1, arg_2)
     };
 
     let observed = make_try_call(input).expect("tryify");
@@ -1037,7 +1037,7 @@ fn try_call_method() {
     };
 
     let expected: Expr = parse_quote! {
-        receiver.__anodized_fn_split_METHOD(arg_1, arg_2)
+        receiver.__anodized_fn_try_METHOD(arg_1, arg_2)
     };
 
     let observed = make_try_call(input).expect("tryify");
@@ -1051,7 +1051,7 @@ fn try_call_associated_fn() {
     };
 
     let expected: Expr = parse_quote! {
-        Type::__anodized_fn_split_FUNC(arg_1, arg_2)
+        Type::__anodized_fn_try_FUNC(arg_1, arg_2)
     };
 
     let observed = make_try_call(input).expect("tryify");
@@ -1065,7 +1065,7 @@ fn try_call_turbofish_associated_fn() {
     };
 
     let expected: Expr = parse_quote! {
-        <Type>::__anodized_fn_split_FUNC(arg_1, arg_2)
+        <Type>::__anodized_fn_try_FUNC(arg_1, arg_2)
     };
 
     let observed = make_try_call(input).expect("tryify");
@@ -1079,7 +1079,7 @@ fn try_call_trait_fn() {
     };
 
     let expected: Expr = parse_quote! {
-        <Type as Trait>::__anodized_fn_split_FUNC(arg_1, arg_2)
+        <Type as Trait>::__anodized_fn_try_FUNC(arg_1, arg_2)
     };
 
     let observed = make_try_call(input).expect("tryify");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -129,7 +129,7 @@ fn default_instrument_item_fn() {
 }
 
 #[test]
-fn emit_try_fn_item_fn() {
+fn emit_try_fn_instrument_item_fn() {
     let fn_spec = make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -129,7 +129,7 @@ fn default_instrument_item_fn() {
 }
 
 #[test]
-fn split_panic_instrument_item_fn() {
+fn emit_try_fn_item_fn() {
     let fn_spec = make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
@@ -202,7 +202,7 @@ fn split_panic_instrument_item_fn() {
         }
     };
 
-    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
         .instrument_item_fn(fn_spec, item_fn)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -15,7 +15,7 @@ impl Mode {
     /// Expand items inside an inherent impl.
     ///
     /// Reasons why impl functions must be treated differently from free-standing functions:
-    /// - The `__anodized_fn_split_*` function must be qualified as `Self::` inside an impl.
+    /// - The `__anodized_fn_try_*` function must be qualified as `Self::` inside an impl.
     pub fn instrument_impl(&self, spec: DataSpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
         if the_impl.trait_.is_some() {
             return Err(make_item_error(&the_impl, "trait impl"));

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -98,16 +98,15 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
 
                     if let Self::InjectChecks(check_settings) = self
                         && let Some(ref panic_settings) = check_settings.does_panic
-                        && panic_settings.split_func
+                        && panic_settings.has_try_fn
                     {
-                        // Build a wrapper that forwards to the "split" function.
+                        // Build a wrapper that forwards to the "try_fn" entry point.
                         let mut wrapper_fn = item_fn.clone();
                         let mangled_ident =
-                            Self::build_split_fn(true, &mut wrapper_fn.sig, &mut wrapper_fn.block);
+                            Self::build_try_fn(true, &mut wrapper_fn.sig, &mut wrapper_fn.block);
                         new_items.push(ImplItem::Fn(wrapper_fn));
 
-                        // "Split" the original function by mangling its return type.
-                        // The "split" entry point is used for e.g. fuzzing and PBT.
+                        // Create the "try_fn" entry point for e.g. fuzzing and PBT.
                         item_fn.sig.ident = mangled_ident;
                         item_fn.sig.output = match item_fn.sig.output {
                             ReturnType::Default => {

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -105,7 +105,7 @@ fn default_instrument_item_impl() {
 }
 
 #[test]
-fn split_panic_instrument_item_impl() {
+fn emit_try_fn_instrument_item_impl() {
     let impl_spec = DataSpec::empty();
     let item_impl: ItemImpl = parse_quote! {
         impl IMPL_TYPE {
@@ -166,7 +166,7 @@ fn split_panic_instrument_item_impl() {
         }
     };
 
-    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
         .instrument_item_impl(impl_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -125,7 +125,7 @@ fn split_panic_instrument_item_impl() {
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
             fn FUNC(input_0: TYPE_1, input_1: TYPE_2) -> RET_TYPE {
-                match Self::__anodized_fn_split_FUNC(input_0, input_1) {
+                match Self::__anodized_fn_try_FUNC(input_0, input_1) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -134,7 +134,7 @@ fn split_panic_instrument_item_impl() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_fn_split_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            fn __anodized_fn_try_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -133,18 +133,17 @@ impl Mode {
 
                     if let Self::InjectChecks(check_settings) = self
                         && let Some(ref panic_settings) = check_settings.does_panic
-                        && panic_settings.split_func
+                        && panic_settings.has_try_fn
                     {
-                        // Build a wrapper that forwards to the "split" function.
+                        // Build a wrapper that forwards to the "try_fn" entry point.
                         let mut wrapper_func = func.clone();
                         let mut wrapper_body: Block = parse_quote!({});
                         let mangled_ident =
-                            Self::build_split_fn(true, &mut wrapper_func.sig, &mut wrapper_body);
+                            Self::build_try_fn(true, &mut wrapper_func.sig, &mut wrapper_body);
                         wrapper_func.default = Some(wrapper_body);
                         new_trait_items.push(TraitItem::Fn(wrapper_func));
 
-                        // "Split" the original function by mangling its return type.
-                        // The "split" entry point is used for e.g. fuzzing and PBT.
+                        // Create the "try_fn" entry point for e.g. fuzzing and PBT.
                         func.sig.ident = mangled_ident;
                         func.sig.output = match func.sig.output {
                             ReturnType::Default => {
@@ -287,7 +286,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     }
 
                     if let Mode::InjectChecks(_) = self {
-                        self.with_split_func(false).instrument_fn(
+                        self.with_try_fn(false).instrument_fn(
                             &fn_spec,
                             &func.sig,
                             &mut func.block,

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -125,7 +125,7 @@ fn default_instrument_item_trait() {
 }
 
 #[test]
-fn split_panic_instrument_item_trait() {
+fn emit_try_fn_instrument_item_trait() {
     let trait_spec = DataSpec::empty();
     let item_trait: ItemTrait = parse_quote! {
         trait TRAIT {
@@ -201,7 +201,7 @@ fn split_panic_instrument_item_trait() {
         }
     };
 
-    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
         .instrument_item_trait(trait_spec, item_trait)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -324,7 +324,7 @@ fn default_instrument_item_impl_trait() {
 }
 
 #[test]
-fn split_panic_instrument_item_impl_trait() {
+fn emit_try_fn_instrument_item_impl_trait() {
     let trait_spec = DataSpec::empty();
     let item_impl: ItemImpl = parse_quote! {
         impl TRAIT for IMPL_TYPE {
@@ -388,7 +388,7 @@ fn split_panic_instrument_item_impl_trait() {
         }
     };
 
-    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_SPLIT_PANIC)
+    let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
         .instrument_item_trait_impl(trait_spec, item_impl)
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -158,7 +158,7 @@ fn split_panic_instrument_item_trait() {
             }
 
             fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
-                match Self::__anodized_fn_split_FUNC(self, input_1, input_2) {
+                match Self::__anodized_fn_try_FUNC(self, input_1, input_2) {
                     Ok(output) => output,
                     Err((false, errors)) => panic!("precondition failed:{errors}"),
                     Err((true, errors)) => panic!("postcondition failed:{errors}"),
@@ -167,7 +167,7 @@ fn split_panic_instrument_item_trait() {
 
             #[doc(hidden)]
             #[inline]
-            fn __anodized_fn_split_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
+            fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::core::result::Result<RET_TYPE, (bool, ::std::string::String)>
             {
                 if true {

--- a/crates/anodized-macros/Cargo.toml
+++ b/crates/anodized-macros/Cargo.toml
@@ -15,7 +15,7 @@ license.workspace = true
 proc-macro = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)", "cfg(anodized_split_func)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(anodized_discard_specs)", "cfg(anodized_panic)", "cfg(anodized_print)", "cfg(anodized_try)"] }
 
 [dependencies]
 anodized-core.workspace = true

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -17,7 +17,7 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
         does_print: cfg!(anodized_print),
         does_panic: if cfg!(anodized_panic) {
             Some(PanicSettings {
-                split_func: cfg!(anodized_split_func),
+                split_func: cfg!(anodized_try),
             })
         } else {
             None
@@ -111,7 +111,7 @@ pub fn try_call(args: TokenStream) -> TokenStream {
     if !CONFIG.does_split_func() {
         return syn::Error::new(
             Span::call_site(),
-            "`try_call` needs the `anodized_split_func` build `cfg` to be enabled",
+            "`try_call` needs the `anodized_try` build `cfg` to be enabled",
         )
         .to_compile_error()
         .into();

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -17,7 +17,7 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
         does_print: cfg!(anodized_print),
         does_panic: if cfg!(anodized_panic) {
             Some(PanicSettings {
-                split_func: cfg!(anodized_try),
+                has_try_fn: cfg!(anodized_try),
             })
         } else {
             None
@@ -108,7 +108,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     - `<Type as Trait>::trait_fn(...)`
 #[proc_macro]
 pub fn try_call(args: TokenStream) -> TokenStream {
-    if !CONFIG.does_split_func() {
+    if !CONFIG.emits_try_fn() {
         return syn::Error::new(
             Span::call_site(),
             "`try_call` needs the `anodized_try` build `cfg` to be enabled",

--- a/crates/anodized/Cargo.toml
+++ b/crates/anodized/Cargo.toml
@@ -17,7 +17,7 @@ check-cfg = [
     "cfg(anodized_discard_specs)",
     "cfg(anodized_panic)",
     "cfg(anodized_print)",
-    "cfg(anodized_split_func)",
+    "cfg(anodized_try)",
 ]
 
 [dependencies]

--- a/examples/bin-search/.cargo/config.toml
+++ b/examples/bin-search/.cargo/config.toml
@@ -4,12 +4,12 @@ target-applies-to-host = false
 rustflags = [
     "--cfg", "anodized_print",
     "--cfg", "anodized_panic",
-    "--cfg", "anodized_split_func",
+    "--cfg", "anodized_try",
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
     "--cfg", "anodized_print",
     "--cfg", "anodized_panic",
-    "--cfg", "anodized_split_func",
+    "--cfg", "anodized_try",
 ]


### PR DESCRIPTION
- `__anodized_fn_split_*` -> `__anodized_fn_try_*`
- `split_func` -> `has_try_fn`
- etc.