### PR TITLE
[anodized-core] refactor: clean up Pre/PostConditions

### DIFF
--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -5,7 +5,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, DataSpec, LoopSpec, LoopVariant, PostCondition, PreCondition, Spec,
+    Capture, Condition, DataSpec, LoopSpec, LoopVariant, Spec,
     annotate::syntax::{CaptureExpr, SpecArg, SpecArgValue},
     qualifiers::FnQualifiers,
 };
@@ -23,11 +23,11 @@ impl Parse for Spec {
 
         let mut errors = MultiError::empty();
         let mut qualifiers = FnQualifiers::empty();
-        let mut requires: Vec<PreCondition> = vec![];
-        let mut maintains: Vec<PreCondition> = vec![];
+        let mut requires: Vec<Condition> = vec![];
+        let mut maintains: Vec<Condition> = vec![];
         let mut captures: Vec<Capture> = vec![];
         let mut binds_pattern: Option<Pat> = None;
-        let mut ensures: Vec<PostCondition> = vec![];
+        let mut ensures: Vec<Condition> = vec![];
 
         let is_sorted = raw_spec.is_sorted();
 
@@ -163,7 +163,7 @@ impl Parse for DataSpec {
         let raw_spec = syntax::SpecArgs::parse(input)?;
 
         let mut errors = MultiError::empty();
-        let mut maintains: Vec<PreCondition> = vec![];
+        let mut maintains: Vec<Condition> = vec![];
 
         for arg in raw_spec.args {
             match arg.keyword {
@@ -206,7 +206,7 @@ impl Parse for LoopSpec {
 
         let mut errors = MultiError::empty();
         let mut decreases = None;
-        let mut maintains: Vec<PreCondition> = vec![];
+        let mut maintains: Vec<Condition> = vec![];
 
         for arg in raw_spec.args {
             match arg.keyword {
@@ -284,7 +284,7 @@ impl SpecArg {
         Ok(())
     }
 
-    fn parse_preconditions(self, preconditions: &mut Vec<PreCondition>) -> Result<()> {
+    fn parse_preconditions(self, preconditions: &mut Vec<Condition>) -> Result<()> {
         let cfg_attr = find_cfg_attribute(&self.attrs)?;
         let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
             Some(attr.parse_args()?)
@@ -294,13 +294,13 @@ impl SpecArg {
         let expr = self.value.try_into_expr()?;
         if let Expr::Array(conditions) = expr {
             for expr in conditions.elems {
-                preconditions.push(PreCondition {
+                preconditions.push(Condition {
                     expr,
                     cfg: cfg.clone(),
                 });
             }
         } else {
-            preconditions.push(PreCondition { expr, cfg });
+            preconditions.push(Condition { expr, cfg });
         }
         Ok(())
     }
@@ -340,7 +340,7 @@ impl SpecArg {
         Ok(())
     }
 
-    fn parse_postconditions(self, postconditions: &mut Vec<PostCondition>) -> Result<()> {
+    fn parse_postconditions(self, postconditions: &mut Vec<Condition>) -> Result<()> {
         let cfg_attr = find_cfg_attribute(&self.attrs)?;
         let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
             Some(attr.parse_args()?)
@@ -350,13 +350,13 @@ impl SpecArg {
         let expr = self.value.try_into_expr()?;
         if let Expr::Array(conditions) = expr {
             for expr in conditions.elems {
-                postconditions.push(PostCondition {
+                postconditions.push(Condition {
                     expr,
                     cfg: cfg.clone(),
                 });
             }
         } else {
-            postconditions.push(PostCondition { expr, cfg });
+            postconditions.push(Condition { expr, cfg });
         }
         Ok(())
     }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -87,12 +87,12 @@ impl Parse for Spec {
                     }
                 }
                 Keyword::Requires => {
-                    if let Err(error) = arg.parse_preconditions(&mut requires) {
+                    if let Err(error) = arg.parse_conditions(&mut requires) {
                         errors.add(error);
                     }
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_preconditions(&mut maintains) {
+                    if let Err(error) = arg.parse_conditions(&mut maintains) {
                         errors.add(error);
                     }
                 }
@@ -119,7 +119,7 @@ impl Parse for Spec {
                     }
                 }
                 Keyword::Ensures => {
-                    if let Err(error) = arg.parse_postconditions(&mut ensures) {
+                    if let Err(error) = arg.parse_conditions(&mut ensures) {
                         errors.add(error);
                     }
                 }
@@ -174,7 +174,7 @@ impl Parse for DataSpec {
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_preconditions(&mut maintains) {
+                    if let Err(error) = arg.parse_conditions(&mut maintains) {
                         errors.add(error);
                     }
                 }
@@ -217,7 +217,7 @@ impl Parse for LoopSpec {
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_preconditions(&mut maintains) {
+                    if let Err(error) = arg.parse_conditions(&mut maintains) {
                         errors.add(error);
                     }
                 }
@@ -284,7 +284,7 @@ impl SpecArg {
         Ok(())
     }
 
-    fn parse_preconditions(self, preconditions: &mut Vec<Condition>) -> Result<()> {
+    fn parse_conditions(self, conditions: &mut Vec<Condition>) -> Result<()> {
         let cfg_attr = find_cfg_attribute(&self.attrs)?;
         let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
             Some(attr.parse_args()?)
@@ -292,15 +292,15 @@ impl SpecArg {
             None
         };
         let expr = self.value.try_into_expr()?;
-        if let Expr::Array(conditions) = expr {
-            for expr in conditions.elems {
-                preconditions.push(Condition {
+        if let Expr::Array(items) = expr {
+            for expr in items.elems {
+                conditions.push(Condition {
                     expr,
                     cfg: cfg.clone(),
                 });
             }
         } else {
-            preconditions.push(Condition { expr, cfg });
+            conditions.push(Condition { expr, cfg });
         }
         Ok(())
     }
@@ -337,27 +337,6 @@ impl SpecArg {
         }
         let binds_pattern = self.value.try_into_pat()?;
         *pattern = Some(binds_pattern);
-        Ok(())
-    }
-
-    fn parse_postconditions(self, postconditions: &mut Vec<Condition>) -> Result<()> {
-        let cfg_attr = find_cfg_attribute(&self.attrs)?;
-        let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
-            Some(attr.parse_args()?)
-        } else {
-            None
-        };
-        let expr = self.value.try_into_expr()?;
-        if let Expr::Array(conditions) = expr {
-            for expr in conditions.elems {
-                postconditions.push(Condition {
-                    expr,
-                    cfg: cfg.clone(),
-                });
-            }
-        } else {
-            postconditions.push(Condition { expr, cfg });
-        }
         Ok(())
     }
 

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -13,14 +13,14 @@ fn simple_spec() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { is_valid(x) },
             cfg: None,
         }],
         maintains: vec![],
         captures: vec![],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { output > x },
             cfg: None,
         }],
@@ -191,17 +191,17 @@ fn all_clauses() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { x > 0 && x.is_power_of_two() },
             cfg: None,
         }],
-        maintains: vec![PreCondition {
+        maintains: vec![Condition {
             expr: parse_quote! { self.is_valid() },
             cfg: None,
         }],
         captures: vec![],
         binds: Some(parse_quote! { z }),
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { z >= x },
             cfg: None,
         }],
@@ -266,11 +266,11 @@ fn array_of_conditions() {
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
-            PreCondition {
+            Condition {
                 expr: parse_quote! { x >= 0 },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { y.len() < 10 },
                 cfg: None,
             },
@@ -279,11 +279,11 @@ fn array_of_conditions() {
         captures: vec![],
         binds: None,
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output != x },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output.is_some() },
                 cfg: None,
             },
@@ -306,7 +306,7 @@ fn ensures_with_explicit_closure() {
         maintains: vec![],
         captures: vec![],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { result.is_ok() || result.unwrap_err().kind() == ErrorKind::NotFound },
             cfg: None,
         }],
@@ -325,14 +325,14 @@ fn precondition_expression_is_preserved() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { x > 0 },
             cfg: None,
         }],
         maintains: vec![],
         captures: vec![],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { result > x },
             cfg: None,
         }],
@@ -354,11 +354,11 @@ fn multiple_clauses_of_same_flavor() {
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
-            PreCondition {
+            Condition {
                 expr: parse_quote! { x > 0 || x < -10 },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { y.is_ascii() },
                 cfg: None,
             },
@@ -367,11 +367,11 @@ fn multiple_clauses_of_same_flavor() {
         captures: vec![],
         binds: None,
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output < x },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output.len() >= y.len() },
                 cfg: None,
             },
@@ -400,15 +400,15 @@ fn mixed_single_and_array_clauses() {
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
-            PreCondition {
+            Condition {
                 expr: parse_quote! { x == 0 },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { y > 1 },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { z.is_empty() || z.contains("foo") },
                 cfg: None,
             },
@@ -417,15 +417,15 @@ fn mixed_single_and_array_clauses() {
         captures: vec![],
         binds: None,
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output != y },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output.starts_with(z) },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { output.len() > x },
                 cfg: None,
             },
@@ -447,14 +447,14 @@ fn cfg_attributes() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { x > 0 && is_mode() },
             cfg: Some(parse_quote! { test }),
         }],
         maintains: vec![],
         captures: vec![],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { output < x },
             cfg: Some(parse_quote! { not(debug_assertions) }),
         }],
@@ -502,17 +502,17 @@ fn macro_in_condition() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle) },
             cfg: None,
         }],
-        maintains: vec![PreCondition {
+        maintains: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle | State::Running | State::Finished) },
             cfg: None,
         }],
         captures: vec![],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Running) },
             cfg: None,
         }],
@@ -539,11 +539,11 @@ fn binds_pattern() {
         captures: vec![],
         binds: Some(parse_quote! { (a, b) }),
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { a <= b },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { (a, b) == pair || (b, a) == pair },
                 cfg: None,
             },
@@ -568,20 +568,20 @@ fn multiple_conditions() {
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
-            PreCondition {
+            Condition {
                 expr: parse_quote! { self.initialized },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { !self.locked },
                 cfg: None,
             },
-            PreCondition {
+            Condition {
                 expr: parse_quote! { index < self.items.len() },
                 cfg: None,
             },
         ],
-        maintains: vec![PreCondition {
+        maintains: vec![Condition {
             expr: parse_quote! { self.items.len() <= self.items.capacity() },
             cfg: None,
         }],
@@ -611,11 +611,11 @@ fn rename_return_value() {
         captures: vec![],
         binds: Some(parse_quote! { result }),
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { result > output },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { val % 2 == 0 },
                 cfg: None,
             },
@@ -642,7 +642,7 @@ fn captures_simple_identifier() {
             pat: parse_quote! { old_count },
         }],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { output == old_count + 1 },
             cfg: None,
         }],
@@ -668,7 +668,7 @@ fn captures_identifier_with_alias() {
             pat: parse_quote! { prev_value },
         }],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { output > prev_value },
             cfg: None,
         }],
@@ -713,15 +713,15 @@ fn captures_array() {
         ],
         binds: None,
         ensures: vec![
-            PostCondition {
+            Condition {
                 expr: parse_quote! { count == old_count + 1 },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { index == old_index + 1 },
                 cfg: None,
             },
-            PostCondition {
+            Condition {
                 expr: parse_quote! { value > old_value },
                 cfg: None,
             },
@@ -744,11 +744,11 @@ fn captures_with_all_clauses() {
 
     let expected = Spec {
         qualifiers: FnQualifiers::empty(),
-        requires: vec![PreCondition {
+        requires: vec![Condition {
             expr: parse_quote! { x > 0 },
             cfg: None,
         }],
-        maintains: vec![PreCondition {
+        maintains: vec![Condition {
             expr: parse_quote! { self.is_valid() },
             cfg: None,
         }],
@@ -757,7 +757,7 @@ fn captures_with_all_clauses() {
             pat: parse_quote! { old_val },
         }],
         binds: Some(parse_quote! { result }),
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { result > old_val },
             cfg: None,
         }],
@@ -792,7 +792,7 @@ fn captures_array_expression() {
             pat: parse_quote! { slice },
         }],
         binds: None,
-        ensures: vec![PostCondition {
+        ensures: vec![Condition {
             expr: parse_quote! { slice.len() == 3 },
             cfg: None,
         }],

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -11,7 +11,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, PostCondition, PreCondition, Spec,
+    Capture, Condition, Spec,
     instrument::{CheckSettings, Mode},
     qualifiers::FnQualifiers,
 };
@@ -119,10 +119,7 @@ impl Mode {
         }
     }
 
-    pub fn build_precondition_fn_body(
-        requires: &[PreCondition],
-        maintains: &[PreCondition],
-    ) -> Block {
+    pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut statements: Vec<Stmt> = vec![];
         let mut clauses: Vec<Expr> = vec![];
 
@@ -147,10 +144,10 @@ impl Mode {
     }
 
     pub fn build_postcondition_fn_body(
-        maintains: &[PreCondition],
+        maintains: &[Condition],
         captures: &[Capture],
         binds: &Option<Pat>,
-        ensures: &[PostCondition],
+        ensures: &[Condition],
     ) -> Result<Block> {
         let mut statements: Vec<Stmt> = vec![];
         let mut clauses: Vec<Expr> = vec![];

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -251,18 +251,11 @@ impl CheckSettings {
 
         // Generate postcondition checks.
         let mut postcondition_clauses: Vec<Expr> = vec![];
-        for condition in &spec.maintains {
+        for condition in spec.maintains.iter().chain(&spec.ensures) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { __anodized_eval_post(|| -> bool { #expr }) };
             let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
-            postcondition_clauses.push(clause);
-        }
-        for postcondition in &spec.ensures {
-            let expr = &postcondition.expr;
-            let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { __anodized_eval_post(|| -> bool { #expr }) };
-            let clause = self.build_clause_eval(postcondition.cfg.as_ref(), &expr, &repr);
             postcondition_clauses.push(clause);
         }
         if postcondition_clauses.is_empty() {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -215,7 +215,7 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { __anodized_eval_pre(|| -> bool { #expr }) };
-            let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
+            let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             precondition_clauses.push(clause);
         }
         if precondition_clauses.is_empty() {
@@ -255,7 +255,7 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { __anodized_eval_post(|| -> bool { #expr }) };
-            let clause = self.build_clause_eval(condition.cfg.as_ref(), &expr, &repr);
+            let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             postcondition_clauses.push(clause);
         }
         if postcondition_clauses.is_empty() {
@@ -315,7 +315,7 @@ impl CheckSettings {
         })
     }
 
-    fn build_clause_eval(&self, cfg: Option<&Meta>, expr: &Expr, repr: &str) -> Expr {
+    fn build_clause_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
             let br_and_repr = format!("\n    {repr}");
             let cfg_guard = match cfg {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -19,15 +19,15 @@ pub struct Spec {
     /// Qualifiers that constrain the behavior of the computation.
     pub qualifiers: FnQualifiers,
     /// Preconditions: conditions that must hold when the function is called.
-    pub requires: Vec<PreCondition>,
+    pub requires: Vec<Condition>,
     /// Invariants: conditions that must hold both when the function is called and when it returns.
-    pub maintains: Vec<PreCondition>,
+    pub maintains: Vec<Condition>,
     /// Captures: expressions to snapshot at function entry for use in postconditions.
     pub captures: Vec<Capture>,
     /// Binds: pattern to bind the output of the function.
     pub binds: Option<Pat>,
     /// Postconditions: conditions that must hold when the function returns.
-    pub ensures: Vec<PostCondition>,
+    pub ensures: Vec<Condition>,
     /// The span in the source code, from which this spec was parsed.
     span: Span,
 }
@@ -65,7 +65,7 @@ impl Spec {
 #[derive(Debug)]
 pub struct DataSpec {
     /// Invariants: conditions that must hold for all instances of the data type.
-    pub maintains: Vec<PreCondition>,
+    pub maintains: Vec<Condition>,
     /// The span in the source code, from which this spec was parsed.
     span: Span,
 }
@@ -94,7 +94,7 @@ impl DataSpec {
 #[derive(Debug)]
 pub struct LoopSpec {
     /// Loop invariants: conditions that must hold both before and after the loop's body runs.
-    pub maintains: Vec<PreCondition>,
+    pub maintains: Vec<Condition>,
     /// Loop variant: an expression that decreases with each run of the loop's body.
     pub decreases: Option<LoopVariant>,
     /// The span in the source code, from which this spec was parsed.
@@ -122,23 +122,11 @@ impl LoopSpec {
     }
 }
 
-/// A precondition represented by a `bool`-valued expression.
+/// A condition represented by a `bool`-valued expression.
 #[derive(Debug)]
 // TODO: Rename to `Condition` for clarity.
-pub struct PreCondition {
-    /// The expression that validates the precondition, e.g. `input.is_valid()`.
-    pub expr: Expr,
-    /// **Static analyzers can safely ignore this field.**
-    ///
-    /// Build configuration filter to decide whether to add runtime checks.
-    /// Passed to a `cfg!()` guard in the instrumented function.
-    pub cfg: Option<Meta>,
-}
-
-/// A postcondition represented by a closure that takes the return value as a reference.
-#[derive(Debug)]
-pub struct PostCondition {
-    /// The expression that validates the postcondition, e.g. `*output > 0`.
+pub struct Condition {
+    /// The expression that validates the condition, e.g. `value > 42`.
     pub expr: Expr,
     /// **Static analyzers can safely ignore this field.**
     ///

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,4 +1,4 @@
-use crate::{Capture, PostCondition, PreCondition, Spec};
+use crate::{Capture, Condition, Spec};
 use pretty_assertions::assert_eq;
 use quote::{ToTokens, quote};
 
@@ -52,25 +52,20 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
         left_requires,
         right_requires,
         "requires",
-        assert_precondition_eq,
+        assert_condition_eq,
     );
     assert_slice_eq(
         left_maintains,
         right_maintains,
         "maintains",
-        assert_precondition_eq,
+        assert_condition_eq,
     );
     assert_slice_eq(left_captures, right_captures, "captures", assert_capture_eq);
     assert_eq!(
         left_binds, right_binds,
         "binds patterns do not match: {left_binds:?} vs {right_binds:?}"
     );
-    assert_slice_eq(
-        left_ensures,
-        right_ensures,
-        "ensures",
-        assert_postcondition_eq,
-    );
+    assert_slice_eq(left_ensures, right_ensures, "ensures", assert_condition_eq);
 }
 
 fn assert_slice_eq<T, F>(left: &[T], right: &[T], item_name: &str, assert_item_eq: F)
@@ -90,14 +85,14 @@ where
     }
 }
 
-fn assert_precondition_eq(left: &PreCondition, right: &PreCondition, msg_prefix: &str) {
+fn assert_condition_eq(left: &Condition, right: &Condition, msg_prefix: &str) {
     // Destructure to ensure we handle all fields
-    let PreCondition {
+    let Condition {
         expr: left_expr,
         cfg: left_cfg,
     } = left;
 
-    let PreCondition {
+    let Condition {
         expr: right_expr,
         cfg: right_cfg,
     } = right;
@@ -106,33 +101,6 @@ fn assert_precondition_eq(left: &PreCondition, right: &PreCondition, msg_prefix:
         left_expr.to_token_stream().to_string(),
         right_expr.to_token_stream().to_string(),
         "{}`expr` does not match",
-        msg_prefix
-    );
-
-    assert_eq!(
-        left_cfg.to_token_stream().to_string(),
-        right_cfg.to_token_stream().to_string(),
-        "{}`cfg` does not match",
-        msg_prefix
-    );
-}
-
-fn assert_postcondition_eq(left: &PostCondition, right: &PostCondition, msg_prefix: &str) {
-    // Destructure to ensure we handle all fields
-    let PostCondition {
-        expr: left_closure,
-        cfg: left_cfg,
-    } = left;
-
-    let PostCondition {
-        expr: right_closure,
-        cfg: right_cfg,
-    } = right;
-
-    assert_eq!(
-        left_closure.to_token_stream().to_string(),
-        right_closure.to_token_stream().to_string(),
-        "{}`closure` does not match",
         msg_prefix
     );
 


### PR DESCRIPTION
- Merge `PreCondition` and `PostCondition` into `Condition`.
- Merge `parse_preconditions` and `parse_postconditions` into `parse_conditions`.
- Simplify instrumentation.
- Update `test_util`.