### PR TITLE
feat: support postconditions in closure-array form

### DIFF
--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -320,44 +320,56 @@ impl SpecArg {
             None
         };
         let expr = self.value.try_into_expr()?;
-        if let Expr::Array(items) = expr {
-            for expr in items.elems {
-                if let Expr::Closure(mut closure_form) = expr {
-                    if closure_form.inputs.len() != 1 {
-                        return Err(Error::new_spanned(
-                            closure_form,
-                            "postcondition closure must have exactly one input",
-                        ));
+        match expr {
+            Expr::Closure(mut closure) => {
+                if closure.inputs.len() != 1 {
+                    return Err(Error::new_spanned(
+                        closure,
+                        "postcondition closure must have exactly one input",
+                    ));
+                }
+                let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
+                if let Expr::Array(array) = *closure.body {
+                    for expr in array.elems {
+                        postconds.push(PostCondition {
+                            pat: Some(pat.clone()),
+                            expr,
+                            cfg: cfg.clone(),
+                        });
                     }
-                    let (pat, _) = closure_form.inputs.pop().unwrap().into_tuple();
-                    postconds.push(PostCondition {
-                        pat: Some(pat),
-                        expr: *closure_form.body,
-                        cfg: cfg.clone(),
-                    });
                 } else {
                     postconds.push(PostCondition {
-                        pat: None,
-                        expr,
+                        pat: Some(pat),
+                        expr: *closure.body,
                         cfg: cfg.clone(),
                     });
                 }
             }
-        } else {
-            if let Expr::Closure(mut closure_form) = expr {
-                if closure_form.inputs.len() != 1 {
-                    return Err(Error::new_spanned(
-                        closure_form,
-                        "postcondition closure must have exactly one input",
-                    ));
+            Expr::Array(array) => {
+                for expr in array.elems {
+                    if let Expr::Closure(mut closure) = expr {
+                        if closure.inputs.len() != 1 {
+                            return Err(Error::new_spanned(
+                                closure,
+                                "postcondition closure must have exactly one input",
+                            ));
+                        }
+                        let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
+                        postconds.push(PostCondition {
+                            pat: Some(pat),
+                            expr: *closure.body,
+                            cfg: cfg.clone(),
+                        });
+                    } else {
+                        postconds.push(PostCondition {
+                            pat: None,
+                            expr,
+                            cfg: cfg.clone(),
+                        });
+                    }
                 }
-                let (pat, _) = closure_form.inputs.pop().unwrap().into_tuple();
-                postconds.push(PostCondition {
-                    pat: Some(pat),
-                    expr: *closure_form.body,
-                    cfg: cfg.clone(),
-                });
-            } else {
+            }
+            _ => {
                 postconds.push(PostCondition {
                     pat: None,
                     expr,

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -376,6 +376,10 @@ fn mixed_single_and_array_clauses() {
             |val| output.starts_with(z),
         ],
         ensures: retval.len() > x,
+        ensures: |output| [
+            output >= x,
+            x != z,
+        ],
     };
 
     let expected = Spec {
@@ -411,6 +415,16 @@ fn mixed_single_and_array_clauses() {
             PostCondition {
                 pat: None,
                 expr: parse_quote! { retval.len() > x },
+                cfg: None,
+            },
+            PostCondition {
+                pat: Some(parse_quote! { output }),
+                expr: parse_quote! { output >= x },
+                cfg: None,
+            },
+            PostCondition {
+                pat: Some(parse_quote! { output }),
+                expr: parse_quote! { x != z },
                 cfg: None,
             },
         ],

--- a/crates/anodized/tests/compile_fail/closure_form_errors.rs
+++ b/crates/anodized/tests/compile_fail/closure_form_errors.rs
@@ -25,7 +25,7 @@ fn some_func() -> i32 {
 }
 
 #[spec(
-    // Should fail: cannot re-bind the postcondition's input.
+    // Should fail: cannot nest postcondition closures.
     ensures: |output| [
         output >= 42,
         |answer| answer <= 42,

--- a/crates/anodized/tests/compile_fail/closure_form_errors.rs
+++ b/crates/anodized/tests/compile_fail/closure_form_errors.rs
@@ -24,4 +24,15 @@ fn some_func() -> i32 {
     todo!()
 }
 
+#[spec(
+    // Should fail: cannot re-bind the postcondition's input.
+    ensures: |output| [
+        output >= 42,
+        |answer| answer <= 42,
+    ],
+)]
+fn some_func_2() -> i32 {
+    todo!()
+}
+
 fn main() {}

--- a/crates/anodized/tests/compile_fail/closure_form_errors.stderr
+++ b/crates/anodized/tests/compile_fail/closure_form_errors.stderr
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
   --> tests/compile_fail/closure_form_errors.rs:31:9
    |
 27 | / #[spec(
-28 | |     // Should fail: cannot re-bind the postcondition's input.
+28 | |     // Should fail: cannot nest postcondition closures.
 29 | |     ensures: |output| [
 30 | |         output >= 42,
 31 | |         |answer| answer <= 42,

--- a/crates/anodized/tests/compile_fail/closure_form_errors.stderr
+++ b/crates/anodized/tests/compile_fail/closure_form_errors.stderr
@@ -19,3 +19,23 @@ error[E0308]: mismatched types
    | |                       ^^ expected `bool`, found integer
 22 | | )]
    | |__- expected `bool` because of return type
+
+error[E0308]: mismatched types
+  --> tests/compile_fail/closure_form_errors.rs:31:9
+   |
+27 | / #[spec(
+28 | |     // Should fail: cannot re-bind the postcondition's input.
+29 | |     ensures: |output| [
+30 | |         output >= 42,
+31 | |         |answer| answer <= 42,
+   | |         ^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found closure
+32 | |     ],
+33 | | )]
+   | |__- expected `bool` because of return type
+   |
+   = note: expected type `bool`
+           found closure `{closure@$DIR/tests/compile_fail/closure_form_errors.rs:31:9: 31:17}`
+help: use parentheses to call this closure
+   |
+31 |         (|answer| answer <= 42)(/* value */),
+   |         +                     ++++++++++++++


### PR DESCRIPTION
- A postcondition in closure-array form is the following: `ensures: |PAT| [EXPR, EXPR, ...]`.
- This is designed to replace the `inspects: PAT` field that applies to all `ensures:` fields.