### PR TITLE
feat: replace `SpecArg` with `syn::FieldValue`

### DIFF
--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -24,26 +24,26 @@ This crate is the interoperability layer for tools connected to the [Anodized](h
 
 ## Specification Syntax
 
-The `#[spec]` attribute's parameters follow a specific grammar, which is formally defined using EBNF as follows.
+The `#[spec]` attribute's fields follow a specific grammar, which is formally defined using EBNF as follows.
 
 ```ebnf
-params = [ requires_params ]
-       , [ maintains_params ]
+fields = [ qualifiers ]
+         [ requires_fields ]
+       , [ maintains_fields ]
        (* not a typo: at most one `captures:` *)
-       , [ captures_param ]
-       (* not a typo: at most one `inspects:` *)
-       , [ inspects_param ]
-       , [ ensures_params ];
+       , [ captures_field ]
+       , [ ensures_fields ];
 
-requires_params  = { requires_param };
-maintains_params = { maintains_param };
-ensures_params   = { ensures_param };
+qualifiers = TODO
+requires_fields  = { requires_field };
+maintains_fields = { maintains_field };
+ensures_fields   = { ensures_field };
 
-requires_param  = [ cfg_attr ] , `requires:` , pre_conditions, `,`;
-maintains_param = [ cfg_attr ] , `maintains:` , pre_conditions, `,`;
-captures_param  = `captures:` , captures, `,`;
-inspects_param     = `inspects:` , pattern, `,`;
-ensures_param   = [ cfg_attr ] , `ensures:` , post_conditions, `,`;
+requires_field  = [ cfg_attr ] , `requires:` , pre_conditions, `,`;
+maintains_field = [ cfg_attr ] , `maintains:` , pre_conditions, `,`;
+captures_field  = `captures:` , captures, `,`;
+inspects_field  = `inspects:` , pattern, `,`;
+ensures_field   = [ cfg_attr ] , `ensures:` , post_conditions, `,`;
 
 pre_conditions = pre_condition_expr | pre_condition_list;
 pre_condition_list = `[` , pre_condition_expr , { `,` , pre_condition_expr } , [ `,` ] , `]`;
@@ -63,9 +63,9 @@ cfg_attr = `#[cfg(` , settings , `)]`;
 **Notes:**
 
 - The last `,` is optional.
-- The `params` rule defines a sequence of optional parameter groups that must appear in the specified order.
+- The `fields` rule defines a sequence of optional field groups that must appear in the specified order.
 - `expr` is a Rust [`expression`](https://doc.rust-lang.org/reference/expressions.html); type checking will fail if it does not evaluate to `bool`.
-- `pre_closure_expr` is a Rust [`closure`](https://doc.rust-lang.org/reference/expressions/closure-expr.html) that receives no inputs and returns `bool`; type checking will fail if it does not evaluate to `bool` and does not take no arguments.
+- `pre_closure_expr` is a Rust [`closure`](https://doc.rust-lang.org/reference/expressions/closure-expr.html) that receives no inputs and returns `bool`; type checking will fail if it does not evaluate to `bool`.
 - `post_closure_expr` is a Rust [`closure`](https://doc.rust-lang.org/reference/expressions/closure-expr.html) that receives the function's return value as a reference; type checking will fail if it does not evaluate to `bool`.
 - `pattern` is an irrefutable Rust [`pattern`](https://doc.rust-lang.org/reference/patterns.html); type checking will fail if its type does not match the function's return value.
 - `settings` is the content of the [`cfg`](https://doc.rust-lang.org/reference/conditional-compilation.html) attribute (e.g. `test`, `debug_assertions`).
@@ -83,7 +83,7 @@ Given an original function like this:
     captures: <ALIAS> = <CAPTURE_EXPR>,
     ensures: |<PATTERN>| <POSTCONDITION>,
 )]
-fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
+fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
     <BODY>
 }
 ```
@@ -91,7 +91,7 @@ fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
 The macro rewrites the body to be conceptually equivalent to the following:
 
 ```rust,ignore
-fn my_function(<ARGUMENTS>) -> <RETURN_TYPE> {
+fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
     // 1. Preconditions and invariants are checked
     check!((| | <PRECONDITION>)(), "Precondition failed: <PRECONDITION>");
     check!((| | <INVARIANT>)(), "Pre-invariant failed: <INVARIANT>");

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -7,8 +7,7 @@ use syn::{
 
 use crate::{
     Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec,
-    annotate::syntax::{SpecArg, SpecArgValue},
-    qualifiers::FnQualifiers,
+    annotate::syntax::SpecArg, qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -262,7 +261,7 @@ impl SpecArg {
                 format!("attributes are not supported on `{}`", self.keyword),
             ));
         }
-        if !matches!(self.value, SpecArgValue::None) {
+        if !matches!(self.value, None) {
             return Err(Error::new_spanned(
                 self.value,
                 format!("qualifier `{}` does not take a value", self.keyword),
@@ -285,7 +284,9 @@ impl SpecArg {
         } else {
             None
         };
-        let expr = self.value.try_into_expr()?;
+        let Some(expr) = self.value else {
+            return Err(Error::new_spanned(self.value, "expected an expression"));
+        };
         if let Expr::Array(items) = expr {
             for expr in items.elems {
                 conditions.push(Condition {
@@ -306,7 +307,9 @@ impl SpecArg {
         } else {
             None
         };
-        let expr = self.value.try_into_expr()?;
+        let Some(expr) = self.value else {
+            return Err(Error::new_spanned(self.value, "expected an expression"));
+        };
         match expr {
             Expr::Closure(mut closure) => {
                 if closure.inputs.len() != 1 {
@@ -375,7 +378,9 @@ impl SpecArg {
                 "`cfg` attribute is not supported on `captures`",
             ));
         }
-        let capture_list = self.value.try_into_expr()?;
+        let Some(capture_list) = self.value else {
+            return Err(Error::new_spanned(self.value, "expected an expression"));
+        };
         match capture_list {
             Expr::Assign(assignment) => {
                 captures.push(interpret_assignment_as_capture(assignment)?);
@@ -406,7 +411,9 @@ impl SpecArg {
             None
         };
         let expr_span = self.value.span();
-        let expr = self.value.try_into_expr()?;
+        let Some(expr) = self.value else {
+            return Err(Error::new_spanned(self.value, "expected an expression"));
+        };
         if let Expr::Array(_) = expr {
             return Err(Error::new(expr_span, "expected a single expression"));
         } else {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -103,7 +103,7 @@ impl Parse for Spec {
                     if !captures.is_empty() {
                         errors.add(Error::new_spanned(
                             &field.member,
-                            "at most one `captures` parameter is allowed; to capture multiple values, use a list: `captures: [binding1 = expr1, binding2 = expr2, ...]`",
+                            "at most one `captures` field is allowed; to capture multiple values, use a list: `captures: [binding1 = expr1, binding2 = expr2, ...]`",
                         ));
                     }
                     if let Err(error) = parse_captures(field, &mut captures) {
@@ -125,7 +125,7 @@ impl Parse for Spec {
                     errors.add(Error::new_spanned(
                         &field.member,
                         format!(
-                            "`{}` parameter is not supported here",
+                            "`{}` field is not supported here",
                             field.member.to_token_stream(),
                         ),
                     ));
@@ -136,7 +136,7 @@ impl Parse for Spec {
         if !is_sorted {
             errors.add(Error::new(
                 input.span(),
-                " are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `inspects`, `ensures`, where `<QUALIFIERS>` are:\n
+                "fields are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `inspects`, `ensures`, where `<QUALIFIERS>` are:\n
 `functional` (`pure` and `total`),\n
 `pure` (`deterministic` and `effectfree`),\n
 `total` (`infallible` and `terminating`)",
@@ -183,7 +183,7 @@ impl Parse for DataSpec {
                     errors.add(Error::new_spanned(
                         &field.member,
                         format!(
-                            "`{}` parameter is not supported here",
+                            "`{}` field is not supported here",
                             field.member.to_token_stream(),
                         ),
                     ));
@@ -230,7 +230,7 @@ impl Parse for LoopSpec {
                     if decreases.is_some() {
                         errors.add(Error::new_spanned(
                             &field.member,
-                            "multiple `decreases` parameters are not allowed",
+                            "multiple `decreases` fields are not allowed",
                         ));
                     }
                     if let Err(error) = parse_decreases(field, &mut decreases) {
@@ -241,7 +241,7 @@ impl Parse for LoopSpec {
                     errors.add(Error::new_spanned(
                         &field.member,
                         format!(
-                            "`{}` parameter is not supported here",
+                            "`{}` field is not supported here",
                             field.member.to_token_stream(),
                         ),
                     ));
@@ -252,7 +252,7 @@ impl Parse for LoopSpec {
         if !is_sorted {
             errors.add(Error::new(
                 input.span(),
-                "parameters are out of order: the expected order is `maintains`, `decreases`",
+                "fields are out of order: the expected order is `maintains`, `decreases`",
             ));
         }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -20,7 +20,7 @@ mod annotate_tests;
 
 impl Parse for Spec {
     fn parse(input: ParseStream) -> Result<Self> {
-        let raw_spec = syntax::SpecArgs::parse(input)?;
+        let raw_spec = syntax::SpecFields::parse(input)?;
 
         let mut errors = MultiError::empty();
         let mut qualifiers = FnQualifiers::empty();
@@ -31,101 +31,102 @@ impl Parse for Spec {
 
         let is_sorted = raw_spec.is_sorted();
 
-        for arg in raw_spec.args {
-            let keyword = Keyword::from(&arg.member);
+        for field in raw_spec.fields {
+            let keyword = Keyword::from(&field.member);
             match keyword {
                 Keyword::Unknown(ident) => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Functional => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::FUNCTIONAL, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::FUNCTIONAL, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Pure => {
-                    if let Err(error) = parse_fn_qualifier(arg, FnQualifiers::PURE, &mut qualifiers)
+                    if let Err(error) =
+                        parse_fn_qualifier(field, FnQualifiers::PURE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Total => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::TOTAL, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::TOTAL, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Deterministic => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::DETERMINISTIC, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::DETERMINISTIC, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Effectfree => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::EFFECTFREE, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::EFFECTFREE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Infallible => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::INFALLIBLE, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::INFALLIBLE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Terminating => {
                     if let Err(error) =
-                        parse_fn_qualifier(arg, FnQualifiers::TERMINATING, &mut qualifiers)
+                        parse_fn_qualifier(field, FnQualifiers::TERMINATING, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Requires => {
-                    if let Err(error) = parse_conditions(arg, &mut requires) {
+                    if let Err(error) = parse_conditions(field, &mut requires) {
                         errors.add(error);
                     }
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = parse_conditions(arg, &mut maintains) {
+                    if let Err(error) = parse_conditions(field, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 Keyword::Captures => {
                     if !captures.is_empty() {
                         errors.add(Error::new_spanned(
-                            &arg.member,
+                            &field.member,
                             "at most one `captures` parameter is allowed; to capture multiple values, use a list: `captures: [binding1 = expr1, binding2 = expr2, ...]`",
                         ));
                     }
-                    if let Err(error) = parse_captures(arg, &mut captures) {
+                    if let Err(error) = parse_captures(field, &mut captures) {
                         errors.add(error);
                     }
                 }
                 Keyword::Binds | Keyword::Inspects => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         "no longer supported, use the following form instead: `ensures: |PAT| [EXPR, EXPR, ...]`",
                     ));
                 }
                 Keyword::Ensures => {
-                    if let Err(error) = parse_postconds(arg, &mut ensures) {
+                    if let Err(error) = parse_postconds(field, &mut ensures) {
                         errors.add(error);
                     }
                 }
                 Keyword::Decreases => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!(
                             "`{}` parameter is not supported here",
-                            arg.member.to_token_stream(),
+                            field.member.to_token_stream(),
                         ),
                     ));
                 }
@@ -159,31 +160,31 @@ impl Parse for Spec {
 
 impl Parse for DataSpec {
     fn parse(input: ParseStream) -> Result<Self> {
-        let raw_spec = syntax::SpecArgs::parse(input)?;
+        let raw_spec = syntax::SpecFields::parse(input)?;
 
         let mut errors = MultiError::empty();
         let mut maintains: Vec<Condition> = vec![];
 
-        for arg in raw_spec.args {
-            let keyword = Keyword::from(&arg.member);
+        for field in raw_spec.fields {
+            let keyword = Keyword::from(&field.member);
             match keyword {
                 Keyword::Unknown(ident) => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = parse_conditions(arg, &mut maintains) {
+                    if let Err(error) = parse_conditions(field, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 _ => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!(
                             "`{}` parameter is not supported here",
-                            arg.member.to_token_stream(),
+                            field.member.to_token_stream(),
                         ),
                     ));
                 }
@@ -203,7 +204,7 @@ impl Parse for DataSpec {
 
 impl Parse for LoopSpec {
     fn parse(input: ParseStream) -> Result<Self> {
-        let raw_spec = syntax::SpecArgs::parse(input)?;
+        let raw_spec = syntax::SpecFields::parse(input)?;
 
         let is_sorted = raw_spec.is_sorted();
 
@@ -211,37 +212,37 @@ impl Parse for LoopSpec {
         let mut decreases = None;
         let mut maintains: Vec<Condition> = vec![];
 
-        for arg in raw_spec.args {
-            let keyword = Keyword::from(&arg.member);
+        for field in raw_spec.fields {
+            let keyword = Keyword::from(&field.member);
             match keyword {
                 Keyword::Unknown(ident) => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = parse_conditions(arg, &mut maintains) {
+                    if let Err(error) = parse_conditions(field, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 Keyword::Decreases => {
                     if decreases.is_some() {
                         errors.add(Error::new_spanned(
-                            &arg.member,
+                            &field.member,
                             "multiple `decreases` parameters are not allowed",
                         ));
                     }
-                    if let Err(error) = parse_decreases(arg, &mut decreases) {
+                    if let Err(error) = parse_decreases(field, &mut decreases) {
                         errors.add(error);
                     }
                 }
                 _ => {
                     errors.add(Error::new_spanned(
-                        &arg.member,
+                        &field.member,
                         format!(
                             "`{}` parameter is not supported here",
-                            arg.member.to_token_stream(),
+                            field.member.to_token_stream(),
                         ),
                     ));
                 }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,5 +1,6 @@
+use quote::ToTokens;
 use syn::{
-    Attribute, Error, Expr, ExprAssign, Meta,
+    Attribute, Error, Expr, ExprAssign, FieldValue, Meta,
     parse::{Parse, ParseStream, Result},
     parse_quote,
     spanned::Spanned,
@@ -7,7 +8,7 @@ use syn::{
 
 use crate::{
     Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec,
-    annotate::syntax::SpecArg, qualifiers::FnQualifiers,
+    qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -31,96 +32,101 @@ impl Parse for Spec {
         let is_sorted = raw_spec.is_sorted();
 
         for arg in raw_spec.args {
-            match arg.keyword {
+            let keyword = Keyword::from(&arg.member);
+            match keyword {
                 Keyword::Unknown(ident) => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
+                    errors.add(Error::new_spanned(
+                        &arg.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Functional => {
                     if let Err(error) =
-                        arg.parse_fn_qualifier(FnQualifiers::FUNCTIONAL, &mut qualifiers)
+                        parse_fn_qualifier(arg, FnQualifiers::FUNCTIONAL, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Pure => {
-                    if let Err(error) = arg.parse_fn_qualifier(FnQualifiers::PURE, &mut qualifiers)
+                    if let Err(error) = parse_fn_qualifier(arg, FnQualifiers::PURE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Total => {
-                    if let Err(error) = arg.parse_fn_qualifier(FnQualifiers::TOTAL, &mut qualifiers)
+                    if let Err(error) =
+                        parse_fn_qualifier(arg, FnQualifiers::TOTAL, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Deterministic => {
                     if let Err(error) =
-                        arg.parse_fn_qualifier(FnQualifiers::DETERMINISTIC, &mut qualifiers)
+                        parse_fn_qualifier(arg, FnQualifiers::DETERMINISTIC, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Effectfree => {
                     if let Err(error) =
-                        arg.parse_fn_qualifier(FnQualifiers::EFFECTFREE, &mut qualifiers)
+                        parse_fn_qualifier(arg, FnQualifiers::EFFECTFREE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Infallible => {
                     if let Err(error) =
-                        arg.parse_fn_qualifier(FnQualifiers::INFALLIBLE, &mut qualifiers)
+                        parse_fn_qualifier(arg, FnQualifiers::INFALLIBLE, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Terminating => {
                     if let Err(error) =
-                        arg.parse_fn_qualifier(FnQualifiers::TERMINATING, &mut qualifiers)
+                        parse_fn_qualifier(arg, FnQualifiers::TERMINATING, &mut qualifiers)
                     {
                         errors.add(error);
                     }
                 }
                 Keyword::Requires => {
-                    if let Err(error) = arg.parse_conditions(&mut requires) {
+                    if let Err(error) = parse_conditions(arg, &mut requires) {
                         errors.add(error);
                     }
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_conditions(&mut maintains) {
+                    if let Err(error) = parse_conditions(arg, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 Keyword::Captures => {
                     if !captures.is_empty() {
-                        errors.add(Error::new(
-                            arg.keyword_span,
+                        errors.add(Error::new_spanned(
+                            &arg.member,
                             "at most one `captures` parameter is allowed; to capture multiple values, use a list: `captures: [binding1 = expr1, binding2 = expr2, ...]`",
                         ));
                     }
-                    if let Err(error) = arg.parse_captures(&mut captures) {
+                    if let Err(error) = parse_captures(arg, &mut captures) {
                         errors.add(error);
                     }
                 }
                 Keyword::Binds | Keyword::Inspects => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
+                    errors.add(Error::new_spanned(
+                        &arg.member,
                         "no longer supported, use the following form instead: `ensures: |PAT| [EXPR, EXPR, ...]`",
                     ));
                 }
                 Keyword::Ensures => {
-                    if let Err(error) = arg.parse_postconds(&mut ensures) {
+                    if let Err(error) = parse_postconds(arg, &mut ensures) {
                         errors.add(error);
                     }
                 }
                 Keyword::Decreases => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("`{}` parameter is not supported here", arg.keyword),
+                    errors.add(Error::new_spanned(
+                        &arg.member,
+                        format!(
+                            "`{}` parameter is not supported here",
+                            arg.member.to_token_stream(),
+                        ),
                     ));
                 }
             }
@@ -159,22 +165,26 @@ impl Parse for DataSpec {
         let mut maintains: Vec<Condition> = vec![];
 
         for arg in raw_spec.args {
-            match arg.keyword {
+            let keyword = Keyword::from(&arg.member);
+            match keyword {
                 Keyword::Unknown(ident) => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
+                    errors.add(Error::new_spanned(
+                        &arg.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_conditions(&mut maintains) {
+                    if let Err(error) = parse_conditions(arg, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 _ => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("`{}` parameter is not supported here", arg.keyword),
+                    errors.add(Error::new_spanned(
+                        &arg.member,
+                        format!(
+                            "`{}` parameter is not supported here",
+                            arg.member.to_token_stream(),
+                        ),
                     ));
                 }
             }
@@ -202,33 +212,37 @@ impl Parse for LoopSpec {
         let mut maintains: Vec<Condition> = vec![];
 
         for arg in raw_spec.args {
-            match arg.keyword {
+            let keyword = Keyword::from(&arg.member);
+            match keyword {
                 Keyword::Unknown(ident) => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
+                    errors.add(Error::new_spanned(
+                        &arg.member,
                         format!("unknown spec keyword `{ident}`"),
                     ));
                 }
                 Keyword::Maintains => {
-                    if let Err(error) = arg.parse_conditions(&mut maintains) {
+                    if let Err(error) = parse_conditions(arg, &mut maintains) {
                         errors.add(error);
                     }
                 }
                 Keyword::Decreases => {
                     if decreases.is_some() {
-                        errors.add(Error::new(
-                            arg.keyword_span,
+                        errors.add(Error::new_spanned(
+                            &arg.member,
                             "multiple `decreases` parameters are not allowed",
                         ));
                     }
-                    if let Err(error) = arg.parse_decreases(&mut decreases) {
+                    if let Err(error) = parse_decreases(arg, &mut decreases) {
                         errors.add(error);
                     }
                 }
                 _ => {
-                    errors.add(Error::new(
-                        arg.keyword_span,
-                        format!("`{}` parameter is not supported here", arg.keyword),
+                    errors.add(Error::new_spanned(
+                        &arg.member,
+                        format!(
+                            "`{}` parameter is not supported here",
+                            arg.member.to_token_stream(),
+                        ),
                     ));
                 }
             }
@@ -253,174 +267,184 @@ impl Parse for LoopSpec {
     }
 }
 
-impl SpecArg {
-    fn parse_fn_qualifier(self, value: FnQualifiers, qualifiers: &mut FnQualifiers) -> Result<()> {
-        if let Some(first_attr) = self.attrs.first() {
-            return Err(Error::new_spanned(
-                first_attr,
-                format!("attributes are not supported on `{}`", self.keyword),
-            ));
-        }
-        if !matches!(self.value, None) {
-            return Err(Error::new_spanned(
-                self.value,
-                format!("qualifier `{}` does not take a value", self.keyword),
-            ));
-        }
-        if qualifiers.contains(value) {
-            return Err(Error::new(
-                self.keyword_span,
-                "this qualifier is redundant; remove it",
-            ));
-        }
-        *qualifiers |= value;
-        Ok(())
+fn parse_fn_qualifier(
+    field: FieldValue,
+    value: FnQualifiers,
+    qualifiers: &mut FnQualifiers,
+) -> Result<()> {
+    if let Some(first_attr) = field.attrs.first() {
+        return Err(Error::new_spanned(
+            first_attr,
+            format!("attributes are not supported on `{:?}`", field.member),
+        ));
     }
+    if !matches!(field.colon_token, None) {
+        return Err(Error::new_spanned(
+            &field.member,
+            format!("qualifier `{:?}` does not take a value", field.member),
+        ));
+    }
+    if qualifiers.contains(value) {
+        return Err(Error::new_spanned(
+            &field.member,
+            "this qualifier is redundant; remove it",
+        ));
+    }
+    *qualifiers |= value;
+    Ok(())
+}
 
-    fn parse_conditions(self, conditions: &mut Vec<Condition>) -> Result<()> {
-        let cfg_attr = find_cfg_attribute(&self.attrs)?;
-        let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
-            Some(attr.parse_args()?)
-        } else {
-            None
-        };
-        let Some(expr) = self.value else {
-            return Err(Error::new_spanned(self.value, "expected an expression"));
-        };
-        if let Expr::Array(items) = expr {
-            for expr in items.elems {
-                conditions.push(Condition {
-                    expr,
+fn parse_conditions(field: FieldValue, conditions: &mut Vec<Condition>) -> Result<()> {
+    let cfg_attr = find_cfg_attribute(&field.attrs)?;
+    let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
+        Some(attr.parse_args()?)
+    } else {
+        None
+    };
+    if field.colon_token.is_none() {
+        return Err(Error::new_spanned(field.expr, "expected an expression"));
+    };
+    if let Expr::Array(items) = field.expr {
+        for expr in items.elems {
+            conditions.push(Condition {
+                expr,
+                cfg: cfg.clone(),
+            });
+        }
+    } else {
+        conditions.push(Condition {
+            expr: field.expr,
+            cfg,
+        });
+    }
+    Ok(())
+}
+
+fn parse_postconds(field: FieldValue, postconds: &mut Vec<PostCondition>) -> Result<()> {
+    let cfg_attr = find_cfg_attribute(&field.attrs)?;
+    let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
+        Some(attr.parse_args()?)
+    } else {
+        None
+    };
+    if field.colon_token.is_none() {
+        return Err(Error::new_spanned(&field.expr, "expected an expression"));
+    };
+    match field.expr {
+        Expr::Closure(mut closure) => {
+            if closure.inputs.len() != 1 {
+                return Err(Error::new_spanned(
+                    closure,
+                    "postcondition closure must have exactly one input",
+                ));
+            }
+            let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
+            if let Expr::Array(array) = *closure.body {
+                for expr in array.elems {
+                    postconds.push(PostCondition {
+                        pat: Some(pat.clone()),
+                        expr,
+                        cfg: cfg.clone(),
+                    });
+                }
+            } else {
+                postconds.push(PostCondition {
+                    pat: Some(pat),
+                    expr: *closure.body,
                     cfg: cfg.clone(),
                 });
             }
-        } else {
-            conditions.push(Condition { expr, cfg });
         }
-        Ok(())
-    }
-
-    fn parse_postconds(self, postconds: &mut Vec<PostCondition>) -> Result<()> {
-        let cfg_attr = find_cfg_attribute(&self.attrs)?;
-        let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
-            Some(attr.parse_args()?)
-        } else {
-            None
-        };
-        let Some(expr) = self.value else {
-            return Err(Error::new_spanned(self.value, "expected an expression"));
-        };
-        match expr {
-            Expr::Closure(mut closure) => {
-                if closure.inputs.len() != 1 {
-                    return Err(Error::new_spanned(
-                        closure,
-                        "postcondition closure must have exactly one input",
-                    ));
-                }
-                let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
-                if let Expr::Array(array) = *closure.body {
-                    for expr in array.elems {
-                        postconds.push(PostCondition {
-                            pat: Some(pat.clone()),
-                            expr,
-                            cfg: cfg.clone(),
-                        });
+        Expr::Array(array) => {
+            for expr in array.elems {
+                if let Expr::Closure(mut closure) = expr {
+                    if closure.inputs.len() != 1 {
+                        return Err(Error::new_spanned(
+                            closure,
+                            "postcondition closure must have exactly one input",
+                        ));
                     }
-                } else {
+                    let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
                     postconds.push(PostCondition {
                         pat: Some(pat),
                         expr: *closure.body,
                         cfg: cfg.clone(),
                     });
+                } else {
+                    postconds.push(PostCondition {
+                        pat: None,
+                        expr,
+                        cfg: cfg.clone(),
+                    });
                 }
-            }
-            Expr::Array(array) => {
-                for expr in array.elems {
-                    if let Expr::Closure(mut closure) = expr {
-                        if closure.inputs.len() != 1 {
-                            return Err(Error::new_spanned(
-                                closure,
-                                "postcondition closure must have exactly one input",
-                            ));
-                        }
-                        let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
-                        postconds.push(PostCondition {
-                            pat: Some(pat),
-                            expr: *closure.body,
-                            cfg: cfg.clone(),
-                        });
-                    } else {
-                        postconds.push(PostCondition {
-                            pat: None,
-                            expr,
-                            cfg: cfg.clone(),
-                        });
-                    }
-                }
-            }
-            _ => {
-                postconds.push(PostCondition {
-                    pat: None,
-                    expr,
-                    cfg: cfg.clone(),
-                });
             }
         }
-        Ok(())
+        _ => {
+            postconds.push(PostCondition {
+                pat: None,
+                expr: field.expr,
+                cfg: cfg.clone(),
+            });
+        }
     }
+    Ok(())
+}
 
-    fn parse_captures(self, captures: &mut Vec<Capture>) -> Result<()> {
-        let cfg_attr = find_cfg_attribute(&self.attrs)?;
-        if cfg_attr.is_some() {
-            return Err(Error::new(
-                cfg_attr.span(),
-                "`cfg` attribute is not supported on `captures`",
-            ));
+fn parse_captures(field: FieldValue, captures: &mut Vec<Capture>) -> Result<()> {
+    let cfg_attr = find_cfg_attribute(&field.attrs)?;
+    if cfg_attr.is_some() {
+        return Err(Error::new(
+            cfg_attr.span(),
+            "`cfg` attribute is not supported on `captures`",
+        ));
+    }
+    if field.colon_token.is_none() {
+        return Err(Error::new_spanned(field.expr, "expected an expression"));
+    };
+    match field.expr {
+        Expr::Assign(assignment) => {
+            captures.push(interpret_assignment_as_capture(assignment)?);
         }
-        let Some(capture_list) = self.value else {
-            return Err(Error::new_spanned(self.value, "expected an expression"));
-        };
-        match capture_list {
-            Expr::Assign(assignment) => {
+        Expr::Array(array) => {
+            for elem in array.elems {
+                let Expr::Assign(assignment) = elem else {
+                    return Err(Error::new_spanned(elem, "expected an assignment"));
+                };
                 captures.push(interpret_assignment_as_capture(assignment)?);
             }
-            Expr::Array(array) => {
-                for elem in array.elems {
-                    let Expr::Assign(assignment) = elem else {
-                        return Err(Error::new_spanned(elem, "expected an assignment"));
-                    };
-                    captures.push(interpret_assignment_as_capture(assignment)?);
-                }
-            }
-            _ => {
-                return Err(Error::new_spanned(
-                    capture_list,
-                    "expected an assignment or block",
-                ));
-            }
         }
-        Ok(())
+        _ => {
+            return Err(Error::new_spanned(
+                field.expr,
+                "expected an assignment or block",
+            ));
+        }
     }
+    Ok(())
+}
 
-    fn parse_decreases(self, decreases: &mut Option<LoopVariant>) -> Result<()> {
-        let cfg_attr = find_cfg_attribute(&self.attrs)?;
-        let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
-            Some(attr.parse_args()?)
-        } else {
-            None
-        };
-        let expr_span = self.value.span();
-        let Some(expr) = self.value else {
-            return Err(Error::new_spanned(self.value, "expected an expression"));
-        };
-        if let Expr::Array(_) = expr {
-            return Err(Error::new(expr_span, "expected a single expression"));
-        } else {
-            *decreases = Some(LoopVariant { expr, cfg });
-        }
-        Ok(())
+fn parse_decreases(field: FieldValue, decreases: &mut Option<LoopVariant>) -> Result<()> {
+    let cfg_attr = find_cfg_attribute(&field.attrs)?;
+    let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
+        Some(attr.parse_args()?)
+    } else {
+        None
+    };
+    if field.colon_token.is_none() {
+        return Err(Error::new_spanned(field.expr, "expected an expression"));
+    };
+    if let Expr::Array(_) = field.expr {
+        return Err(Error::new_spanned(
+            field.expr,
+            "expected a single expression",
+        ));
+    } else {
+        *decreases = Some(LoopVariant {
+            expr: field.expr,
+            cfg,
+        });
     }
+    Ok(())
 }
 
 /// Try to interpret an ExprAssign as a single Capture.

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -136,7 +136,7 @@ impl Parse for Spec {
         if !is_sorted {
             errors.add(Error::new(
                 input.span(),
-                "parameters are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `inspects`, `ensures`, where `<QUALIFIERS>` are:\n
+                " are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `inspects`, `ensures`, where `<QUALIFIERS>` are:\n
 `functional` (`pure` and `total`),\n
 `pure` (`deterministic` and `effectfree`),\n
 `total` (`infallible` and `terminating`)",

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -275,13 +275,19 @@ fn parse_fn_qualifier(
     if let Some(first_attr) = field.attrs.first() {
         return Err(Error::new_spanned(
             first_attr,
-            format!("attributes are not supported on `{:?}`", field.member),
+            format!(
+                "attributes are not supported on `{}`",
+                field.member.to_token_stream()
+            ),
         ));
     }
     if !matches!(field.colon_token, None) {
         return Err(Error::new_spanned(
             &field.member,
-            format!("qualifier `{:?}` does not take a value", field.member),
+            format!(
+                "qualifier `{}` does not take a value",
+                field.member.to_token_stream()
+            ),
         ));
     }
     if qualifiers.contains(value) {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -282,7 +282,7 @@ fn parse_fn_qualifier(
             ),
         ));
     }
-    if !matches!(field.colon_token, None) {
+    if field.colon_token.is_some() {
         return Err(Error::new_spanned(
             &field.member,
             format!(

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,4 +1,3 @@
-use quote::ToTokens;
 use syn::{
     Attribute, Error, Expr, ExprAssign, FieldValue, Meta,
     parse::{Parse, ParseStream, Result},
@@ -34,11 +33,9 @@ impl Parse for Spec {
         for field in raw_spec.fields {
             let keyword = Keyword::from(&field.member);
             match keyword {
-                Keyword::Unknown(ident) => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!("unknown spec keyword `{ident}`"),
-                    ));
+                Keyword::Unknown(_) => {
+                    // TODO: Check if it seems like a typo of a known keyword.
+                    errors.add(Error::new_spanned(&field.member, "unknown spec field"));
                 }
                 Keyword::Functional => {
                     if let Err(error) =
@@ -122,13 +119,7 @@ impl Parse for Spec {
                     }
                 }
                 Keyword::Decreases => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!(
-                            "`{}` field is not supported here",
-                            field.member.to_token_stream(),
-                        ),
-                    ));
+                    errors.add(Error::new_spanned(&field.member, "not allowed here"));
                 }
             }
         }
@@ -168,11 +159,8 @@ impl Parse for DataSpec {
         for field in raw_spec.fields {
             let keyword = Keyword::from(&field.member);
             match keyword {
-                Keyword::Unknown(ident) => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!("unknown spec keyword `{ident}`"),
-                    ));
+                Keyword::Unknown(_) => {
+                    errors.add(Error::new_spanned(&field.member, "unknown spec field"));
                 }
                 Keyword::Maintains => {
                     if let Err(error) = parse_conditions(field, &mut maintains) {
@@ -180,13 +168,7 @@ impl Parse for DataSpec {
                     }
                 }
                 _ => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!(
-                            "`{}` field is not supported here",
-                            field.member.to_token_stream(),
-                        ),
-                    ));
+                    errors.add(Error::new_spanned(&field.member, "not allowed here"));
                 }
             }
         }
@@ -215,11 +197,8 @@ impl Parse for LoopSpec {
         for field in raw_spec.fields {
             let keyword = Keyword::from(&field.member);
             match keyword {
-                Keyword::Unknown(ident) => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!("unknown spec keyword `{ident}`"),
-                    ));
+                Keyword::Unknown(_) => {
+                    errors.add(Error::new_spanned(&field.member, "unknown spec field"));
                 }
                 Keyword::Maintains => {
                     if let Err(error) = parse_conditions(field, &mut maintains) {
@@ -238,13 +217,7 @@ impl Parse for LoopSpec {
                     }
                 }
                 _ => {
-                    errors.add(Error::new_spanned(
-                        &field.member,
-                        format!(
-                            "`{}` field is not supported here",
-                            field.member.to_token_stream(),
-                        ),
-                    ));
+                    errors.add(Error::new_spanned(&field.member, "not allowed here"));
                 }
             }
         }
@@ -276,24 +249,18 @@ fn parse_fn_qualifier(
     if let Some(first_attr) = field.attrs.first() {
         return Err(Error::new_spanned(
             first_attr,
-            format!(
-                "attributes are not supported on `{}`",
-                field.member.to_token_stream()
-            ),
+            "attributes are not supported here",
         ));
     }
     if field.colon_token.is_some() {
         return Err(Error::new_spanned(
-            &field.member,
-            format!(
-                "qualifier `{}` does not take a value",
-                field.member.to_token_stream()
-            ),
+            field.member,
+            "qualifier does not take a value",
         ));
     }
     if qualifiers.contains(value) {
         return Err(Error::new_spanned(
-            &field.member,
+            field.member,
             "this qualifier is redundant; remove it",
         ));
     }
@@ -402,7 +369,7 @@ fn parse_captures(field: FieldValue, captures: &mut Vec<Capture>) -> Result<()> 
     if cfg_attr.is_some() {
         return Err(Error::new(
             cfg_attr.span(),
-            "`cfg` attribute is not supported on `captures`",
+            "`cfg` attribute is not supported here",
         ));
     }
     if field.colon_token.is_none() {

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -7,6 +7,9 @@ use syn::{
 /// Raw spec fields, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
 ///
 /// Represents a syntactically well-formed but otherwise unvalidated set of `spec` fields.
+///
+/// It reuses Rust's grammar of fields inside a `struct` expression. For reference, see:
+/// https://doc.rust-lang.org/reference/expressions/struct-expr.html#railroad-StructExprField
 #[derive(Debug, Clone)]
 pub struct SpecFields {
     pub fields: Punctuated<FieldValue, Token![,]>,

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,6 +1,5 @@
-use proc_macro2::Span;
 use syn::{
-    Attribute, Expr, Ident, Token,
+    FieldValue, Ident, Member, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
 };
@@ -10,13 +9,13 @@ use syn::{
 /// Can represent a well-formed but invalid spec so that e.g. `anodized-fmt` may work with it.
 #[derive(Debug, Clone)]
 pub struct SpecArgs {
-    pub args: Punctuated<SpecArg, Token![,]>,
+    pub args: Punctuated<FieldValue, Token![,]>,
 }
 
 impl Parse for SpecArgs {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Self {
-            args: Punctuated::<SpecArg, Token![,]>::parse_terminated(input)?,
+            args: Punctuated::<FieldValue, Token![,]>::parse_terminated(input)?,
         })
     }
 }
@@ -26,39 +25,9 @@ impl SpecArgs {
     pub fn is_sorted(&self) -> bool {
         self.args
             .iter()
-            .filter(|arg| !matches!(arg.keyword, Keyword::Unknown(_)))
-            .is_sorted_by_key(|arg| &arg.keyword)
-    }
-}
-
-/// A single spec argument.
-#[derive(Debug, Clone)]
-pub struct SpecArg {
-    pub attrs: Vec<Attribute>,
-    pub keyword: Keyword,
-    pub keyword_span: Span,
-    pub colon: Option<Token![:]>,
-    pub value: Option<Expr>,
-}
-
-impl Parse for SpecArg {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let attrs = input.call(Attribute::parse_outer)?;
-        let (keyword, keyword_span) = Keyword::parse(input)?;
-
-        let (colon, value) = if input.peek(Token![:]) {
-            (input.parse()?, Some(input.parse()?))
-        } else {
-            (None, None)
-        };
-
-        Ok(Self {
-            attrs,
-            keyword,
-            keyword_span,
-            colon,
-            value,
-        })
+            .map(|field| Keyword::from(&field.member))
+            .filter(|keyword| !matches!(keyword, Keyword::Unknown(_)))
+            .is_sorted()
     }
 }
 
@@ -94,63 +63,34 @@ pub enum Keyword {
     Requires,
     Maintains,
     Captures,
-    // TODO: Remove `binds` before v0.6 is released.
+    // TODO: Remove `binds` and `inspects` before v0.6 is released.
     Binds,
     Inspects,
     Ensures,
     Decreases,
 }
 
-impl Keyword {
-    fn parse(input: ParseStream) -> Result<(Self, Span)> {
+impl From<&Member> for Keyword {
+    fn from(value: &Member) -> Self {
         use Keyword::*;
-        Ok(if input.peek(kw::functional) {
-            let keyword: kw::functional = input.parse()?;
-            (Functional, keyword.span)
-        } else if input.peek(kw::pure) {
-            let keyword: kw::pure = input.parse()?;
-            (Pure, keyword.span)
-        } else if input.peek(kw::total) {
-            let keyword: kw::total = input.parse()?;
-            (Total, keyword.span)
-        } else if input.peek(kw::deterministic) {
-            let keyword: kw::deterministic = input.parse()?;
-            (Deterministic, keyword.span)
-        } else if input.peek(kw::effectfree) {
-            let keyword: kw::effectfree = input.parse()?;
-            (Effectfree, keyword.span)
-        } else if input.peek(kw::infallible) {
-            let keyword: kw::infallible = input.parse()?;
-            (Infallible, keyword.span)
-        } else if input.peek(kw::terminating) {
-            let keyword: kw::terminating = input.parse()?;
-            (Terminating, keyword.span)
-        } else if input.peek(kw::requires) {
-            let keyword: kw::requires = input.parse()?;
-            (Requires, keyword.span)
-        } else if input.peek(kw::maintains) {
-            let token: kw::maintains = input.parse()?;
-            (Maintains, token.span)
-        } else if input.peek(kw::captures) {
-            let token: kw::captures = input.parse()?;
-            (Captures, token.span)
-        } else if input.peek(kw::binds) {
-            let token: kw::binds = input.parse()?;
-            (Binds, token.span)
-        } else if input.peek(kw::inspects) {
-            let token: kw::inspects = input.parse()?;
-            (Inspects, token.span)
-        } else if input.peek(kw::ensures) {
-            let token: kw::ensures = input.parse()?;
-            (Ensures, token.span)
-        } else if input.peek(kw::decreases) {
-            let token: kw::decreases = input.parse()?;
-            (Decreases, token.span)
-        } else {
-            let ident: Ident = input.parse()?;
-            let span = ident.span();
-            (Unknown(ident), span)
-        })
+        match value {
+            Member::Named(ident) if ident == "functional" => Functional,
+            Member::Named(ident) if ident == "pure" => Pure,
+            Member::Named(ident) if ident == "total" => Total,
+            Member::Named(ident) if ident == "deterministic" => Deterministic,
+            Member::Named(ident) if ident == "effectfree" => Effectfree,
+            Member::Named(ident) if ident == "infallible" => Infallible,
+            Member::Named(ident) if ident == "terminating" => Terminating,
+            Member::Named(ident) if ident == "requires" => Requires,
+            Member::Named(ident) if ident == "maintains" => Maintains,
+            Member::Named(ident) if ident == "captures" => Captures,
+            Member::Named(ident) if ident == "binds" => Binds,
+            Member::Named(ident) if ident == "inspects" => Inspects,
+            Member::Named(ident) if ident == "ensures" => Ensures,
+            Member::Named(ident) if ident == "decreases" => Decreases,
+            Member::Named(ident) => Unknown(ident.clone()),
+            Member::Unnamed(index) => Unknown(Ident::new(&format!("{}", index.index), index.span)),
+        }
     }
 }
 

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -31,25 +31,6 @@ impl SpecArgs {
     }
 }
 
-/// Custom keywords for parsing. This allows us to use `requires`, `ensures`, etc.,
-/// as if they were built-in Rust keywords during parsing.
-pub mod kw {
-    syn::custom_keyword!(functional);
-    syn::custom_keyword!(pure);
-    syn::custom_keyword!(total);
-    syn::custom_keyword!(deterministic);
-    syn::custom_keyword!(effectfree);
-    syn::custom_keyword!(infallible);
-    syn::custom_keyword!(terminating);
-    syn::custom_keyword!(requires);
-    syn::custom_keyword!(maintains);
-    syn::custom_keyword!(captures);
-    syn::custom_keyword!(binds);
-    syn::custom_keyword!(inspects);
-    syn::custom_keyword!(ensures);
-    syn::custom_keyword!(decreases);
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Keyword {
     Unknown(Ident),

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -21,7 +21,7 @@ impl Parse for SpecFields {
 }
 
 impl SpecFields {
-    /// Check whether the spec arguments are sorted correctly, ignoring unknown keywords.
+    /// Check whether the spec fields are sorted correctly, ignoring unknown keywords.
     pub fn is_sorted(&self) -> bool {
         self.fields
             .iter()

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -4,26 +4,26 @@ use syn::{
     punctuated::Punctuated,
 };
 
-/// Raw spec arguments, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
+/// Raw spec fields, i.e. as they appear in the `#[spec(...)]` proc macro invocation.
 ///
-/// Can represent a well-formed but invalid spec so that e.g. `anodized-fmt` may work with it.
+/// Represents a syntactically well-formed but otherwise unvalidated set of `spec` fields.
 #[derive(Debug, Clone)]
-pub struct SpecArgs {
-    pub args: Punctuated<FieldValue, Token![,]>,
+pub struct SpecFields {
+    pub fields: Punctuated<FieldValue, Token![,]>,
 }
 
-impl Parse for SpecArgs {
+impl Parse for SpecFields {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Self {
-            args: Punctuated::<FieldValue, Token![,]>::parse_terminated(input)?,
+            fields: Punctuated::<FieldValue, Token![,]>::parse_terminated(input)?,
         })
     }
 }
 
-impl SpecArgs {
+impl SpecFields {
     /// Check whether the spec arguments are sorted correctly, ignoring unknown keywords.
     pub fn is_sorted(&self) -> bool {
-        self.args
+        self.fields
             .iter()
             .map(|field| Keyword::from(&field.member))
             .filter(|keyword| !matches!(keyword, Keyword::Unknown(_)))

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,7 +1,6 @@
-use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
+use proc_macro2::Span;
 use syn::{
-    Attribute, Expr, Ident, Pat, Token,
+    Attribute, Expr, Ident, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
 };
@@ -39,7 +38,7 @@ pub struct SpecArg {
     pub keyword: Keyword,
     pub keyword_span: Span,
     pub colon: Option<Token![:]>,
-    pub value: SpecArgValue,
+    pub value: Option<Expr>,
 }
 
 impl Parse for SpecArg {
@@ -48,15 +47,9 @@ impl Parse for SpecArg {
         let (keyword, keyword_span) = Keyword::parse(input)?;
 
         let (colon, value) = if input.peek(Token![:]) {
-            (
-                input.parse()?,
-                match keyword {
-                    Keyword::Binds | Keyword::Inspects => SpecArgValue::parse_pat_or_expr(input)?,
-                    _ => SpecArgValue::parse_expr_or_pat(input)?,
-                },
-            )
+            (input.parse()?, Some(input.parse()?))
         } else {
-            (None, SpecArgValue::None)
+            (None, None)
         };
 
         Ok(Self {
@@ -66,94 +59,6 @@ impl Parse for SpecArg {
             colon,
             value,
         })
-    }
-}
-/// Each [`SpecArg`]'s value needs to be parsed in a way that allows invalid specs, e.g.
-/// forms which do not correspond directly to an [`syn::Expr`] in standard Rust.
-///
-/// NOTE:
-/// a [`SpecArgValue`] may hold unrelated syntactic elements such as ['syn::Expr`], [`syn::Pat`],
-/// and even fragments that would never appear as part of a valid Rust program.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum SpecArgValue {
-    None,
-    Expr(Expr),
-    Pat(Pat),
-}
-
-impl SpecArgValue {
-    /// Return the `Expr` or fail.
-    pub fn try_into_expr(self) -> Result<Expr> {
-        if let Self::Expr(expr) = self {
-            return Ok(expr);
-        };
-        Err(syn::Error::new_spanned(self, "expected an expression"))
-    }
-
-    /// Return the `Pat` or fail.
-    pub fn try_into_pat(self) -> Result<Pat> {
-        if let Self::Pat(pat) = self {
-            return Ok(pat);
-        };
-        Err(syn::Error::new_spanned(self, "expected a pattern"))
-    }
-
-    /// Try to parse as `Expr` then as `Pat`.
-    fn parse_expr_or_pat(input: ParseStream) -> Result<Self> {
-        if let Ok(expr) = Self::parse_expr_or_nothing(input) {
-            Ok(Self::Expr(expr))
-        } else if let Ok(pat) = Self::parse_pat_or_nothing(input) {
-            Ok(Self::Pat(pat))
-        } else {
-            Err(input.error("expected an expression or a pattern"))
-        }
-    }
-
-    /// Try to parse as `Pat` then as `Expr`.
-    fn parse_pat_or_expr(input: ParseStream) -> Result<Self> {
-        if let Ok(pat) = Self::parse_pat_or_nothing(input) {
-            Ok(Self::Pat(pat))
-        } else if let Ok(expr) = Self::parse_expr_or_nothing(input) {
-            Ok(Self::Expr(expr))
-        } else {
-            Err(input.error("expected a pattern or an expression"))
-        }
-    }
-
-    /// Try to parse as `Expr` but consume no input on failure.
-    fn parse_expr_or_nothing(input: ParseStream<'_>) -> Result<Expr> {
-        use syn::parse::discouraged::Speculative;
-        let fork = input.fork();
-        match Expr::parse(&fork) {
-            Ok(expr) => {
-                input.advance_to(&fork);
-                Ok(expr)
-            }
-            Err(err) => Err(err),
-        }
-    }
-
-    /// Try to parse as `Pat` but consume no input on failure.
-    fn parse_pat_or_nothing(input: ParseStream<'_>) -> Result<Pat> {
-        use syn::parse::discouraged::Speculative;
-        let fork = input.fork();
-        match Pat::parse_single(&fork) {
-            Ok(pat) => {
-                input.advance_to(&fork);
-                Ok(pat)
-            }
-            Err(err) => Err(err),
-        }
-    }
-}
-
-impl ToTokens for SpecArgValue {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            SpecArgValue::None => {}
-            SpecArgValue::Expr(expr) => expr.to_tokens(tokens),
-            SpecArgValue::Pat(pat) => pat.to_tokens(tokens),
-        }
     }
 }
 

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -999,7 +999,7 @@ fn captures_pattern_with_binding_modifier() {
 #[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_is_rejected_by_spec_args() {
     let input = "captures: Person { name, age } =,";
-    let _: syntax::SpecArgs = parse_str(input).unwrap();
+    let _: syntax::SpecFields = parse_str(input).unwrap();
 }
 
 #[test]
@@ -1022,13 +1022,13 @@ fn captures_with_extra_semicolon() {
 
 #[test]
 fn field_value_supports_shorthand_expression() {
-    let spec_args: syntax::SpecArgs = parse_quote! {
+    let spec_args: syntax::SpecFields = parse_quote! {
         key_1,
         key_2: value,
         key_3: value as expr,
     };
 
-    let args: Vec<_> = spec_args.args.into_iter().collect();
+    let args: Vec<_> = spec_args.fields.into_iter().collect();
     let [arg_1, arg_2, arg_3] = args.as_slice() else {
         panic!("expected 3 args");
     };

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -101,7 +101,7 @@ fn fn_qualifiers_typo_missing_comma() {
 }
 
 #[test]
-#[should_panic = "qualifier `pure` does not take a value"]
+#[should_panic = "qualifier does not take a value"]
 fn fn_qualifiers_typo_colon_instead_of_comma() {
     let _: Spec = parse_quote! {
         pure: total,
@@ -117,7 +117,7 @@ fn fn_qualifiers_invalid_colon() {
 }
 
 #[test]
-#[should_panic = "qualifier `functional` does not take a value"]
+#[should_panic = "qualifier does not take a value"]
 fn fn_qualifiers_invalid_value_expr() {
     let _: Spec = parse_quote! {
         functional: x == 42,
@@ -209,7 +209,7 @@ fn all_clauses() {
 }
 
 #[test]
-#[should_panic(expected = "unknown spec keyword `goat`")]
+#[should_panic(expected = "unknown spec field")]
 fn unknown_keyword() {
     let _: Spec = parse_quote! {
         ensures: output == x,
@@ -807,7 +807,7 @@ fn captures_complex_expressions() {
 }
 
 #[test]
-#[should_panic(expected = "`cfg` attribute is not supported on `captures`")]
+#[should_panic(expected = "`cfg` attribute is not supported here")]
 fn cfg_on_captures() {
     let _: Spec = parse_quote! {
         #[cfg(test)]

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -219,7 +219,7 @@ fn unknown_keyword() {
 }
 
 #[test]
-#[should_panic(expected = "parameters are out of order")]
+#[should_panic(expected = "fields are out of order")]
 fn out_of_order() {
     let _: Spec = parse_quote! {
         ensures: output == x,
@@ -238,7 +238,7 @@ fn multiple_binds() {
 
 #[test]
 #[should_panic(
-    expected = "at most one `captures` parameter is allowed; to capture multiple values, use a list"
+    expected = "at most one `captures` field is allowed; to capture multiple values, use a list"
 )]
 fn multiple_captures() {
     let _: Spec = parse_quote! {
@@ -757,7 +757,7 @@ fn captures_with_all_clauses() {
 }
 
 #[test]
-#[should_panic(expected = "parameters are out of order")]
+#[should_panic(expected = "fields are out of order")]
 fn captures_out_of_order() {
     let _: Spec = parse_quote! {
         captures: old_value = value,

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -2,6 +2,7 @@ use crate::test_util::assert_spec_eq;
 
 use super::*;
 use proc_macro2::Span;
+use quote::ToTokens;
 use syn::{parse_quote, parse_str};
 
 #[test]
@@ -108,7 +109,7 @@ fn fn_qualifiers_typo_colon_instead_of_comma() {
 }
 
 #[test]
-#[should_panic = "expected an expression or a pattern"]
+#[should_panic = "expected an expression"]
 fn fn_qualifiers_invalid_colon() {
     let _: Spec = parse_quote! {
         pure:,
@@ -995,14 +996,14 @@ fn captures_pattern_with_binding_modifier() {
 }
 
 #[test]
-#[should_panic(expected = "expected `,`")]
+#[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_is_rejected_by_spec_args() {
     let input = "captures: Person { name, age } =,";
     let _: syntax::SpecArgs = parse_str(input).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "expected `,`")]
+#[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_errors_as_spec() {
     let _: Spec = parse_str("captures: Person { name, age } =,").unwrap();
 }
@@ -1034,13 +1035,19 @@ fn spec_arg_can_omit_value() {
 
     assert!(arg_1.keyword.to_string() == "key_1");
     assert!(arg_1.colon.is_none());
-    assert_eq!(arg_1.value, SpecArgValue::None);
+    assert!(arg_1.value.is_none());
 
     assert!(arg_2.keyword.to_string() == "key_2");
     assert!(arg_2.colon.is_some());
-    assert_eq!(arg_2.value, SpecArgValue::Expr(parse_quote!(value)));
+    assert_eq!(
+        arg_2.value.as_ref().unwrap().to_token_stream().to_string(),
+        "value"
+    );
 
     assert!(arg_3.keyword.to_string() == "key_3");
     assert!(arg_3.colon.is_some());
-    assert_eq!(arg_3.value, SpecArgValue::Expr(parse_quote!(value as expr)));
+    assert_eq!(
+        arg_3.value.as_ref().unwrap().to_token_stream().to_string(),
+        "value as expr"
+    );
 }

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1021,7 +1021,7 @@ fn captures_with_extra_semicolon() {
 }
 
 #[test]
-fn spec_arg_can_omit_value() {
+fn field_value_supports_shorthand_expression() {
     let spec_args: syntax::SpecArgs = parse_quote! {
         key_1,
         key_2: value,
@@ -1033,21 +1033,15 @@ fn spec_arg_can_omit_value() {
         panic!("expected 3 args");
     };
 
-    assert!(arg_1.keyword.to_string() == "key_1");
-    assert!(arg_1.colon.is_none());
-    assert!(arg_1.value.is_none());
+    assert_eq!(arg_1.member.to_token_stream().to_string(), "key_1");
+    assert!(arg_1.colon_token.is_none());
+    assert_eq!(arg_1.expr.to_token_stream().to_string(), "key_1");
 
-    assert!(arg_2.keyword.to_string() == "key_2");
-    assert!(arg_2.colon.is_some());
-    assert_eq!(
-        arg_2.value.as_ref().unwrap().to_token_stream().to_string(),
-        "value"
-    );
+    assert_eq!(arg_2.member.to_token_stream().to_string(), "key_2");
+    assert!(arg_2.colon_token.is_some());
+    assert_eq!(arg_2.expr.to_token_stream().to_string(), "value");
 
-    assert!(arg_3.keyword.to_string() == "key_3");
-    assert!(arg_3.colon.is_some());
-    assert_eq!(
-        arg_3.value.as_ref().unwrap().to_token_stream().to_string(),
-        "value as expr"
-    );
+    assert_eq!(arg_3.member.to_token_stream().to_string(), "key_3");
+    assert!(arg_3.colon_token.is_some());
+    assert_eq!(arg_3.expr.to_token_stream().to_string(), "value as expr");
 }

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -997,7 +997,7 @@ fn captures_pattern_with_binding_modifier() {
 
 #[test]
 #[should_panic(expected = "expected an expression")]
-fn captures_missing_assignment_value_is_rejected_by_spec_args() {
+fn captures_missing_assignment_value_is_rejected_by_spec_fields() {
     let input = "captures: Person { name, age } =,";
     let _: syntax::SpecFields = parse_str(input).unwrap();
 }

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1022,26 +1022,26 @@ fn captures_with_extra_semicolon() {
 
 #[test]
 fn field_value_supports_shorthand_expression() {
-    let spec_args: syntax::SpecFields = parse_quote! {
+    let spec_fields: syntax::SpecFields = parse_quote! {
         key_1,
         key_2: value,
         key_3: value as expr,
     };
 
-    let args: Vec<_> = spec_args.fields.into_iter().collect();
-    let [arg_1, arg_2, arg_3] = args.as_slice() else {
-        panic!("expected 3 args");
+    let fields: Vec<_> = spec_fields.fields.into_iter().collect();
+    let [field_1, field_2, field_3] = fields.as_slice() else {
+        panic!("expected 3 fields");
     };
 
-    assert_eq!(arg_1.member.to_token_stream().to_string(), "key_1");
-    assert!(arg_1.colon_token.is_none());
-    assert_eq!(arg_1.expr.to_token_stream().to_string(), "key_1");
+    assert_eq!(field_1.member.to_token_stream().to_string(), "key_1");
+    assert!(field_1.colon_token.is_none());
+    assert_eq!(field_1.expr.to_token_stream().to_string(), "key_1");
 
-    assert_eq!(arg_2.member.to_token_stream().to_string(), "key_2");
-    assert!(arg_2.colon_token.is_some());
-    assert_eq!(arg_2.expr.to_token_stream().to_string(), "value");
+    assert_eq!(field_2.member.to_token_stream().to_string(), "key_2");
+    assert!(field_2.colon_token.is_some());
+    assert_eq!(field_2.expr.to_token_stream().to_string(), "value");
 
-    assert_eq!(arg_3.member.to_token_stream().to_string(), "key_3");
-    assert!(arg_3.colon_token.is_some());
-    assert_eq!(arg_3.expr.to_token_stream().to_string(), "value as expr");
+    assert_eq!(field_3.member.to_token_stream().to_string(), "key_3");
+    assert!(field_3.colon_token.is_some());
+    assert_eq!(field_3.expr.to_token_stream().to_string(), "value as expr");
 }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -681,7 +681,7 @@ fn multiple_conditions_in_clauses() {
 }
 
 #[test]
-fn binds_parameter() {
+fn postcond_closure_form() {
     let spec: Spec = parse_quote! {
         ensures: |OUTPUT_PATTERN| CONDITION_1,
     };

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -25,7 +25,7 @@ impl Mode {
         spec: DataSpec,
         mut the_trait: syn::ItemTrait,
     ) -> syn::Result<syn::ItemTrait> {
-        // Currently we don't support any spec arguments for traits themselves.
+        // Currently we don't support any spec fields for traits themselves.
         if !spec.is_empty() {
             return Err(spec.spec_err(
                 "Unsupported spec element on trait. Try placing it on an item inside the trait",

--- a/crates/anodized-fmt/README.md
+++ b/crates/anodized-fmt/README.md
@@ -123,8 +123,8 @@ let formatted = format_file(source, &config)?;
 ## How It Works
 
 1. **Find** - Locate `#[spec(` patterns in source text using simple string search
-2. **Parse** - Parse each spec using `anodized-core::SpecArgs` for permissive parsing
-3. **Format** - Walk the `SpecArgs` struct and emit formatted text with configurable options
+2. **Parse** - Parse each spec using `anodized-core::SpecFields` for permissive parsing
+3. **Format** - Walk the `SpecFields` struct and emit formatted text with configurable options
 4. **Replace** - Substitute the original attribute with the formatted version
 
-Individual expressions(`syn::expr::Expr`) are formatted using `prettyplease` and patterns(`syn::pat::Pat`) are formatted with quote::quote! .
+Individual expressions (`syn::expr::Expr`) are formatted using `prettyplease`.

--- a/crates/anodized-fmt/README.md
+++ b/crates/anodized-fmt/README.md
@@ -72,7 +72,7 @@ Create an `anodized-fmt.toml` file in your project root:
 # Number of spaces for indentation
 tab_spaces = 4
 
-# Reorder spec arguments into recommended order
+# Reorder spec fields into recommended order
 # (requires, maintains, captures, inspects, ensures)
 reorder_spec_items = true,
 

--- a/crates/anodized-fmt/src/formatter.rs
+++ b/crates/anodized-fmt/src/formatter.rs
@@ -114,9 +114,9 @@ impl<'a> Formatter<'a> {
     }
 
     /// Format a spec field into the output.
-    pub fn format_spec_arg(&mut self, arg: &FieldValue) {
+    pub fn format_spec_field(&mut self, field: &FieldValue) {
         // Add cfg attribute if present
-        if let Some(cfg_attr) = Self::find_cfg_attribute(&arg.attrs)
+        if let Some(cfg_attr) = Self::find_cfg_attribute(&field.attrs)
             && let Ok(meta) = cfg_attr.parse_args::<Meta>()
         {
             self.write(&Self::format_cfg_attr(&meta));
@@ -124,10 +124,10 @@ impl<'a> Formatter<'a> {
             self.write_indent();
         }
 
-        if arg.colon_token.is_none() {
-            self.write(&format!("{},", arg.member.to_token_stream()));
+        if field.colon_token.is_none() {
+            self.write(&format!("{},", field.member.to_token_stream()));
         } else {
-            let value_str = if let syn::Expr::Array(array) = &arg.expr {
+            let value_str = if let syn::Expr::Array(array) = &field.expr {
                 let elem_strs = Vec::from_iter(array.elems.iter().map(format_expr));
                 let elem_lines: Vec<usize> = array
                     .elems
@@ -143,9 +143,13 @@ impl<'a> Formatter<'a> {
                     .saturating_sub(1);
                 self.format_array(&elem_strs, Some(&elem_lines), Some(bracket_line))
             } else {
-                format_expr(&arg.expr)
+                format_expr(&field.expr)
             };
-            self.write(&format!("{}: {},", arg.member.to_token_stream(), value_str));
+            self.write(&format!(
+                "{}: {},",
+                field.member.to_token_stream(),
+                value_str
+            ));
         }
     }
 

--- a/crates/anodized-fmt/src/formatter.rs
+++ b/crates/anodized-fmt/src/formatter.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
-use anodized_core::annotate::syntax::{SpecArg, SpecArgValue};
-use syn::Meta;
+use quote::ToTokens;
 use syn::spanned::Spanned;
+use syn::{FieldValue, Meta};
 
 use crate::config::{Config, TrailingComma};
 
 mod expr;
 mod spec;
 
-use expr::{format_expr, format_pattern};
+use expr::format_expr;
 
 pub use spec::format_spec_attribute;
 
@@ -113,8 +113,8 @@ impl<'a> Formatter<'a> {
         self.output
     }
 
-    /// Format a SpecArg into the output.
-    pub fn format_spec_arg(&mut self, arg: &SpecArg) {
+    /// Format a spec field into the output.
+    pub fn format_spec_arg(&mut self, arg: &FieldValue) {
         // Add cfg attribute if present
         if let Some(cfg_attr) = Self::find_cfg_attribute(&arg.attrs)
             && let Ok(meta) = cfg_attr.parse_args::<Meta>()
@@ -124,36 +124,28 @@ impl<'a> Formatter<'a> {
             self.write_indent();
         }
 
-        // Format the value based on what it contains
-        let value_str = match &arg.value {
-            SpecArgValue::None => String::new(),
-            SpecArgValue::Expr(expr) => {
-                if let syn::Expr::Array(array) = expr {
-                    let elem_strs = Vec::from_iter(array.elems.iter().map(format_expr));
-                    let elem_lines: Vec<usize> = array
-                        .elems
-                        .iter()
-                        .map(|e| e.span().start().line.saturating_sub(1))
-                        .collect();
-                    let bracket_line = array
-                        .bracket_token
-                        .span
-                        .open()
-                        .start()
-                        .line
-                        .saturating_sub(1);
-                    self.format_array(&elem_strs, Some(&elem_lines), Some(bracket_line))
-                } else {
-                    format_expr(expr)
-                }
-            }
-            SpecArgValue::Pat(pat) => format_pattern(pat),
-        };
-
-        if value_str.is_empty() {
-            self.write(&format!("{},", arg.keyword));
+        if arg.colon_token.is_none() {
+            self.write(&format!("{},", arg.member.to_token_stream()));
         } else {
-            self.write(&format!("{}: {},", arg.keyword, value_str));
+            let value_str = if let syn::Expr::Array(array) = &arg.expr {
+                let elem_strs = Vec::from_iter(array.elems.iter().map(format_expr));
+                let elem_lines: Vec<usize> = array
+                    .elems
+                    .iter()
+                    .map(|e| e.span().start().line.saturating_sub(1))
+                    .collect();
+                let bracket_line = array
+                    .bracket_token
+                    .span
+                    .open()
+                    .start()
+                    .line
+                    .saturating_sub(1);
+                self.format_array(&elem_strs, Some(&elem_lines), Some(bracket_line))
+            } else {
+                format_expr(&arg.expr)
+            };
+            self.write(&format!("{}: {},", arg.member.to_token_stream(), value_str));
         }
     }
 

--- a/crates/anodized-fmt/src/formatter/expr.rs
+++ b/crates/anodized-fmt/src/formatter/expr.rs
@@ -1,5 +1,5 @@
 use quote::ToTokens;
-use syn::{Expr, Pat};
+use syn::Expr;
 
 /// Format an expression using prettyplease
 /// This properly formats Rust expressions without excessive whitespace
@@ -39,15 +39,6 @@ pub fn format_expr(expr: &Expr) -> String {
     remove_spaces_before_commas(&result)
 }
 
-/// Format a pattern (for inspects parameter)
-pub fn format_pattern(pat: &Pat) -> String {
-    // For patterns, quote works fine
-    let result = quote::quote!(#pat).to_string();
-
-    // Remove extra spaces before commas in patterns too
-    remove_spaces_before_commas(&result)
-}
-
 /// Remove spaces before commas in formatted output
 /// This handles prettyplease's formatting of arrays/tuples like `[a , b , c]` -> `[a, b, c]`
 fn remove_spaces_before_commas(s: &str) -> String {
@@ -72,21 +63,6 @@ mod tests {
         let formatted = format_expr(&expr);
         assert!(formatted.contains("x > 0"));
         assert!(formatted.contains("y < 100"));
-    }
-
-    #[test]
-    fn test_format_pattern() {
-        let pat: Pat = parse_quote!(output);
-        let formatted = format_pattern(&pat);
-        assert_eq!(formatted, "output");
-    }
-
-    #[test]
-    fn test_format_tuple_pattern() {
-        let pat: Pat = parse_quote!((a, b));
-        let formatted = format_pattern(&pat);
-        assert!(formatted.contains("a"));
-        assert!(formatted.contains("b"));
     }
 
     #[test]

--- a/crates/anodized-fmt/src/formatter/spec.rs
+++ b/crates/anodized-fmt/src/formatter/spec.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anodized_core::annotate::syntax::{Keyword, SpecArgs};
+use anodized_core::annotate::syntax::{Keyword, SpecFields};
 use syn::FieldValue;
 use syn::spanned::Spanned;
 
@@ -8,66 +8,65 @@ use crate::{collect::ParentIndent, config::Config};
 
 use super::Formatter;
 
-fn arg_end_line(arg: &FieldValue) -> usize {
-    arg.expr.span().end().line.saturating_sub(1)
+fn field_end_line(field: &FieldValue) -> usize {
+    field.expr.span().end().line.saturating_sub(1)
 }
 
 /// Format a complete #[spec(...)] attribute with comment preservation.
 ///
 /// This is the main entry point for formatting a spec attribute. It:
 /// 1. Creates a formatter with the comment map and base indentation
-/// 2. Formats the spec args
+/// 2. Formats the spec fields
 /// 3. Returns the complete #[spec(...)] string
 pub fn format_spec_attribute(
-    spec_args: &SpecArgs,
+    spec_fields: &SpecFields,
     config: &Config,
     base_indent: &ParentIndent,
     comments: HashMap<usize, Option<String>>,
 ) -> String {
     let indent_spaces = base_indent.total_spaces(config.tab_spaces);
     let mut formatter = Formatter::new(config, indent_spaces, comments);
-    formatter.spec_args(spec_args);
+    formatter.spec_fields(spec_fields);
     formatter.finish()
 }
 
 impl Formatter<'_> {
-    /// Format SpecArgs into the output.
-    pub fn spec_args(&mut self, spec_args: &SpecArgs) {
+    /// Format SpecFields into the output.
+    pub fn spec_fields(&mut self, spec_fields: &SpecFields) {
         let base_indent = self.base_indent;
         self.write("#[spec(");
 
-        if spec_args.args.is_empty() {
+        if spec_fields.fields.is_empty() {
             self.write(")]");
             return;
         }
 
         // Use vertical layout
         self.newline();
-        let arg_indent = base_indent + self.settings.tab_spaces;
-        self.set_indent(arg_indent);
+        let field_indent = base_indent + self.settings.tab_spaces;
+        self.set_indent(field_indent);
 
-        // Collect args with their original line numbers for comment association
-        let args_with_lines: Vec<(&FieldValue, usize)> = spec_args
-            .args
+        // Collect fields with their original line numbers for comment association
+        let fields_with_lines: Vec<(&FieldValue, usize)> = spec_fields
+            .fields
             .iter()
-            .map(|arg| {
-                let line = arg.member.span().start().line.saturating_sub(1);
-                (arg, line)
+            .map(|field| {
+                let line = field.member.span().start().line.saturating_sub(1);
+                (field, line)
             })
             .collect();
 
-        // Associate comments with their corresponding args before sorting
-        // For each arg, find comments that appear between the previous arg's end and this arg's keyword
-        type ArgWithComments<'a> = (&'a FieldValue, usize, Vec<(usize, Option<String>)>);
-        let args_with_comments: Vec<ArgWithComments> = if self.settings.reorder_spec_items {
-            args_with_lines
+        // Associate comments with their corresponding fields before sorting.
+        type FieldWithComments<'a> = (&'a FieldValue, usize, Vec<(usize, Option<String>)>);
+        let fields_with_comments: Vec<FieldWithComments> = if self.settings.reorder_spec_items {
+            fields_with_lines
                 .iter()
                 .enumerate()
-                .map(|(idx, (arg, line))| {
+                .map(|(idx, (field, line))| {
                     let start_line = if idx == 0 {
                         0
                     } else {
-                        arg_end_line(args_with_lines[idx - 1].0) + 1
+                        field_end_line(fields_with_lines[idx - 1].0) + 1
                     };
                     let end_line = *line;
 
@@ -78,27 +77,27 @@ impl Formatter<'_> {
                         }
                     }
 
-                    (*arg, *line, comments)
+                    (*field, *line, comments)
                 })
                 .collect()
         } else {
             // No reordering, so no need to pre-collect comments
-            args_with_lines
+            fields_with_lines
                 .into_iter()
-                .map(|(arg, line)| (arg, line, Vec::new()))
+                .map(|(field, line)| (field, line, Vec::new()))
                 .collect()
         };
 
-        // Sort if reordering is enabled (comments are now bundled with args)
-        let mut final_args = args_with_comments;
+        // Sort if reordering is enabled (comments are now bundled with fields).
+        let mut final_fields = fields_with_comments;
         if self.settings.reorder_spec_items {
-            final_args.sort_by_key(|(arg, _line, _comments)| Keyword::from(&arg.member));
+            final_fields.sort_by_key(|(field, _line, _comments)| Keyword::from(&field.member));
         }
 
-        // Format each arg with its associated comments
-        for (arg, original_line, comments) in final_args {
+        // Format each field with its associated comments.
+        for (field, original_line, comments) in final_fields {
             if self.settings.reorder_spec_items {
-                // Write the pre-collected comments for this arg
+                // Write the pre-collected comments for this field.
                 for (_line, comment_opt) in comments {
                     if let Some(comment) = comment_opt {
                         self.write_indent();
@@ -113,7 +112,7 @@ impl Formatter<'_> {
             }
 
             self.write_indent();
-            self.format_spec_arg(arg);
+            self.format_spec_field(field);
             self.newline();
         }
 
@@ -131,24 +130,24 @@ mod tests {
 
     #[test]
     fn test_format_simple_spec() {
-        let spec_args: SpecArgs = parse_str("requires: x > 0").unwrap();
+        let spec_fields: SpecFields = parse_str("requires: x > 0").unwrap();
         let config = Config::default();
         let comments = HashMap::new();
         let indent = ParentIndent::default();
 
-        let formatted = format_spec_attribute(&spec_args, &config, &indent, comments);
+        let formatted = format_spec_attribute(&spec_fields, &config, &indent, comments);
 
         assert_eq!(formatted, "#[spec(\n    requires: x > 0,\n)]");
     }
 
     #[test]
     fn test_format_empty_spec() {
-        let spec_args: SpecArgs = parse_str("").unwrap();
+        let spec_fields: SpecFields = parse_str("").unwrap();
         let config = Config::default();
         let comments = HashMap::new();
         let indent = ParentIndent::default();
 
-        let formatted = format_spec_attribute(&spec_args, &config, &indent, comments);
+        let formatted = format_spec_attribute(&spec_fields, &config, &indent, comments);
 
         assert_eq!(formatted, "#[spec()]");
     }

--- a/crates/anodized-fmt/src/formatter/spec.rs
+++ b/crates/anodized-fmt/src/formatter/spec.rs
@@ -1,18 +1,15 @@
 use std::collections::HashMap;
 
-use anodized_core::annotate::syntax::{SpecArg, SpecArgValue, SpecArgs};
+use anodized_core::annotate::syntax::{Keyword, SpecArgs};
+use syn::FieldValue;
 use syn::spanned::Spanned;
 
 use crate::{collect::ParentIndent, config::Config};
 
 use super::Formatter;
 
-fn arg_end_line(arg: &SpecArg) -> usize {
-    match &arg.value {
-        SpecArgValue::None => arg.keyword_span.end().line.saturating_sub(1),
-        SpecArgValue::Expr(expr) => expr.span().end().line.saturating_sub(1),
-        SpecArgValue::Pat(pat) => pat.span().end().line.saturating_sub(1),
-    }
+fn arg_end_line(arg: &FieldValue) -> usize {
+    arg.expr.span().end().line.saturating_sub(1)
 }
 
 /// Format a complete #[spec(...)] attribute with comment preservation.
@@ -50,18 +47,18 @@ impl Formatter<'_> {
         self.set_indent(arg_indent);
 
         // Collect args with their original line numbers for comment association
-        let args_with_lines: Vec<(&SpecArg, usize)> = spec_args
+        let args_with_lines: Vec<(&FieldValue, usize)> = spec_args
             .args
             .iter()
             .map(|arg| {
-                let line = arg.keyword_span.start().line.saturating_sub(1);
+                let line = arg.member.span().start().line.saturating_sub(1);
                 (arg, line)
             })
             .collect();
 
         // Associate comments with their corresponding args before sorting
         // For each arg, find comments that appear between the previous arg's end and this arg's keyword
-        type ArgWithComments<'a> = (&'a SpecArg, usize, Vec<(usize, Option<String>)>);
+        type ArgWithComments<'a> = (&'a FieldValue, usize, Vec<(usize, Option<String>)>);
         let args_with_comments: Vec<ArgWithComments> = if self.settings.reorder_spec_items {
             args_with_lines
                 .iter()
@@ -95,7 +92,7 @@ impl Formatter<'_> {
         // Sort if reordering is enabled (comments are now bundled with args)
         let mut final_args = args_with_comments;
         if self.settings.reorder_spec_items {
-            final_args.sort_by_key(|(arg, _line, _comments)| &arg.keyword);
+            final_args.sort_by_key(|(arg, _line, _comments)| Keyword::from(&arg.member));
         }
 
         // Format each arg with its associated comments

--- a/crates/anodized-fmt/src/source_file.rs
+++ b/crates/anodized-fmt/src/source_file.rs
@@ -49,7 +49,7 @@ fn format_source(
         let start = span.start();
         let end = span.end();
 
-        // Parse the spec arguments
+        // Parse the spec fields.
         let spec_fields = match attr.parse_args::<SpecFields>() {
             Ok(fields) => fields,
             Err(_) => continue, // Skip malformed specs

--- a/crates/anodized-fmt/src/source_file.rs
+++ b/crates/anodized-fmt/src/source_file.rs
@@ -11,7 +11,7 @@ use crate::{
     formatter::format_spec_attribute,
 };
 
-use anodized_core::annotate::syntax::SpecArgs;
+use anodized_core::annotate::syntax::SpecFields;
 
 #[derive(Debug)]
 struct TextEdit {
@@ -50,8 +50,8 @@ fn format_source(
         let end = span.end();
 
         // Parse the spec arguments
-        let spec_args = match attr.parse_args::<SpecArgs>() {
-            Ok(args) => args,
+        let spec_fields = match attr.parse_args::<SpecFields>() {
+            Ok(fields) => fields,
             Err(_) => continue, // Skip malformed specs
         };
 
@@ -71,7 +71,8 @@ fn format_source(
             crate::collect_comments::extract_standalone_comments(&attr_source, start.line - 1);
 
         // Format with comments
-        let formatted = format_spec_attribute(&spec_args, config, &spec_attr.base_indent, comments);
+        let formatted =
+            format_spec_attribute(&spec_fields, config, &spec_attr.base_indent, comments);
 
         edits.push(TextEdit {
             range: start_byte..end_byte,

--- a/crates/anodized-fmt/tests/fixtures/expected/with_comments.rs
+++ b/crates/anodized-fmt/tests/fixtures/expected/with_comments.rs
@@ -24,7 +24,7 @@ fn double_positive(x: i32) -> i32 {
 
 // Multiple comments for same arg
 #[spec(
-    // First parameter must be positive
+    // First input must be positive
     // Another comment about the precondition
     requires: a > 0,
     // Result is positive
@@ -114,7 +114,7 @@ trait Validator {
 
 // Multiple clauses in requires without internal comments
 #[spec(
-    // Preconditions for all three parameters
+    // Preconditions for all three inputs
     requires: x > 0 && y > 0 && z > 0,
     ensures: *output > 0,
 )]

--- a/crates/anodized-fmt/tests/fixtures/input/with_comments.rs
+++ b/crates/anodized-fmt/tests/fixtures/input/with_comments.rs
@@ -24,7 +24,7 @@ fn double_positive(x: i32) -> i32 {
 
 // Multiple comments for same arg
 #[spec(
-    // First parameter must be positive
+    // First input must be positive
         // Another comment about the precondition
     requires: a > 0,
     // Result is positive
@@ -114,7 +114,7 @@ trait Validator {
 
 // Multiple clauses in requires without internal comments
 #[spec(
-           // Preconditions for all three parameters
+           // Preconditions for all three inputs
     requires: x > 0 &&
               y > 0 &&
               z > 0,

--- a/crates/anodized/REFERENCE.md
+++ b/crates/anodized/REFERENCE.md
@@ -110,7 +110,7 @@ fn push_checked<T>(vec: &mut Vec<T>, value: T) { todo!() }
 
 ### `captures`: Capture Entry-Time Values
 
-Sometimes postconditions need to compare the function's final state with its initial state. The `captures` parameter lets you capture values at function entry for use in postconditions.
+Sometimes postconditions need to compare the function's final state with its initial state. The `captures` field lets you capture values at function entry for use in postconditions.
 
 ```rust, no_run
 use anodized::spec;
@@ -164,7 +164,7 @@ fn get_positive_value() -> i32 { todo!() }
 
 The default spec-wide binding is `output`. If that collides with an existing identifier, you can choose a different name for it in two ways:
 
-**1. Spec-Wide Binding**: Use the `inspects` parameter to set a new name for the return value across all postconditions in the specification. It must be placed immediately before any `ensures` conditions.
+**1. Spec-Wide Binding**: Use the `inspects` field to set a new name for the return value across all postconditions in the specification. It must be placed immediately before any `ensures` conditions.
 
 ```rust, no_run
 use anodized::spec;
@@ -231,7 +231,7 @@ use anodized::spec;
 fn sort_pair(pair: (i32, i32)) -> (i32, i32) { todo!() }
 ```
 
-**5. Example With All Function Spec Arguments**
+**5. Example With All Function Spec Fields**
 
 ```rust, no_run
 use anodized::spec;
@@ -411,4 +411,4 @@ enum MonotonicVec<T: Ord> {
 Important restrictions:
 
 - Runtime checks are **not implemented** yet.
-- Only the `maintains` spec parameter is supported.
+- Only the `maintains` spec field is supported.

--- a/crates/anodized/tests/compile_fail/struct_invalid_spec.stderr
+++ b/crates/anodized/tests/compile_fail/struct_invalid_spec.stderr
@@ -1,22 +1,22 @@
-error: `requires` parameter is not supported here
+error: `requires` field is not supported here
  --> tests/compile_fail/struct_invalid_spec.rs:6:5
   |
 6 |     requires: self.x > 0.0,
   |     ^^^^^^^^
 
-error: `captures` parameter is not supported here
+error: `captures` field is not supported here
  --> tests/compile_fail/struct_invalid_spec.rs:8:5
   |
 8 |     captures: old_x = self.x,
   |     ^^^^^^^^
 
-error: `inspects` parameter is not supported here
+error: `inspects` field is not supported here
  --> tests/compile_fail/struct_invalid_spec.rs:9:5
   |
 9 |     inspects: ret_val,
   |     ^^^^^^^^
 
-error: `ensures` parameter is not supported here
+error: `ensures` field is not supported here
   --> tests/compile_fail/struct_invalid_spec.rs:10:5
    |
 10 |     ensures: self.y > 0.0,

--- a/crates/anodized/tests/compile_fail/struct_invalid_spec.stderr
+++ b/crates/anodized/tests/compile_fail/struct_invalid_spec.stderr
@@ -1,22 +1,22 @@
-error: `requires` field is not supported here
+error: not allowed here
  --> tests/compile_fail/struct_invalid_spec.rs:6:5
   |
 6 |     requires: self.x > 0.0,
   |     ^^^^^^^^
 
-error: `captures` field is not supported here
+error: not allowed here
  --> tests/compile_fail/struct_invalid_spec.rs:8:5
   |
 8 |     captures: old_x = self.x,
   |     ^^^^^^^^
 
-error: `inspects` field is not supported here
+error: not allowed here
  --> tests/compile_fail/struct_invalid_spec.rs:9:5
   |
 9 |     inspects: ret_val,
   |     ^^^^^^^^
 
-error: `ensures` field is not supported here
+error: not allowed here
   --> tests/compile_fail/struct_invalid_spec.rs:10:5
    |
 10 |     ensures: self.y > 0.0,


### PR DESCRIPTION
- Delete `SpecArg` and `SpecArgValue`, using `syn::FieldValue` instead.
- Rename `SpecArgs` to `SpecFields`.
- Revise terminology across code, docs, and tests to use "field" instead of "argument" and "parameter".
- Streamline error messages.