### PR TITLE
[anodized-core] refactor: simplify runtime check effects

### DIFF
--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -168,11 +168,11 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
                 match #maybe_self #mangled_ident(#(#args),*) #maybe_await {
                     ::anodized::result::Result::Ok(output) => output,
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Pre(errors)
-                    ) => panic!("precondition failed:{errors}"),
+                        ::anodized::result::Error::Pre
+                    ) => panic!("precondition failed"),
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Post(_, errors)
-                    ) => panic!("postcondition failed:{errors}"),
+                        ::anodized::result::Error::Post(_)
+                    ) => panic!("postcondition failed"),
                 }
             }
         };

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -39,8 +39,8 @@ fn embed_spec_item_struct() {
             'LT_1: 'LT_2,
         {
             fn __anodized_data_maintains(&self) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_1 })();
-                let __anodized_clause_2 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 __anodized_clause_1 && __anodized_clause_2
             }
         }
@@ -91,8 +91,8 @@ fn embed_spec_item_enum() {
         {
             fn __anodized_data_maintains(&self) -> bool {
                 use ENUM::*;
-                let __anodized_clause_1 = (|| -> bool { COND_1 })();
-                let __anodized_clause_2 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 __anodized_clause_1 && __anodized_clause_2
             }
         }

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -39,8 +39,8 @@ fn embed_spec_item_struct() {
             'LT_1: 'LT_2,
         {
             fn __anodized_data_maintains(&self) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
                 __anodized_clause_1 && __anodized_clause_2
             }
         }
@@ -91,8 +91,8 @@ fn embed_spec_item_enum() {
         {
             fn __anodized_data_maintains(&self) -> bool {
                 use ENUM::*;
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
                 __anodized_clause_1 && __anodized_clause_2
             }
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -5,7 +5,7 @@ mod fns_tests;
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Block, Expr, Ident, Meta, Pat, Path, ReturnType, Signature, Stmt, Type,
+    Attribute, Block, Expr, Ident, Pat, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
     parse_quote,
 };
@@ -213,8 +213,13 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_precond_eval(&condition.cfg, &expr, &repr);
+            let eval = self.build_precond_eval(&expr, &repr);
+            let cfg: Option<Attribute> = condition
+                .cfg
+                .as_ref()
+                .map(|meta| parse_quote! { #[cfg(#meta)] });
             precondition_checks.push(parse_quote! {
+                #cfg
                 let __anodized_pre = __anodized_pre & #eval;
             });
         }
@@ -253,8 +258,13 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_postcond_eval(&condition.cfg, &expr, &repr);
+            let eval = self.build_postcond_eval(&expr, &repr);
+            let cfg: Option<Attribute> = condition
+                .cfg
+                .as_ref()
+                .map(|meta| parse_quote! { #[cfg(#meta)] });
             postcondition_checks.push(parse_quote! {
+                #cfg
                 let __anodized_post = __anodized_post & #eval;
             });
         }
@@ -268,8 +278,13 @@ impl CheckSettings {
             } else {
                 parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) }
             };
-            let eval = self.build_postcond_eval(&postcond.cfg, &expr, &repr);
+            let eval = self.build_postcond_eval(&expr, &repr);
+            let cfg: Option<Attribute> = postcond
+                .cfg
+                .as_ref()
+                .map(|meta| parse_quote! { #[cfg(#meta)] });
             postcondition_checks.push(parse_quote! {
+                #cfg
                 let __anodized_post = __anodized_post & #eval;
             });
         }
@@ -319,25 +334,17 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+    fn build_precond_eval(&self, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
-            let cfg_guard = match cfg {
-                Some(meta) => quote! { !cfg!(#meta) || },
-                None => quote!(),
-            };
-            parse_quote! { ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () ) }
+            parse_quote! { ( #expr || eprintln!("precondition failed: {}", #repr) != () ) }
         } else {
             expr.clone()
         }
     }
 
-    fn build_postcond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+    fn build_postcond_eval(&self, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
-            let cfg_guard = match cfg {
-                Some(meta) => quote! { !cfg!(#meta) || },
-                None => quote!(),
-            };
-            parse_quote! { ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
+            parse_quote! { ( #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
         } else {
             expr.clone()
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -208,16 +208,15 @@ impl CheckSettings {
         let output_ident: Pat = parse_quote!(__anodized_output);
 
         // Generate precondition checks.
-        let mut precondition_clauses: Vec<Expr> = vec![];
+        let mut precondition_checks: Vec<Stmt> = vec![parse_quote! { let __anodized_pre = true; }];
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
-            precondition_clauses.push(clause);
-        }
-        if precondition_clauses.is_empty() {
-            precondition_clauses.push(parse_quote!(true));
+            let eval = self.build_precond_eval(&condition.cfg, &expr, &repr);
+            precondition_checks.push(parse_quote! {
+                let __anodized_pre = __anodized_pre & #eval;
+            });
         }
 
         // Bind capture values and function output in a single tuple assignment.
@@ -248,13 +247,16 @@ impl CheckSettings {
         };
 
         // Generate postcondition checks.
-        let mut postcondition_clauses: Vec<Expr> = vec![];
+        let mut postcondition_checks: Vec<Stmt> =
+            vec![parse_quote! { let __anodized_post = true; }];
         for condition in &spec.maintains {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
-            postcondition_clauses.push(clause);
+            let eval = self.build_postcond_eval(&condition.cfg, &expr, &repr);
+            postcondition_checks.push(parse_quote! {
+                let __anodized_post = __anodized_post & #eval;
+            });
         }
         for postcond in &spec.ensures {
             let expr = &postcond.expr;
@@ -266,11 +268,10 @@ impl CheckSettings {
             } else {
                 parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) }
             };
-            let clause = self.build_clause_eval(&postcond.cfg, &expr, &repr);
-            postcondition_clauses.push(clause);
-        }
-        if postcondition_clauses.is_empty() {
-            postcondition_clauses.push(parse_quote!(true));
+            let eval = self.build_postcond_eval(&postcond.cfg, &expr, &repr);
+            postcondition_checks.push(parse_quote! {
+                let __anodized_post = __anodized_post & #eval;
+            });
         }
 
         let do_run_checks = self.does_print || self.does_panic.is_some();
@@ -300,16 +301,16 @@ impl CheckSettings {
             {
                 if #do_run_checks {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = #(#precondition_clauses)&*;
-                    if !__anodized_precond {
+                    #(#precondition_checks)*
+                    if !__anodized_pre {
                         #precond_fail_action
                     }
                 }
                 #captures_and_output
                 if #do_run_checks {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = #(#postcondition_clauses)&*;
-                    if !__anodized_postcond {
+                    #(#postcondition_checks)*
+                    if !__anodized_post {
                         #postcond_fail_action
                     }
                 }
@@ -318,14 +319,25 @@ impl CheckSettings {
         })
     }
 
-    fn build_clause_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+    fn build_precond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
-            let br_and_repr = format!("\n    {repr}");
             let cfg_guard = match cfg {
                 Some(meta) => quote! { !cfg!(#meta) || },
                 None => quote!(),
             };
-            parse_quote! { ( #cfg_guard #expr || __anodized_errors.push_str(#br_and_repr) != () ) }
+            parse_quote! { ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () ) }
+        } else {
+            expr.clone()
+        }
+    }
+
+    fn build_postcond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+        if self.does_print {
+            let cfg_guard = match cfg {
+                Some(meta) => quote! { !cfg!(#meta) || },
+                None => quote!(),
+            };
+            parse_quote! { ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
         } else {
             expr.clone()
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -5,7 +5,7 @@ mod fns_tests;
 use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Block, Expr, Ident, Pat, Path, ReturnType, Signature, Stmt, Type,
+    Attribute, Block, Expr, Ident, Meta, Pat, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
     parse_quote,
 };
@@ -216,13 +216,8 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_precond_eval(&expr, &repr);
-            let cfg: Option<Attribute> = condition
-                .cfg
-                .as_ref()
-                .map(|meta| parse_quote! { #[cfg(#meta)] });
+            let eval = self.build_precond_eval(&condition.cfg, &expr, &repr);
             precondition_checks.push(parse_quote! {
-                #cfg
                 let __anodized_pre = __anodized_pre & #eval;
             });
         }
@@ -261,13 +256,8 @@ impl CheckSettings {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
             let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_postcond_eval(&expr, &repr);
-            let cfg: Option<Attribute> = condition
-                .cfg
-                .as_ref()
-                .map(|meta| parse_quote! { #[cfg(#meta)] });
+            let eval = self.build_postcond_eval(&condition.cfg, &expr, &repr);
             postcondition_checks.push(parse_quote! {
-                #cfg
                 let __anodized_post = __anodized_post & #eval;
             });
         }
@@ -281,13 +271,8 @@ impl CheckSettings {
             } else {
                 parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) }
             };
-            let eval = self.build_postcond_eval(&expr, &repr);
-            let cfg: Option<Attribute> = postcond
-                .cfg
-                .as_ref()
-                .map(|meta| parse_quote! { #[cfg(#meta)] });
+            let eval = self.build_postcond_eval(&postcond.cfg, &expr, &repr);
             postcondition_checks.push(parse_quote! {
-                #cfg
                 let __anodized_post = __anodized_post & #eval;
             });
         }
@@ -335,17 +320,25 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_eval(&self, expr: &Expr, repr: &str) -> Expr {
+    fn build_precond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
-            parse_quote! { ( #expr || eprintln!("precondition failed: {}", #repr) != () ) }
+            let cfg_guard = match cfg {
+                Some(meta) => quote! { !cfg!(#meta) || },
+                None => quote!(),
+            };
+            parse_quote! { ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () ) }
         } else {
             expr.clone()
         }
     }
 
-    fn build_postcond_eval(&self, expr: &Expr, repr: &str) -> Expr {
+    fn build_postcond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
-            parse_quote! { ( #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
+            let cfg_guard = match cfg {
+                Some(meta) => quote! { !cfg!(#meta) || },
+                None => quote!(),
+            };
+            parse_quote! { ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
         } else {
             expr.clone()
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -126,10 +126,8 @@ impl Mode {
         for condition in requires.iter().chain(maintains) {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
-            let expr = &condition.expr;
-            statements.push(parse_quote! {
-                let #name = ::anodized::__::eval::<bool>(|| { #expr });
-            });
+            let eval = build_cond_eval(&condition.expr);
+            statements.push(parse_quote! { let #name = #eval; });
             clauses.push(parse_quote! { #name });
         }
 
@@ -156,10 +154,8 @@ impl Mode {
         for condition in maintains {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
-            let expr = &condition.expr;
-            statements.push(parse_quote! {
-                let #name = ::anodized::__::eval::<bool>(|| { #expr });
-            });
+            let eval = build_cond_eval(&condition.expr);
+            statements.push(parse_quote! { let #name = #eval; });
             clauses.push(parse_quote! { #name });
         }
 
@@ -177,17 +173,14 @@ impl Mode {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &postcond.expr;
-            if let Some(pat) = &postcond.pat {
-                statements.push(parse_quote! {
-                    let #name = ::anodized::__::eval::<bool>(|| {
-                        let #pat = __anodized_output; #expr
-                    });
-                });
+            let eval = if let Some(pat) = &postcond.pat {
+                build_cond_eval(&parse_quote! {
+                    { let #pat = __anodized_output; #expr }
+                })
             } else {
-                statements.push(parse_quote! {
-                    let #name = ::anodized::__::eval::<bool>(|| { #expr });
-                });
-            }
+                build_cond_eval(expr)
+            };
+            statements.push(parse_quote! { let #name = #eval; });
             clauses.push(parse_quote! { #name });
         }
 
@@ -222,10 +215,10 @@ impl CheckSettings {
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_precond_eval(&condition.cfg, &expr, &repr);
+            let eval = build_cond_eval(expr);
+            let check = self.build_precond_check(&condition.cfg, &eval, &repr);
             precondition_checks.push(parse_quote! {
-                let __anodized_pre = __anodized_pre & #eval;
+                let __anodized_pre = __anodized_pre & #check;
             });
         }
 
@@ -263,25 +256,25 @@ impl CheckSettings {
         for condition in &spec.maintains {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
-            let eval = self.build_postcond_eval(&condition.cfg, &expr, &repr);
+            let eval = build_cond_eval(expr);
+            let check = self.build_postcond_check(&condition.cfg, &eval, &repr);
             postcondition_checks.push(parse_quote! {
-                let __anodized_post = __anodized_post & #eval;
+                let __anodized_post = __anodized_post & #check;
             });
         }
         for postcond in &spec.ensures {
             let expr = &postcond.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = if let Some(pat) = &postcond.pat {
-                parse_quote! {
-                    ::anodized::__::eval::<bool>(|| { let #pat = #output_ident; #expr })
-                }
+            let eval = if let Some(pat) = &postcond.pat {
+                build_cond_eval(&parse_quote! {
+                    { let #pat = #output_ident; #expr }
+                })
             } else {
-                parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) }
+                build_cond_eval(expr)
             };
-            let eval = self.build_postcond_eval(&postcond.cfg, &expr, &repr);
+            let check = self.build_postcond_check(&postcond.cfg, &eval, &repr);
             postcondition_checks.push(parse_quote! {
-                let __anodized_post = __anodized_post & #eval;
+                let __anodized_post = __anodized_post & #check;
             });
         }
 
@@ -293,12 +286,8 @@ impl CheckSettings {
             {
                 (
                     quote! { Ok(#output_ident) },
-                    Some(parse_quote! {
-                        return ::anodized::result::pre_err();
-                    }),
-                    Some(parse_quote! {
-                        return ::anodized::result::post_err(#output_ident);
-                    }),
+                    Some(parse_quote! { return ::anodized::result::pre_err(); }),
+                    Some(parse_quote! { return ::anodized::result::post_err(#output_ident); }),
                 )
             } else {
                 (
@@ -328,15 +317,15 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        self.build_cond_eval("precondition failed: {}", cfg, expr, repr)
+    fn build_precond_check(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+        self.build_cond_check("precondition failed: {}", cfg, expr, repr)
     }
 
-    fn build_postcond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        self.build_cond_eval("postcondition failed: {}", cfg, expr, repr)
+    fn build_postcond_check(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+        self.build_cond_check("postcondition failed: {}", cfg, expr, repr)
     }
 
-    fn build_cond_eval(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
             let cfg_guard = match cfg {
                 Some(meta) => quote! { !cfg!(#meta) || },
@@ -355,6 +344,10 @@ impl CheckSettings {
             .as_ref()
             .map(|_| parse_quote! { panic!(#message); })
     }
+}
+
+fn build_cond_eval(expr: &Expr) -> Expr {
+    parse_quote! { ::anodized::__::eval::<bool>(|| #expr) }
 }
 
 pub(crate) fn make_try_fn_ident(ident: &Ident) -> Ident {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -127,7 +127,8 @@ impl Mode {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &condition.expr;
-            statements.push(parse_quote! { let #name = (|| -> bool { #expr })(); });
+            statements
+                .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
             clauses.push(parse_quote! { #name });
         }
 
@@ -155,7 +156,8 @@ impl Mode {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &condition.expr;
-            statements.push(parse_quote! { let #name = (|| -> bool { #expr })(); });
+            statements
+                .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
             clauses.push(parse_quote! { #name });
         }
 
@@ -175,10 +177,11 @@ impl Mode {
             let expr = &postcond.expr;
             if let Some(pat) = &postcond.pat {
                 statements.push(
-                    parse_quote! { let #name = (|#pat| -> bool { #expr })(__anodized_output); },
+                    parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { let #pat = __anodized_output; #expr }); },
                 );
             } else {
-                statements.push(parse_quote! { let #name = (|| -> bool { #expr })(); });
+                statements
+                    .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
             }
             clauses.push(parse_quote! { #name });
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -209,7 +209,7 @@ impl CheckSettings {
         let output_ident: Pat = parse_quote!(__anodized_output);
 
         // Generate precondition checks.
-        let mut precondition_checks: Vec<Stmt> = vec![parse_quote! {
+        let mut precond_checks: Vec<Stmt> = vec![parse_quote! {
             let __anodized_pre = true;
         }];
         for condition in spec.requires.iter().chain(&spec.maintains) {
@@ -217,7 +217,7 @@ impl CheckSettings {
             let repr = expr.to_token_stream().to_string();
             let eval = build_cond_eval(expr);
             let check = self.build_precond_check(&condition.cfg, &eval, &repr);
-            precondition_checks.push(parse_quote! {
+            precond_checks.push(parse_quote! {
                 let __anodized_pre = __anodized_pre & #check;
             });
         }
@@ -250,7 +250,7 @@ impl CheckSettings {
         };
 
         // Generate postcondition checks.
-        let mut postcondition_checks: Vec<Stmt> = vec![parse_quote! {
+        let mut postcond_checks: Vec<Stmt> = vec![parse_quote! {
             let __anodized_post = true;
         }];
         for condition in &spec.maintains {
@@ -258,7 +258,7 @@ impl CheckSettings {
             let repr = expr.to_token_stream().to_string();
             let eval = build_cond_eval(expr);
             let check = self.build_postcond_check(&condition.cfg, &eval, &repr);
-            postcondition_checks.push(parse_quote! {
+            postcond_checks.push(parse_quote! {
                 let __anodized_post = __anodized_post & #check;
             });
         }
@@ -273,7 +273,7 @@ impl CheckSettings {
                 build_cond_eval(expr)
             };
             let check = self.build_postcond_check(&postcond.cfg, &eval, &repr);
-            postcondition_checks.push(parse_quote! {
+            postcond_checks.push(parse_quote! {
                 let __anodized_post = __anodized_post & #check;
             });
         }
@@ -300,14 +300,14 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
-                    #(#precondition_checks)*
+                    #(#precond_checks)*
                     if !__anodized_pre {
                         #precond_fail_action
                     }
                 }
                 #captures_and_output
                 if #do_run_checks {
-                    #(#postcondition_checks)*
+                    #(#postcond_checks)*
                     if !__anodized_post {
                         #postcond_fail_action
                     }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -212,7 +212,7 @@ impl CheckSettings {
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { __anodized_eval_pre(|| -> bool { #expr }) };
+            let expr = parse_quote! { ::anodized::__::eval(|| -> bool { #expr }) };
             let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             precondition_clauses.push(clause);
         }
@@ -252,7 +252,7 @@ impl CheckSettings {
         for condition in &spec.maintains {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { __anodized_eval_post(|| -> bool { #expr }) };
+            let expr = parse_quote! { ::anodized::__::eval(|| -> bool { #expr }) };
             let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             postcondition_clauses.push(clause);
         }
@@ -261,10 +261,10 @@ impl CheckSettings {
             let repr = expr.to_token_stream().to_string();
             let expr = if let Some(pat) = &postcond.pat {
                 parse_quote! {
-                    __anodized_eval_post(|| -> bool { let #pat = #output_ident; #expr })
+                    ::anodized::__::eval(|| -> bool { let #pat = #output_ident; #expr })
                 }
             } else {
-                parse_quote! { __anodized_eval_post(|| -> bool { #expr }) }
+                parse_quote! { ::anodized::__::eval(|| { #expr }) }
             };
             let clause = self.build_clause_eval(&postcond.cfg, &expr, &repr);
             postcondition_clauses.push(clause);
@@ -299,7 +299,6 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_precond = #(#precondition_clauses)&*;
                     if !__anodized_precond {
@@ -308,7 +307,6 @@ impl CheckSettings {
                 }
                 #captures_and_output
                 if #do_run_checks {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_postcond = #(#postcondition_clauses)&*;
                     if !__anodized_postcond {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -298,10 +298,10 @@ impl CheckSettings {
                 (
                     quote! { Ok(#output_ident) },
                     Some(parse_quote! {
-                        return ::anodized::result::pre_err(__anodized_errors);
+                        return ::anodized::result::pre_err();
                     }),
                     Some(parse_quote! {
-                        return ::anodized::result::post_err(#output_ident, __anodized_errors);
+                        return ::anodized::result::post_err(#output_ident);
                     }),
                 )
             } else {
@@ -315,7 +315,6 @@ impl CheckSettings {
         Ok(parse_quote! {
             {
                 if #do_run_checks {
-                    let mut __anodized_errors = ::std::string::String::new();
                     #(#precondition_checks)*
                     if !__anodized_pre {
                         #precond_fail_action
@@ -323,7 +322,6 @@ impl CheckSettings {
                 }
                 #captures_and_output
                 if #do_run_checks {
-                    let mut __anodized_errors = ::std::string::String::new();
                     #(#postcondition_checks)*
                     if !__anodized_post {
                         #postcond_fail_action
@@ -351,13 +349,9 @@ impl CheckSettings {
     }
 
     fn build_fail_action(&self, message: &str) -> Option<Stmt> {
-        let message_and_errors = format!("{message}:{{__anodized_errors}}");
-        match (self.does_print, self.does_panic.is_some()) {
-            (true, true) => Some(parse_quote! { panic!(#message_and_errors); }),
-            (true, false) => Some(parse_quote! { eprintln!(#message_and_errors); }),
-            (false, true) => Some(parse_quote! { panic!(#message); }),
-            (false, false) => None,
-        }
+        self.does_panic
+            .as_ref()
+            .map(|_| parse_quote! { panic!(#message); })
     }
 }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -212,7 +212,7 @@ impl CheckSettings {
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { ::anodized::__::eval(|| -> bool { #expr }) };
+            let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
             let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             precondition_clauses.push(clause);
         }
@@ -252,7 +252,7 @@ impl CheckSettings {
         for condition in &spec.maintains {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
-            let expr = parse_quote! { ::anodized::__::eval(|| -> bool { #expr }) };
+            let expr = parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) };
             let clause = self.build_clause_eval(&condition.cfg, &expr, &repr);
             postcondition_clauses.push(clause);
         }
@@ -261,10 +261,10 @@ impl CheckSettings {
             let repr = expr.to_token_stream().to_string();
             let expr = if let Some(pat) = &postcond.pat {
                 parse_quote! {
-                    ::anodized::__::eval(|| -> bool { let #pat = #output_ident; #expr })
+                    ::anodized::__::eval::<bool>(|| { let #pat = #output_ident; #expr })
                 }
             } else {
-                parse_quote! { ::anodized::__::eval(|| { #expr }) }
+                parse_quote! { ::anodized::__::eval::<bool>(|| { #expr }) }
             };
             let clause = self.build_clause_eval(&postcond.cfg, &expr, &repr);
             postcondition_clauses.push(clause);

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -329,27 +329,21 @@ impl CheckSettings {
     }
 
     fn build_precond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        if self.does_print {
-            let cfg_guard = match cfg {
-                Some(meta) => quote! { !cfg!(#meta) || },
-                None => quote!(),
-            };
-            parse_quote! {
-                ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () )
-            }
-        } else {
-            expr.clone()
-        }
+        self.build_cond_eval("precondition failed: {}", cfg, expr, repr)
     }
 
     fn build_postcond_eval(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+        self.build_cond_eval("postcondition failed: {}", cfg, expr, repr)
+    }
+
+    fn build_cond_eval(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
         if self.does_print {
             let cfg_guard = match cfg {
                 Some(meta) => quote! { !cfg!(#meta) || },
                 None => quote!(),
             };
             parse_quote! {
-                ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () )
+                ( #cfg_guard #expr || eprintln!(#msg, #repr) != () )
             }
         } else {
             expr.clone()

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -127,8 +127,9 @@ impl Mode {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &condition.expr;
-            statements
-                .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
+            statements.push(parse_quote! {
+                let #name = ::anodized::__::eval::<bool>(|| { #expr });
+            });
             clauses.push(parse_quote! { #name });
         }
 
@@ -156,8 +157,9 @@ impl Mode {
             let i = clauses.len();
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &condition.expr;
-            statements
-                .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
+            statements.push(parse_quote! {
+                let #name = ::anodized::__::eval::<bool>(|| { #expr });
+            });
             clauses.push(parse_quote! { #name });
         }
 
@@ -176,12 +178,15 @@ impl Mode {
             let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &postcond.expr;
             if let Some(pat) = &postcond.pat {
-                statements.push(
-                    parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { let #pat = __anodized_output; #expr }); },
-                );
+                statements.push(parse_quote! {
+                    let #name = ::anodized::__::eval::<bool>(|| {
+                        let #pat = __anodized_output; #expr
+                    });
+                });
             } else {
-                statements
-                    .push(parse_quote! { let #name = ::anodized::__::eval::<bool>(|| { #expr }); });
+                statements.push(parse_quote! {
+                    let #name = ::anodized::__::eval::<bool>(|| { #expr });
+                });
             }
             clauses.push(parse_quote! { #name });
         }
@@ -211,7 +216,9 @@ impl CheckSettings {
         let output_ident: Pat = parse_quote!(__anodized_output);
 
         // Generate precondition checks.
-        let mut precondition_checks: Vec<Stmt> = vec![parse_quote! { let __anodized_pre = true; }];
+        let mut precondition_checks: Vec<Stmt> = vec![parse_quote! {
+            let __anodized_pre = true;
+        }];
         for condition in spec.requires.iter().chain(&spec.maintains) {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
@@ -250,8 +257,9 @@ impl CheckSettings {
         };
 
         // Generate postcondition checks.
-        let mut postcondition_checks: Vec<Stmt> =
-            vec![parse_quote! { let __anodized_post = true; }];
+        let mut postcondition_checks: Vec<Stmt> = vec![parse_quote! {
+            let __anodized_post = true;
+        }];
         for condition in &spec.maintains {
             let expr = &condition.expr;
             let repr = expr.to_token_stream().to_string();
@@ -326,7 +334,9 @@ impl CheckSettings {
                 Some(meta) => quote! { !cfg!(#meta) || },
                 None => quote!(),
             };
-            parse_quote! { ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () ) }
+            parse_quote! {
+                ( #cfg_guard #expr || eprintln!("precondition failed: {}", #repr) != () )
+            }
         } else {
             expr.clone()
         }
@@ -338,7 +348,9 @@ impl CheckSettings {
                 Some(meta) => quote! { !cfg!(#meta) || },
                 None => quote!(),
             };
-            parse_quote! { ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () ) }
+            parse_quote! {
+                ( #cfg_guard #expr || eprintln!("postcondition failed: {}", #repr) != () )
+            }
         } else {
             expr.clone()
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -213,10 +213,7 @@ impl CheckSettings {
             let __anodized_pre = true;
         }];
         for condition in spec.requires.iter().chain(&spec.maintains) {
-            let expr = &condition.expr;
-            let repr = expr.to_token_stream().to_string();
-            let eval = build_cond_eval(expr);
-            let check = self.build_precond_check(&condition.cfg, &eval, &repr);
+            let check = self.build_precond_check(&condition.cfg, &condition.expr);
             precond_checks.push(parse_quote! {
                 let __anodized_pre = __anodized_pre & #check;
             });
@@ -254,25 +251,13 @@ impl CheckSettings {
             let __anodized_post = true;
         }];
         for condition in &spec.maintains {
-            let expr = &condition.expr;
-            let repr = expr.to_token_stream().to_string();
-            let eval = build_cond_eval(expr);
-            let check = self.build_postcond_check(&condition.cfg, &eval, &repr);
+            let check = self.build_postcond_check(&condition.cfg, &None, &condition.expr);
             postcond_checks.push(parse_quote! {
                 let __anodized_post = __anodized_post & #check;
             });
         }
         for postcond in &spec.ensures {
-            let expr = &postcond.expr;
-            let repr = expr.to_token_stream().to_string();
-            let eval = if let Some(pat) = &postcond.pat {
-                build_cond_eval(&parse_quote! {
-                    { let #pat = #output_ident; #expr }
-                })
-            } else {
-                build_cond_eval(expr)
-            };
-            let check = self.build_postcond_check(&postcond.cfg, &eval, &repr);
+            let check = self.build_postcond_check(&postcond.cfg, &postcond.pat, &postcond.expr);
             postcond_checks.push(parse_quote! {
                 let __anodized_post = __anodized_post & #check;
             });
@@ -317,12 +302,22 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        self.build_cond_check("precondition failed: {}", cfg, expr, repr)
+    fn build_precond_check(&self, cfg: &Option<Meta>, expr: &Expr) -> Expr {
+        let repr = expr.to_token_stream().to_string();
+        let eval = build_cond_eval(expr);
+        self.build_cond_check("precondition failed: {}", cfg, &eval, &repr)
     }
 
-    fn build_postcond_check(&self, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        self.build_cond_check("postcondition failed: {}", cfg, expr, repr)
+    fn build_postcond_check(&self, cfg: &Option<Meta>, pat: &Option<Pat>, expr: &Expr) -> Expr {
+        let repr = expr.to_token_stream().to_string();
+        let eval = if let Some(pat) = pat {
+            build_cond_eval(&parse_quote! {
+                { let #pat = __anodized_output; #expr }
+            })
+        } else {
+            build_cond_eval(expr)
+        };
+        self.build_cond_check("postcondition failed: {}", cfg, &eval, &repr)
     }
 
     fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -101,7 +101,6 @@ fn default_instrument_item_fn() {
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_5 });
                 #[cfg(META_2)]
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_6 });
-
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
@@ -121,7 +120,6 @@ fn default_instrument_item_fn() {
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
                 #[cfg(META_3)]
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
-
                 if !__anodized_post {}
             }
             __anodized_output
@@ -177,7 +175,6 @@ fn emit_try_fn_instrument_item_fn() {
                 #[cfg(META_2)]
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_6 })
                         || eprintln!("precondition failed: {}", "COND_6") != ());
-
                 if !__anodized_pre {
                     return ::anodized::result::pre_err(__anodized_errors);
                 }
@@ -205,7 +202,6 @@ fn emit_try_fn_instrument_item_fn() {
                 #[cfg(META_3)]
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
                         || eprintln!("postcondition failed: {}", "COND_9") != ());
-
                 if !__anodized_post {
                     return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                 }
@@ -248,7 +244,6 @@ fn simple_requires() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -257,7 +252,6 @@ fn simple_requires() {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -290,14 +284,12 @@ fn requires_disable_runtime_checks() {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { CONDITION_1 });
-
                 if !__anodized_pre {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if false {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
-
                 if !__anodized_post {}
             }
             __anodized_output
@@ -322,7 +314,6 @@ fn requires_no_panic_runtime() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     eprintln!("precondition failed:{__anodized_errors}");
                 }
@@ -331,7 +322,6 @@ fn requires_no_panic_runtime() {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
-
                 if !__anodized_post {
                     eprintln!("postcondition failed:{__anodized_errors}");
                 }
@@ -362,7 +352,6 @@ fn simple_maintains() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -373,7 +362,6 @@ fn simple_maintains() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -402,7 +390,6 @@ fn simple_ensures() {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -413,7 +400,6 @@ fn simple_ensures() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -447,7 +433,6 @@ fn simple_requires_and_maintains() {
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -458,7 +443,6 @@ fn simple_requires_and_maintains() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -490,7 +474,6 @@ fn simple_requires_and_ensures() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -501,7 +484,6 @@ fn simple_requires_and_ensures() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -533,7 +515,6 @@ fn simple_maintains_and_ensures() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -546,7 +527,6 @@ fn simple_maintains_and_ensures() {
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -581,7 +561,6 @@ fn simple_requires_maintains_and_ensures() {
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -594,7 +573,6 @@ fn simple_requires_maintains_and_ensures() {
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -629,7 +607,6 @@ fn simple_async_requires_maintains_and_ensures() {
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -642,7 +619,6 @@ fn simple_async_requires_maintains_and_ensures() {
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -681,7 +657,6 @@ fn multiple_conditions_in_clauses() {
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("precondition failed: {}", "CONDITION_4") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -698,7 +673,6 @@ fn multiple_conditions_in_clauses() {
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -727,7 +701,6 @@ fn postcond_closure_form() {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -738,7 +711,6 @@ fn postcond_closure_form() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -772,7 +744,6 @@ fn ensures_with_mixed_conditions() {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -789,7 +760,6 @@ fn ensures_with_mixed_conditions() {
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -829,7 +799,6 @@ fn cfg_attributes() {
                 #[cfg(SETTING_2)]
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -844,7 +813,6 @@ fn cfg_attributes() {
                 #[cfg(SETTING_3)]
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -884,7 +852,6 @@ fn cfg_on_single_and_list_conditions() {
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -903,7 +870,6 @@ fn cfg_on_single_and_list_conditions() {
                 #[cfg(SETTING_2)]
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -955,7 +921,6 @@ fn complex_mixed_conditions() {
                 #[cfg(SETTING_2)]
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("precondition failed: {}", "CONDITION_6") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -979,7 +944,6 @@ fn complex_mixed_conditions() {
                 #[cfg(SETTING_3)]
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_9 })
                         || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
@@ -1018,7 +982,6 @@ fn captures() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-
                 if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
@@ -1031,7 +994,6 @@ fn captures() {
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-
                 if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -43,12 +43,12 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
-            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| { COND_3 });
-            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { COND_4 });
-            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { COND_5 });
-            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| { COND_6 });
+            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
+            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| COND_3);
+            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| COND_4);
+            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| COND_5);
+            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| COND_6);
             __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
                 && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
         }
@@ -56,9 +56,9 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_4 });
-            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_5 });
-            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| { COND_6 });
+            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_4);
+            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_5);
+            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| COND_6);
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((|| EXPR_1)(), (|| EXPR_2)());
             let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
             let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
@@ -91,12 +91,12 @@ fn default_instrument_item_fn() {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_3 });
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_4 });
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_5 });
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_6 });
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_3);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_4);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_5);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_6);
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
@@ -106,9 +106,9 @@ fn default_instrument_item_fn() {
             );
             if false {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_4 });
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_5 });
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_6 });
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_4);
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_5);
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_6);
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
@@ -151,17 +151,17 @@ fn emit_try_fn_instrument_item_fn() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                         || eprintln!("precondition failed: {}", "COND_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("precondition failed: {}", "COND_2") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_3 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
                         || eprintln!("precondition failed: {}", "COND_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_4 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_4)
                         || eprintln!("precondition failed: {}", "COND_4") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_5 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_5)
                         || eprintln!("precondition failed: {}", "COND_5") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
                         || eprintln!("precondition failed: {}", "COND_6") != ());
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
@@ -174,11 +174,11 @@ fn emit_try_fn_instrument_item_fn() {
             );
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_4 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_4)
                         || eprintln!("postcondition failed: {}", "COND_4") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_5 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_5)
                         || eprintln!("postcondition failed: {}", "COND_5") != ());
-                let __anodized_post = __anodized_post & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
+                let __anodized_post = __anodized_post & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
                         || eprintln!("postcondition failed: {}", "COND_6") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
                         || eprintln!("postcondition failed: {}", "COND_7") != ());
@@ -225,7 +225,7 @@ fn simple_requires() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -264,7 +264,7 @@ fn requires_disable_runtime_checks() {
         {
             if false {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { CONDITION_1 });
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| CONDITION_1);
                 if !__anodized_pre {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
@@ -291,7 +291,7 @@ fn requires_no_panic_runtime() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {}
             }
@@ -323,7 +323,7 @@ fn simple_maintains() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -332,7 +332,7 @@ fn simple_maintains() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -368,7 +368,7 @@ fn simple_ensures() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -398,9 +398,9 @@ fn simple_requires_and_maintains() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -409,7 +409,7 @@ fn simple_requires_and_maintains() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -439,7 +439,7 @@ fn simple_requires_and_ensures() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -448,7 +448,7 @@ fn simple_requires_and_ensures() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -478,7 +478,7 @@ fn simple_maintains_and_ensures() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -487,9 +487,9 @@ fn simple_maintains_and_ensures() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -520,9 +520,9 @@ fn simple_requires_maintains_and_ensures() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -531,9 +531,9 @@ fn simple_requires_maintains_and_ensures() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -564,9 +564,9 @@ fn simple_async_requires_maintains_and_ensures() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -575,9 +575,9 @@ fn simple_async_requires_maintains_and_ensures() {
             let (__anodized_output) = ((async || #ret_type #body)().await);
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -608,13 +608,13 @@ fn multiple_conditions_in_clauses() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
                         || eprintln!("precondition failed: {}", "CONDITION_4") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -623,13 +623,13 @@ fn multiple_conditions_in_clauses() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_5)
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_6)
                         || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -706,13 +706,13 @@ fn ensures_with_mixed_conditions() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -746,9 +746,9 @@ fn cfg_attributes() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -757,9 +757,9 @@ fn cfg_attributes() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -792,11 +792,11 @@ fn cfg_on_single_and_list_conditions() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -805,13 +805,13 @@ fn cfg_on_single_and_list_conditions() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_4)
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_5)
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -848,17 +848,17 @@ fn complex_mixed_conditions() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
                         || eprintln!("precondition failed: {}", "CONDITION_4") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_5)
                         || eprintln!("precondition failed: {}", "CONDITION_5") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
                         || eprintln!("precondition failed: {}", "CONDITION_6") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -867,17 +867,17 @@ fn complex_mixed_conditions() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                     || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_5)
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
                         || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_7 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_7)
                         || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_8 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_8)
                         || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
-                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_9 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_9)
                         || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -914,7 +914,7 @@ fn captures() {
         {
             if true {
                 let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -923,9 +923,9 @@ fn captures() {
             let (ALIAS_1, ALIAS_2, __anodized_output) = ((|| EXPR_1) (), (|| EXPR_2) (), (|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -43,12 +43,12 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-            let __anodized_clause_1 = (|| -> bool { COND_1 })();
-            let __anodized_clause_2 = (|| -> bool { COND_2 })();
-            let __anodized_clause_3 = (|| -> bool { COND_3 })();
-            let __anodized_clause_4 = (|| -> bool { COND_4 })();
-            let __anodized_clause_5 = (|| -> bool { COND_5 })();
-            let __anodized_clause_6 = (|| -> bool { COND_6 })();
+            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| { COND_3 });
+            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { COND_4 });
+            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { COND_5 });
+            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| { COND_6 });
             __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
                 && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
         }
@@ -56,13 +56,13 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-            let __anodized_clause_1 = (|| -> bool { COND_4 })();
-            let __anodized_clause_2 = (|| -> bool { COND_5 })();
-            let __anodized_clause_3 = (|| -> bool { COND_6 })();
+            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_4 });
+            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_5 });
+            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| { COND_6 });
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((|| EXPR_1)(), (|| EXPR_2)());
-            let __anodized_clause_4 = (|PAT_1| -> bool { COND_7 })(__anodized_output);
-            let __anodized_clause_5 = (|PAT_1| -> bool { COND_8 })(__anodized_output);
-            let __anodized_clause_6 = (|PAT_1| -> bool { COND_9 })(__anodized_output);
+            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
+            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
+            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
             __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
                 && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
         }
@@ -92,13 +92,10 @@ fn default_instrument_item_fn() {
             if false {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
-                #[cfg(META_1)]
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
-                #[cfg(META_1)]
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_3 });
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_4 });
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_5 });
-                #[cfg(META_2)]
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_6 });
                 if !__anodized_pre {}
             }
@@ -111,12 +108,9 @@ fn default_instrument_item_fn() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_4 });
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_5 });
-                #[cfg(META_2)]
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_6 });
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
-                #[cfg(META_3)]
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
-                #[cfg(META_3)]
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
                 if !__anodized_post {}
             }
@@ -142,11 +136,11 @@ fn emit_try_fn_instrument_item_fn() {
             match __anodized_fn_try_FUNC(self, input_1, input_2) {
                 ::anodized::result::Result::Ok(output) => output,
                 ::anodized::result::Result::Err(
-                    ::anodized::result::Error::Pre(errors)
-                ) => panic!("precondition failed:{errors}"),
+                    ::anodized::result::Error::Pre
+                ) => panic!("precondition failed"),
                 ::anodized::result::Result::Err(
-                    ::anodized::result::Error::Post(_, errors)
-                ) => panic!("postcondition failed:{errors}"),
+                    ::anodized::result::Error::Post(_)
+                ) => panic!("postcondition failed"),
             }
         }
 
@@ -159,18 +153,15 @@ fn emit_try_fn_instrument_item_fn() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
                         || eprintln!("precondition failed: {}", "COND_1") != ());
-                #[cfg(META_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_2 })
                         || eprintln!("precondition failed: {}", "COND_2") != ());
-                #[cfg(META_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_3 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_3 })
                         || eprintln!("precondition failed: {}", "COND_3") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_4 })
                         || eprintln!("precondition failed: {}", "COND_4") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_5 })
                         || eprintln!("precondition failed: {}", "COND_5") != ());
-                #[cfg(META_2)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_6 })
+                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
                         || eprintln!("precondition failed: {}", "COND_6") != ());
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
@@ -187,16 +178,13 @@ fn emit_try_fn_instrument_item_fn() {
                         || eprintln!("postcondition failed: {}", "COND_4") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_5 })
                         || eprintln!("postcondition failed: {}", "COND_5") != ());
-                #[cfg(META_2)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { COND_6 })
+                let __anodized_post = __anodized_post & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
                         || eprintln!("postcondition failed: {}", "COND_6") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
                         || eprintln!("postcondition failed: {}", "COND_7") != ());
-                #[cfg(META_3)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
+                let __anodized_post = __anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
                         || eprintln!("postcondition failed: {}", "COND_8") != ());
-                #[cfg(META_3)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
+                let __anodized_post = __anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
                         || eprintln!("postcondition failed: {}", "COND_9") != ());
                 if !__anodized_post {
                     return ::anodized::result::post_err(__anodized_output);
@@ -758,11 +746,9 @@ fn cfg_attributes() {
         {
             if true {
                 let __anodized_pre = true;
-                #[cfg(SETTING_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                #[cfg(SETTING_2)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -771,11 +757,9 @@ fn cfg_attributes() {
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let __anodized_post = true;
-                #[cfg(SETTING_2)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                #[cfg(SETTING_3)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -808,8 +792,7 @@ fn cfg_on_single_and_list_conditions() {
         {
             if true {
                 let __anodized_pre = true;
-                #[cfg(SETTING_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
@@ -826,11 +809,9 @@ fn cfg_on_single_and_list_conditions() {
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                #[cfg(SETTING_2)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                #[cfg(SETTING_2)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");
@@ -869,18 +850,15 @@ fn complex_mixed_conditions() {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                #[cfg(SETTING_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                #[cfg(SETTING_1)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("precondition failed: {}", "CONDITION_4") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || eprintln!("precondition failed: {}", "CONDITION_5") != ());
-                #[cfg(SETTING_2)]
-                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("precondition failed: {}", "CONDITION_6") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -893,16 +871,13 @@ fn complex_mixed_conditions() {
                     || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-                #[cfg(SETTING_2)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_7 })
                         || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
-                #[cfg(SETTING_3)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_8 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_8 })
                         || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
-                #[cfg(SETTING_3)]
-                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_9 })
+                let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| { CONDITION_9 })
                         || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
                 if !__anodized_post {
                     panic!("postcondition failed");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -91,13 +91,18 @@ fn default_instrument_item_fn() {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
-                    & ::anodized::__::eval::<bool>(|| { COND_2 })
-                    & ::anodized::__::eval::<bool>(|| { COND_3 })
-                    & ::anodized::__::eval::<bool>(|| { COND_4 })
-                    & ::anodized::__::eval::<bool>(|| { COND_5 })
-                    & ::anodized::__::eval::<bool>(|| { COND_6 });
-                if !__anodized_precond {}
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
+                #[cfg(META_1)]
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+                #[cfg(META_1)]
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_3 });
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_4 });
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_5 });
+                #[cfg(META_2)]
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_6 });
+
+                if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
                 (|| EXPR_1)(),
@@ -106,13 +111,18 @@ fn default_instrument_item_fn() {
             );
             if false {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_4 })
-                    & ::anodized::__::eval::<bool>(|| { COND_5 })
-                    & ::anodized::__::eval::<bool>(|| { COND_6 })
-                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
-                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
-                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
-                if !__anodized_postcond {}
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_4 });
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_5 });
+                #[cfg(META_2)]
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_6 });
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
+                #[cfg(META_3)]
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
+                #[cfg(META_3)]
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
+
+                if !__anodized_post {}
             }
             __anodized_output
         }
@@ -151,19 +161,24 @@ fn emit_try_fn_instrument_item_fn() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
-                        || __anodized_errors.push_str("\n    COND_1") != ())
-                    & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_2 })
-                        || __anodized_errors.push_str("\n    COND_2") != ())
-                    & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_3 })
-                        || __anodized_errors.push_str("\n    COND_3") != ())
-                    & (::anodized::__::eval::<bool>(|| { COND_4 })
-                        || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (::anodized::__::eval::<bool>(|| { COND_5 })
-                        || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
-                        || __anodized_errors.push_str("\n    COND_6") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                        || eprintln!("precondition failed: {}", "COND_1") != ());
+                #[cfg(META_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_2 })
+                        || eprintln!("precondition failed: {}", "COND_2") != ());
+                #[cfg(META_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_3 })
+                        || eprintln!("precondition failed: {}", "COND_3") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_4 })
+                        || eprintln!("precondition failed: {}", "COND_4") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_5 })
+                        || eprintln!("precondition failed: {}", "COND_5") != ());
+                #[cfg(META_2)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_6 })
+                        || eprintln!("precondition failed: {}", "COND_6") != ());
+
+                if !__anodized_pre {
                     return ::anodized::result::pre_err(__anodized_errors);
                 }
             }
@@ -174,20 +189,24 @@ fn emit_try_fn_instrument_item_fn() {
             );
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_4 })
-                        || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (::anodized::__::eval::<bool>(|| { COND_5 })
-                        || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
-                        || __anodized_errors.push_str("\n    COND_6") != ())
-                    & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
-                        || __anodized_errors.push_str("\n    COND_7") != ())
-                    & (!cfg!(META_3)
-                        || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
-                        || __anodized_errors.push_str("\n    COND_8") != ())
-                    & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
-                        || __anodized_errors.push_str("\n    COND_9") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_4 })
+                        || eprintln!("postcondition failed: {}", "COND_4") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_5 })
+                        || eprintln!("postcondition failed: {}", "COND_5") != ());
+                #[cfg(META_2)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { COND_6 })
+                        || eprintln!("postcondition failed: {}", "COND_6") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
+                        || eprintln!("postcondition failed: {}", "COND_7") != ());
+                #[cfg(META_3)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
+                        || eprintln!("postcondition failed: {}", "COND_8") != ());
+                #[cfg(META_3)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
+                        || eprintln!("postcondition failed: {}", "COND_9") != ());
+
+                if !__anodized_post {
                     return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                 }
             }
@@ -226,17 +245,20 @@ fn simple_requires() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = true;
-                if !__anodized_postcond {
+                let __anodized_post = true;
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -266,14 +288,17 @@ fn requires_disable_runtime_checks() {
         {
             if false {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = ::anodized::__::eval::<bool>(|| { CONDITION_1 });
-                if !__anodized_precond {}
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { CONDITION_1 });
+
+                if !__anodized_pre {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if false {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = true;
-                if !__anodized_postcond {}
+                let __anodized_post = true;
+
+                if !__anodized_post {}
             }
             __anodized_output
         }
@@ -294,17 +319,20 @@ fn requires_no_panic_runtime() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     eprintln!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = true;
-                if !__anodized_postcond {
+                let __anodized_post = true;
+
+                if !__anodized_post {
                     eprintln!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -331,18 +359,22 @@ fn simple_maintains() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -369,17 +401,20 @@ fn simple_ensures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = true;
-                if !__anodized_precond {
+                let __anodized_pre = true;
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -407,20 +442,24 @@ fn simple_requires_and_maintains() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -448,18 +487,22 @@ fn simple_requires_and_ensures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -487,20 +530,24 @@ fn simple_maintains_and_ensures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -529,22 +576,26 @@ fn simple_requires_maintains_and_ensures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -573,22 +624,26 @@ fn simple_async_requires_maintains_and_ensures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((async || #ret_type #body)().await);
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -617,30 +672,34 @@ fn multiple_conditions_in_clauses() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                        || __anodized_errors.push_str("\n    CONDITION_4") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("precondition failed: {}", "CONDITION_3") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                        || eprintln!("precondition failed: {}", "CONDITION_4") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                    || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                        || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
-                        || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
-                        || __anodized_errors.push_str("\n    CONDITION_6") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -667,17 +726,20 @@ fn postcond_closure_form() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = true;
-                if !__anodized_precond {
+                let __anodized_pre = true;
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -709,23 +771,26 @@ fn ensures_with_mixed_conditions() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = true;
-                if !__anodized_precond {
+                let __anodized_pre = true;
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                        || __anodized_errors.push_str("\n    CONDITION_4") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -757,23 +822,30 @@ fn cfg_attributes() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                #[cfg(SETTING_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                #[cfg(SETTING_2)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (!cfg!(SETTING_3)
-                        || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                #[cfg(SETTING_2)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                #[cfg(SETTING_3)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -804,30 +876,35 @@ fn cfg_on_single_and_list_conditions() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                #[cfg(SETTING_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("precondition failed: {}", "CONDITION_3") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (!cfg!(SETTING_2)
-                        || ::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                        || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (!cfg!(SETTING_2)
-                        || ::anodized::__::eval::<bool>(|| { CONDITION_5 })
-                        || __anodized_errors.push_str("\n    CONDITION_5") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+                #[cfg(SETTING_2)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+                #[cfg(SETTING_2)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -862,40 +939,48 @@ fn complex_mixed_conditions() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                        || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                        || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
-                        || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
-                        || __anodized_errors.push_str("\n    CONDITION_6") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+                #[cfg(SETTING_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+                #[cfg(SETTING_1)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("precondition failed: {}", "CONDITION_3") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                        || eprintln!("precondition failed: {}", "CONDITION_4") != ());
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                        || eprintln!("precondition failed: {}", "CONDITION_5") != ());
+                #[cfg(SETTING_2)]
+                let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                        || eprintln!("precondition failed: {}", "CONDITION_6") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_4 })
-                    || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
-                        || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
-                        || __anodized_errors.push_str("\n    CONDITION_6") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_7 })
-                        || __anodized_errors.push_str("\n    CONDITION_7") != ())
-                    & (!cfg!(SETTING_3)
-                        || ::anodized::__::eval::<bool>(|| { CONDITION_8 })
-                        || __anodized_errors.push_str("\n    CONDITION_8") != ())
-                    & (!cfg!(SETTING_3)
-                        || ::anodized::__::eval::<bool>(|| { CONDITION_9 })
-                        || __anodized_errors.push_str("\n    CONDITION_9") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
+                #[cfg(SETTING_2)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_7 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
+                #[cfg(SETTING_3)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_8 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
+                #[cfg(SETTING_3)]
+                let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_9 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }
@@ -930,20 +1015,24 @@ fn captures() {
         {
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
-                    || __anodized_errors.push_str("\n    CONDITION_1") != ());
-                if !__anodized_precond {
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
+                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+
+                if !__anodized_pre {
                     panic!("precondition failed:{__anodized_errors}");
                 }
             }
             let (ALIAS_1, ALIAS_2, __anodized_output) = ((|| EXPR_1) (), (|| EXPR_2) (), (|| #ret_type #body)());
             if true {
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
-                    || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
-                        || __anodized_errors.push_str("\n    CONDITION_3") != ());
-                if !__anodized_postcond {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
+                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+
+                if !__anodized_post {
                     panic!("postcondition failed:{__anodized_errors}");
                 }
             }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -90,7 +90,6 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                 #[cfg(META_1)]
@@ -109,7 +108,6 @@ fn default_instrument_item_fn() {
                 (|| -> RET_TYPE { BODY })(),
             );
             if false {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_4 });
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_5 });
@@ -158,7 +156,6 @@ fn emit_try_fn_instrument_item_fn() {
             -> ::anodized::result::Result<RET_TYPE>
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
                         || eprintln!("precondition failed: {}", "COND_1") != ());
@@ -176,7 +173,7 @@ fn emit_try_fn_instrument_item_fn() {
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { COND_6 })
                         || eprintln!("precondition failed: {}", "COND_6") != ());
                 if !__anodized_pre {
-                    return ::anodized::result::pre_err(__anodized_errors);
+                    return ::anodized::result::pre_err();
                 }
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
@@ -185,7 +182,6 @@ fn emit_try_fn_instrument_item_fn() {
                 (|| -> RET_TYPE { BODY })(),
             );
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_4 })
                         || eprintln!("postcondition failed: {}", "COND_4") != ());
@@ -203,7 +199,7 @@ fn emit_try_fn_instrument_item_fn() {
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
                         || eprintln!("postcondition failed: {}", "COND_9") != ());
                 if !__anodized_post {
-                    return ::anodized::result::post_err(__anodized_output, __anodized_errors);
+                    return ::anodized::result::post_err(__anodized_output);
                 }
             }
             Ok(__anodized_output)
@@ -240,20 +236,18 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -281,14 +275,12 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { CONDITION_1 });
                 if !__anodized_pre {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if false {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 if !__anodized_post {}
             }
@@ -310,21 +302,15 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    eprintln!("precondition failed:{__anodized_errors}");
-                }
+                if !__anodized_pre {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
-                if !__anodized_post {
-                    eprintln!("postcondition failed:{__anodized_errors}");
-                }
+                if !__anodized_post {}
             }
             __anodized_output
         }
@@ -348,22 +334,20 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -388,20 +372,18 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -427,24 +409,22 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -470,22 +450,20 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -511,24 +489,22 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -555,26 +531,24 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -601,26 +575,24 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((async || #ret_type #body)().await);
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -647,7 +619,6 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
@@ -658,12 +629,11 @@ fn multiple_conditions_in_clauses() {
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("precondition failed: {}", "CONDITION_4") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
@@ -674,7 +644,7 @@ fn multiple_conditions_in_clauses() {
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -699,20 +669,18 @@ fn postcond_closure_form() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -742,15 +710,13 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -761,7 +727,7 @@ fn ensures_with_mixed_conditions() {
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -791,7 +757,6 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 #[cfg(SETTING_1)]
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
@@ -800,12 +765,11 @@ fn cfg_attributes() {
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || eprintln!("precondition failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 #[cfg(SETTING_2)]
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_2 })
@@ -814,7 +778,7 @@ fn cfg_attributes() {
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -843,7 +807,6 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 #[cfg(SETTING_1)]
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_1 })
@@ -853,12 +816,11 @@ fn cfg_on_single_and_list_conditions() {
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("precondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -871,7 +833,7 @@ fn cfg_on_single_and_list_conditions() {
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -904,7 +866,6 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
@@ -922,12 +883,11 @@ fn complex_mixed_conditions() {
                 let __anodized_pre = __anodized_pre & ( ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || eprintln!("precondition failed: {}", "CONDITION_6") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                     || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
@@ -945,7 +905,7 @@ fn complex_mixed_conditions() {
                 let __anodized_post = __anodized_post & ( ::anodized::__::eval::<bool>(|| { CONDITION_9 })
                         || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output
@@ -978,24 +938,22 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
-                    panic!("precondition failed:{__anodized_errors}");
+                    panic!("precondition failed");
                 }
             }
             let (ALIAS_1, ALIAS_2, __anodized_output) = ((|| EXPR_1) (), (|| EXPR_2) (), (|| #ret_type #body)());
             if true {
-                let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
                 if !__anodized_post {
-                    panic!("postcondition failed:{__anodized_errors}");
+                    panic!("postcondition failed");
                 }
             }
             __anodized_output

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -90,14 +90,13 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
-                    & __anodized_eval_pre(|| -> bool { COND_2 })
-                    & __anodized_eval_pre(|| -> bool { COND_3 })
-                    & __anodized_eval_pre(|| -> bool { COND_4 })
-                    & __anodized_eval_pre(|| -> bool { COND_5 })
-                    & __anodized_eval_pre(|| -> bool { COND_6 });
+                let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
+                    & ::anodized::__::eval::<bool>(|| { COND_2 })
+                    & ::anodized::__::eval::<bool>(|| { COND_3 })
+                    & ::anodized::__::eval::<bool>(|| { COND_4 })
+                    & ::anodized::__::eval::<bool>(|| { COND_5 })
+                    & ::anodized::__::eval::<bool>(|| { COND_6 });
                 if !__anodized_precond {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
@@ -106,14 +105,13 @@ fn default_instrument_item_fn() {
                 (|| -> RET_TYPE { BODY })(),
             );
             if false {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = __anodized_eval_post(|| -> bool { COND_4 })
-                    & __anodized_eval_post(|| -> bool { COND_5 })
-                    & __anodized_eval_post(|| -> bool { COND_6 })
-                    & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_7 })
-                    & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_8 })
-                    & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_9 });
+                let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_4 })
+                    & ::anodized::__::eval::<bool>(|| { COND_5 })
+                    & ::anodized::__::eval::<bool>(|| { COND_6 })
+                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
+                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
+                    & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
                 if !__anodized_postcond {}
             }
             __anodized_output
@@ -152,19 +150,18 @@ fn emit_try_fn_instrument_item_fn() {
             -> ::anodized::result::Result<RET_TYPE>
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
                         || __anodized_errors.push_str("\n    COND_1") != ())
-                    & (!cfg!(META_1) || __anodized_eval_pre(|| -> bool { COND_2 })
+                    & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_2 })
                         || __anodized_errors.push_str("\n    COND_2") != ())
-                    & (!cfg!(META_1) || __anodized_eval_pre(|| -> bool { COND_3 })
+                    & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| { COND_3 })
                         || __anodized_errors.push_str("\n    COND_3") != ())
-                    & (__anodized_eval_pre(|| -> bool { COND_4 })
+                    & (::anodized::__::eval::<bool>(|| { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (__anodized_eval_pre(|| -> bool { COND_5 })
+                    & (::anodized::__::eval::<bool>(|| { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || __anodized_eval_pre(|| -> bool { COND_6 })
+                    & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ());
                 if !__anodized_precond {
                     return ::anodized::result::pre_err(__anodized_errors);
@@ -176,20 +173,19 @@ fn emit_try_fn_instrument_item_fn() {
                 (|| -> RET_TYPE { BODY })(),
             );
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { COND_4 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_4 })
                         || __anodized_errors.push_str("\n    COND_4") != ())
-                    & (__anodized_eval_post(|| -> bool { COND_5 })
+                    & (::anodized::__::eval::<bool>(|| { COND_5 })
                         || __anodized_errors.push_str("\n    COND_5") != ())
-                    & (!cfg!(META_2) || __anodized_eval_post(|| -> bool { COND_6 })
+                    & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| { COND_6 })
                         || __anodized_errors.push_str("\n    COND_6") != ())
-                    & (__anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_7 })
+                    & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 })
                         || __anodized_errors.push_str("\n    COND_7") != ())
                     & (!cfg!(META_3)
-                        || __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_8 })
+                        || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 })
                         || __anodized_errors.push_str("\n    COND_8") != ())
-                    & (!cfg!(META_3) || __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_9 })
+                    & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 })
                         || __anodized_errors.push_str("\n    COND_9") != ());
                 if !__anodized_postcond {
                     return ::anodized::result::post_err(__anodized_output, __anodized_errors);
@@ -229,9 +225,8 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -239,7 +234,6 @@ fn simple_requires() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -271,14 +265,12 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = __anodized_eval_pre(|| -> bool { CONDITION_1 });
+                let __anodized_precond = ::anodized::__::eval::<bool>(|| { CONDITION_1 });
                 if !__anodized_precond {}
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if false {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {}
@@ -301,9 +293,8 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     eprintln!("precondition failed:{__anodized_errors}");
@@ -311,7 +302,6 @@ fn requires_no_panic_runtime() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_postcond = true;
                 if !__anodized_postcond {
@@ -340,9 +330,8 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -350,9 +339,8 @@ fn simple_maintains() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -380,7 +368,6 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -389,9 +376,8 @@ fn simple_ensures() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -420,11 +406,10 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -432,9 +417,8 @@ fn simple_requires_and_maintains() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -463,9 +447,8 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -473,9 +456,8 @@ fn simple_requires_and_ensures() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -504,9 +486,8 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -514,11 +495,10 @@ fn simple_maintains_and_ensures() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -548,11 +528,10 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -560,11 +539,10 @@ fn simple_requires_maintains_and_ensures() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -594,11 +572,10 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -606,11 +583,10 @@ fn simple_async_requires_maintains_and_ensures() {
             }
             let (__anodized_output) = ((async || #ret_type #body)().await);
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -640,15 +616,14 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_4 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -656,15 +631,14 @@ fn multiple_conditions_in_clauses() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                     || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_4 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_5 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_6 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -692,7 +666,6 @@ fn postcond_closure_form() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -701,9 +674,8 @@ fn postcond_closure_form() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { let OUTPUT_PATTERN = __anodized_output; CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -736,7 +708,6 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
                 let __anodized_precond = true;
                 if !__anodized_precond {
@@ -745,15 +716,14 @@ fn ensures_with_mixed_conditions() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_1 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_4 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -786,11 +756,10 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -798,12 +767,11 @@ fn cfg_attributes() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (!cfg!(SETTING_2) || __anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(|| -> bool { CONDITION_3 })
+                        || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -835,13 +803,12 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -849,17 +816,16 @@ fn cfg_on_single_and_list_conditions() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
                     & (!cfg!(SETTING_2)
-                        || __anodized_eval_post(|| -> bool { CONDITION_4 })
+                        || ::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
                     & (!cfg!(SETTING_2)
-                        || __anodized_eval_post(|| -> bool { CONDITION_5 })
+                        || ::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -895,19 +861,18 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ())
-                    & (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_2 })
+                    & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_2 })
                         || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (!cfg!(SETTING_1) || __anodized_eval_pre(|| -> bool { CONDITION_3 })
+                    & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_4 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                         || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_pre(|| -> bool { CONDITION_5 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_pre(|| -> bool { CONDITION_6 })
+                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -915,21 +880,20 @@ fn complex_mixed_conditions() {
             }
             let (__anodized_output) = ((|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_4 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_4 })
                     || __anodized_errors.push_str("\n    CONDITION_4") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_5 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_5 })
                         || __anodized_errors.push_str("\n    CONDITION_5") != ())
-                    & (!cfg!(SETTING_2) || __anodized_eval_post(|| -> bool { CONDITION_6 })
+                    & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| { CONDITION_6 })
                         || __anodized_errors.push_str("\n    CONDITION_6") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_7 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_7 })
                         || __anodized_errors.push_str("\n    CONDITION_7") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(|| -> bool { CONDITION_8 })
+                        || ::anodized::__::eval::<bool>(|| { CONDITION_8 })
                         || __anodized_errors.push_str("\n    CONDITION_8") != ())
                     & (!cfg!(SETTING_3)
-                        || __anodized_eval_post(|| -> bool { CONDITION_9 })
+                        || ::anodized::__::eval::<bool>(|| { CONDITION_9 })
                         || __anodized_errors.push_str("\n    CONDITION_9") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");
@@ -965,9 +929,8 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_precond = (__anodized_eval_pre(|| -> bool { CONDITION_1 })
+                let __anodized_precond = (::anodized::__::eval::<bool>(|| { CONDITION_1 })
                     || __anodized_errors.push_str("\n    CONDITION_1") != ());
                 if !__anodized_precond {
                     panic!("precondition failed:{__anodized_errors}");
@@ -975,11 +938,10 @@ fn captures() {
             }
             let (ALIAS_1, ALIAS_2, __anodized_output) = ((|| EXPR_1) (), (|| EXPR_2) (), (|| #ret_type #body)());
             if true {
-                fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                 let mut __anodized_errors = ::std::string::String::new();
-                let __anodized_postcond = (__anodized_eval_post(|| -> bool { CONDITION_2 })
+                let __anodized_postcond = (::anodized::__::eval::<bool>(|| { CONDITION_2 })
                     || __anodized_errors.push_str("\n    CONDITION_2") != ())
-                    & (__anodized_eval_post(|| -> bool { CONDITION_3 })
+                    & (::anodized::__::eval::<bool>(|| { CONDITION_3 })
                         || __anodized_errors.push_str("\n    CONDITION_3") != ());
                 if !__anodized_postcond {
                     panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -77,16 +77,20 @@ fn default_instrument_item_impl() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
-                        & ::anodized::__::eval::<bool>(|| { COND_2 });
-                    if !__anodized_precond {}
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+
+                    if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
-                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                    if !__anodized_postcond {}
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+
+                    if !__anodized_post {}
                 }
                 __anodized_output
             }
@@ -137,22 +141,26 @@ fn emit_try_fn_instrument_item_impl() {
             {
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
-                            || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ());
-                    if !__anodized_precond {
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                            || eprintln!("precondition failed: {}", "COND_1") != ());
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("precondition failed: {}", "COND_2") != ());
+
+                    if !__anodized_pre {
                         return ::anodized::result::pre_err(__anodized_errors);
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
-                            || __anodized_errors.push_str("\n    COND_3") != ());
-                    if !__anodized_postcond {
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("postcondition failed: {}", "COND_2") != ());
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
+                            || eprintln!("postcondition failed: {}", "COND_3") != ());
+
+                    if !__anodized_post {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                     }
                 }

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -76,18 +76,16 @@ fn default_instrument_item_impl() {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
-                        & __anodized_eval_pre(|| -> bool { COND_2 });
+                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
+                        & ::anodized::__::eval::<bool>(|| { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = __anodized_eval_post(|| -> bool { COND_2 })
-                        & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 });
+                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
+                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -138,11 +136,10 @@ fn emit_try_fn_instrument_item_impl() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
+                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (__anodized_eval_pre(|| -> bool { COND_2 })
+                        & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         return ::anodized::result::pre_err(__anodized_errors);
@@ -150,11 +147,10 @@ fn emit_try_fn_instrument_item_impl() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (__anodized_eval_post(|| -> bool { COND_2 })
+                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (__anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 })
+                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || __anodized_errors.push_str("\n    COND_3") != ());
                     if !__anodized_postcond {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -80,7 +80,6 @@ fn default_instrument_item_impl() {
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
-
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
@@ -89,7 +88,6 @@ fn default_instrument_item_impl() {
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-
                     if !__anodized_post {}
                 }
                 __anodized_output
@@ -146,7 +144,6 @@ fn emit_try_fn_instrument_item_impl() {
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
-
                     if !__anodized_pre {
                         return ::anodized::result::pre_err(__anodized_errors);
                     }
@@ -159,7 +156,6 @@ fn emit_try_fn_instrument_item_impl() {
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
-
                     if !__anodized_post {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                     }

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -76,7 +76,6 @@ fn default_instrument_item_impl() {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
@@ -84,7 +83,6 @@ fn default_instrument_item_impl() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
@@ -138,26 +136,24 @@ fn emit_try_fn_instrument_item_impl() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
-                        return ::anodized::result::pre_err(__anodized_errors);
+                        return ::anodized::result::pre_err();
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
                     if !__anodized_post {
-                        return ::anodized::result::post_err(__anodized_output, __anodized_errors);
+                        return ::anodized::result::post_err(__anodized_output);
                     }
                 }
                 Ok(__anodized_output)

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -30,17 +30,17 @@ fn embed_spec_item_impl() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_1 })();
-                let __anodized_clause_2 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 let () = ();
-                let __anodized_clause_2 = (|PAT_1| -> bool { COND_3 })(__anodized_output);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 
@@ -122,11 +122,11 @@ fn emit_try_fn_instrument_item_impl() {
                 match Self::__anodized_fn_try_FUNC(input_0, input_1) {
                     ::anodized::result::Result::Ok(output) => output,
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Pre(errors)
-                    ) => panic!("precondition failed:{errors}"),
+                        ::anodized::result::Error::Pre
+                    ) => panic!("precondition failed"),
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Post(_, errors)
-                    ) => panic!("postcondition failed:{errors}"),
+                        ::anodized::result::Error::Post(_)
+                    ) => panic!("postcondition failed"),
                 }
             }
 

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -30,15 +30,15 @@ fn embed_spec_item_impl() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
@@ -77,14 +77,14 @@ fn default_instrument_item_impl() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_post {}
                 }
@@ -137,9 +137,9 @@ fn emit_try_fn_instrument_item_impl() {
             {
                 if true {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                             || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         return ::anodized::result::pre_err();
@@ -148,7 +148,7 @@ fn emit_try_fn_instrument_item_impl() {
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -21,8 +21,8 @@ fn embed_spec_expr_while() {
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { INVAR_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { INVAR_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| INVAR_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| INVAR_2);
                 __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = || {
@@ -56,8 +56,8 @@ fn embed_spec_expr_for() {
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { INVAR_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { INVAR_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| INVAR_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| INVAR_2);
                 __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = || {};

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -21,8 +21,8 @@ fn embed_spec_expr_while() {
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = (|| -> bool { INVAR_1 })();
-                let __anodized_clause_2 = (|| -> bool { INVAR_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { INVAR_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { INVAR_2 });
                 __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = || {
@@ -56,8 +56,8 @@ fn embed_spec_expr_for() {
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = (|| -> bool { INVAR_1 })();
-                let __anodized_clause_2 = (|| -> bool { INVAR_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { INVAR_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { INVAR_2 });
                 __anodized_clause_1 && __anodized_clause_2
             };
             let __anodized_loop_decreases = || {};

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -98,7 +98,6 @@ fn default_instrument_item_trait() {
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
-
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
@@ -107,7 +106,6 @@ fn default_instrument_item_trait() {
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-
                     if !__anodized_post {}
                 }
                 __anodized_output
@@ -177,7 +175,6 @@ fn emit_try_fn_instrument_item_trait() {
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
-
                     if !__anodized_pre {
                         return ::anodized::result::pre_err(__anodized_errors);
                     }
@@ -190,7 +187,6 @@ fn emit_try_fn_instrument_item_trait() {
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
-
                     if !__anodized_post {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                     }
@@ -296,7 +292,6 @@ fn default_instrument_item_impl_trait() {
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
-
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
@@ -305,7 +300,6 @@ fn default_instrument_item_impl_trait() {
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-
                     if !__anodized_post {}
                 }
                 __anodized_output
@@ -359,7 +353,6 @@ fn emit_try_fn_instrument_item_impl_trait() {
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
-
                     if !__anodized_pre {
                         panic!("precondition failed:{__anodized_errors}");
                     }
@@ -372,7 +365,6 @@ fn emit_try_fn_instrument_item_impl_trait() {
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
-
                     if !__anodized_post {
                         panic!("postcondition failed:{__anodized_errors}");
                     }

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -94,18 +94,16 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
-                        & __anodized_eval_pre(|| -> bool { COND_2 });
+                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
+                        & ::anodized::__::eval::<bool>(|| { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if false {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = __anodized_eval_post(|| -> bool { COND_2 })
-                        & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 });
+                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
+                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -169,11 +167,10 @@ fn emit_try_fn_instrument_item_trait() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
+                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (__anodized_eval_pre(|| -> bool { COND_2 })
+                        & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         return ::anodized::result::pre_err(__anodized_errors);
@@ -181,11 +178,10 @@ fn emit_try_fn_instrument_item_trait() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if true {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (__anodized_eval_post(|| -> bool { COND_2 })
+                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (__anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 })
+                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || __anodized_errors.push_str("\n    COND_3") != ());
                     if !__anodized_postcond {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);
@@ -288,18 +284,16 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = __anodized_eval_pre(|| -> bool { COND_1 })
-                        & __anodized_eval_pre(|| -> bool { COND_2 });
+                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
+                        & ::anodized::__::eval::<bool>(|| { COND_2 });
                     if !__anodized_precond {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = __anodized_eval_post(|| -> bool { COND_2 })
-                        & __anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 });
+                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
+                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_postcond {}
                 }
                 __anodized_output
@@ -347,11 +341,10 @@ fn emit_try_fn_instrument_item_impl_trait() {
                     );
                 };
                 if true {
-                    fn __anodized_eval_pre(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (__anodized_eval_pre(|| -> bool { COND_1 })
+                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
                             || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (__anodized_eval_pre(|| -> bool { COND_2 })
+                        & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ());
                     if !__anodized_precond {
                         panic!("precondition failed:{__anodized_errors}");
@@ -359,11 +352,10 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
-                    fn __anodized_eval_post(c: impl Fn() -> bool) -> bool { c() }
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (__anodized_eval_post(|| -> bool { COND_2 })
+                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
                             || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (__anodized_eval_post(|| -> bool { let PAT_1 = __anodized_output; COND_3 })
+                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || __anodized_errors.push_str("\n    COND_3") != ());
                     if !__anodized_postcond {
                         panic!("postcondition failed:{__anodized_errors}");

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -94,7 +94,6 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
@@ -102,7 +101,6 @@ fn default_instrument_item_trait() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
@@ -169,26 +167,24 @@ fn emit_try_fn_instrument_item_trait() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
-                        return ::anodized::result::pre_err(__anodized_errors);
+                        return ::anodized::result::pre_err();
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
                     if !__anodized_post {
-                        return ::anodized::result::post_err(__anodized_output, __anodized_errors);
+                        return ::anodized::result::post_err(__anodized_output);
                     }
                 }
                 Ok(__anodized_output)
@@ -288,7 +284,6 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
                     let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
@@ -296,7 +291,6 @@ fn default_instrument_item_impl_trait() {
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
@@ -347,26 +341,24 @@ fn emit_try_fn_instrument_item_impl_trait() {
                     );
                 };
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_pre = true;
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
                             || eprintln!("precondition failed: {}", "COND_1") != ());
                     let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
-                        panic!("precondition failed:{__anodized_errors}");
+                        panic!("precondition failed");
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
-                    let mut __anodized_errors = ::std::string::String::new();
                     let __anodized_post = true;
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
                     if !__anodized_post {
-                        panic!("postcondition failed:{__anodized_errors}");
+                        panic!("postcondition failed");
                     }
                 }
                 __anodized_output

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -95,16 +95,20 @@ fn default_instrument_item_trait() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
-                        & ::anodized::__::eval::<bool>(|| { COND_2 });
-                    if !__anodized_precond {}
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+
+                    if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
-                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                    if !__anodized_postcond {}
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+
+                    if !__anodized_post {}
                 }
                 __anodized_output
             }
@@ -168,22 +172,26 @@ fn emit_try_fn_instrument_item_trait() {
             {
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
-                            || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ());
-                    if !__anodized_precond {
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                            || eprintln!("precondition failed: {}", "COND_1") != ());
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("precondition failed: {}", "COND_2") != ());
+
+                    if !__anodized_pre {
                         return ::anodized::result::pre_err(__anodized_errors);
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
-                            || __anodized_errors.push_str("\n    COND_3") != ());
-                    if !__anodized_postcond {
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("postcondition failed: {}", "COND_2") != ());
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
+                            || eprintln!("postcondition failed: {}", "COND_3") != ());
+
+                    if !__anodized_post {
                         return ::anodized::result::post_err(__anodized_output, __anodized_errors);
                     }
                 }
@@ -285,16 +293,20 @@ fn default_instrument_item_impl_trait() {
                 };
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = ::anodized::__::eval::<bool>(|| { COND_1 })
-                        & ::anodized::__::eval::<bool>(|| { COND_2 });
-                    if !__anodized_precond {}
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+
+                    if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = ::anodized::__::eval::<bool>(|| { COND_2 })
-                        & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                    if !__anodized_postcond {}
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+
+                    if !__anodized_post {}
                 }
                 __anodized_output
             }
@@ -342,22 +354,26 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 };
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_precond = (::anodized::__::eval::<bool>(|| { COND_1 })
-                            || __anodized_errors.push_str("\n    COND_1") != ())
-                        & (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ());
-                    if !__anodized_precond {
+                    let __anodized_pre = true;
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                            || eprintln!("precondition failed: {}", "COND_1") != ());
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("precondition failed: {}", "COND_2") != ());
+
+                    if !__anodized_pre {
                         panic!("precondition failed:{__anodized_errors}");
                     }
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
                     let mut __anodized_errors = ::std::string::String::new();
-                    let __anodized_postcond = (::anodized::__::eval::<bool>(|| { COND_2 })
-                            || __anodized_errors.push_str("\n    COND_2") != ())
-                        & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
-                            || __anodized_errors.push_str("\n    COND_3") != ());
-                    if !__anodized_postcond {
+                    let __anodized_post = true;
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                            || eprintln!("postcondition failed: {}", "COND_2") != ());
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
+                            || eprintln!("postcondition failed: {}", "COND_3") != ());
+
+                    if !__anodized_post {
                         panic!("postcondition failed:{__anodized_errors}");
                     }
                 }

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -26,15 +26,15 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
@@ -95,14 +95,14 @@ fn default_instrument_item_trait() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if false {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_post {}
                 }
@@ -168,9 +168,9 @@ fn emit_try_fn_instrument_item_trait() {
             {
                 if true {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                             || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         return ::anodized::result::pre_err();
@@ -179,7 +179,7 @@ fn emit_try_fn_instrument_item_trait() {
                 let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if true {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());
@@ -220,15 +220,15 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
@@ -285,14 +285,14 @@ fn default_instrument_item_impl_trait() {
                 };
                 if false {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_1 });
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { COND_2 });
+                    let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                     let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                     if !__anodized_post {}
                 }
@@ -342,9 +342,9 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 };
                 if true {
                     let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_1 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                             || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("precondition failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         panic!("precondition failed");
@@ -353,7 +353,7 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if true {
                     let __anodized_post = true;
-                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { COND_2 })
+                    let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                             || eprintln!("postcondition failed: {}", "COND_2") != ());
                     let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 })
                             || eprintln!("postcondition failed: {}", "COND_3") != ());

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -26,17 +26,17 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_1 })();
-                let __anodized_clause_2 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 let () = ();
-                let __anodized_clause_2 = (|PAT_1| -> bool { COND_3 })(__anodized_output);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 
@@ -153,11 +153,11 @@ fn emit_try_fn_instrument_item_trait() {
                 match Self::__anodized_fn_try_FUNC(self, input_1, input_2) {
                     ::anodized::result::Result::Ok(output) => output,
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Pre(errors)
-                    ) => panic!("precondition failed:{errors}"),
+                        ::anodized::result::Error::Pre
+                    ) => panic!("precondition failed"),
                     ::anodized::result::Result::Err(
-                        ::anodized::result::Error::Post(_, errors)
-                    ) => panic!("postcondition failed:{errors}"),
+                        ::anodized::result::Error::Post(_)
+                    ) => panic!("postcondition failed"),
                 }
             }
 
@@ -220,17 +220,17 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_1 })();
-                let __anodized_clause_2 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_1 });
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = (|| -> bool { COND_2 })();
+                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| { COND_2 });
                 let () = ();
-                let __anodized_clause_2 = (|PAT_1| -> bool { COND_3 })(__anodized_output);
+                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_clause_1 && __anodized_clause_2
             }
 

--- a/crates/anodized/src/__.rs
+++ b/crates/anodized/src/__.rs
@@ -1,0 +1,5 @@
+//! Module for the internal use of `anodized_macros`.
+
+pub fn eval<T>(cond: impl Fn() -> T) -> T {
+    cond()
+}

--- a/crates/anodized/src/__.rs
+++ b/crates/anodized/src/__.rs
@@ -1,5 +1,6 @@
 //! Module for the internal use of `anodized_macros`.
 
-pub fn eval<T>(cond: impl Fn() -> T) -> T {
-    cond()
+/// Make the evaluated closure mutation-free by coercing it to `Fn`.
+pub fn eval<T>(closure: impl Fn() -> T) -> T {
+    closure()
 }

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -4,4 +4,5 @@ pub use anodized_logic as logic;
 pub use anodized_logic::arithmetic;
 pub use anodized_macros::spec;
 
+pub mod __;
 pub mod result;

--- a/crates/anodized/src/result.rs
+++ b/crates/anodized/src/result.rs
@@ -23,13 +23,13 @@ pub use anodized_macros::try_call;
 pub type Result<T> = std::result::Result<T, Error<T>>;
 
 /// Construct a precondition failure.
-pub fn pre_err<T>(messages: Messages) -> Result<T> {
-    Result::Err(Error::Pre(messages))
+pub fn pre_err<T>() -> Result<T> {
+    Result::Err(Error::Pre)
 }
 
 /// Construct a postcondition failure.
-pub fn post_err<T>(output: T, messages: Messages) -> Result<T> {
-    Result::Err(Error::Post(output, messages))
+pub fn post_err<T>(output: T) -> Result<T> {
+    Result::Err(Error::Post(output))
 }
 
 pub use Error::Post as PostError;
@@ -38,9 +38,9 @@ pub use Error::Pre as PreError;
 /// Error that represents a pre/postcondition failure.
 pub enum Error<T> {
     /// Preconditions failed.
-    Pre(Messages),
+    Pre,
     /// Postconditions failed.
-    Post(T, Messages),
+    Post(T),
 }
 
 pub type Messages = String;

--- a/crates/anodized/src/result.rs
+++ b/crates/anodized/src/result.rs
@@ -42,5 +42,3 @@ pub enum Error<T> {
     /// Postconditions failed.
     Post(T),
 }
-
-pub type Messages = String;

--- a/crates/anodized/tests/basic_enum.rs
+++ b/crates/anodized/tests/basic_enum.rs
@@ -32,8 +32,7 @@ fn job_start_success() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    matches! (self.state, State::Idle)")]
+#[should_panic(expected = "precondition failed")]
 fn job_start_panics_if_not_idle() {
     let mut job = Job {
         state: State::Running,

--- a/crates/anodized/tests/basic_function.rs
+++ b/crates/anodized/tests/basic_function.rs
@@ -16,8 +16,7 @@ fn divide_success() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    divisor != 0")]
+#[should_panic(expected = "precondition failed")]
 fn divide_by_zero_panics() {
     checked_divide(10, 0);
 }

--- a/crates/anodized/tests/basic_traits.rs
+++ b/crates/anodized/tests/basic_traits.rs
@@ -68,8 +68,7 @@ fn should_succeed() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    x > 0")]
+#[should_panic(expected = "precondition failed")]
 fn should_fail_add_to() {
     let test = TestStruct(3);
     assert_eq!(test.add_to(0), 3);
@@ -77,8 +76,7 @@ fn should_fail_add_to() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    output > old_val")]
+#[should_panic(expected = "postcondition failed")]
 fn should_fail_negative_mul_by() {
     let test = TestStruct(-3);
     assert_eq!(test.mul_by(1), 3);

--- a/crates/anodized/tests/compile_fail/closure_form_errors.stderr
+++ b/crates/anodized/tests/compile_fail/closure_form_errors.stderr
@@ -13,25 +13,14 @@ error: postcondition closure must have exactly one input
 error[E0308]: mismatched types
   --> tests/compile_fail/closure_form_errors.rs:21:23
    |
-19 | / #[spec(
-20 | |     // Should fail: postcondition closures must return `bool`.
-21 | |     ensures: |output| 42,
-   | |                       ^^ expected `bool`, found integer
-22 | | )]
-   | |__- expected `bool` because of return type
+21 |     ensures: |output| 42,
+   |                       ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
   --> tests/compile_fail/closure_form_errors.rs:31:9
    |
-27 | / #[spec(
-28 | |     // Should fail: cannot nest postcondition closures.
-29 | |     ensures: |output| [
-30 | |         output >= 42,
-31 | |         |answer| answer <= 42,
-   | |         ^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found closure
-32 | |     ],
-33 | | )]
-   | |__- expected `bool` because of return type
+31 |         |answer| answer <= 42,
+   |         ^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found closure
    |
    = note: expected type `bool`
            found closure `{closure@$DIR/tests/compile_fail/closure_form_errors.rs:31:9: 31:17}`

--- a/crates/anodized/tests/default_output_pattern.rs
+++ b/crates/anodized/tests/default_output_pattern.rs
@@ -14,8 +14,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    a <= b")]
+#[should_panic(expected = "postcondition failed")]
 fn sort_fail_postcondition() {
     sort_pair((5, 2));
 }

--- a/crates/anodized/tests/explicit_binding_in_postcondition.rs
+++ b/crates/anodized/tests/explicit_binding_in_postcondition.rs
@@ -15,8 +15,7 @@ fn sort_pair(pair: (i32, i32)) -> (i32, i32) {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    a <= b")]
+#[should_panic(expected = "postcondition failed")]
 fn sort_fail_postcondition() {
     sort_pair((2, 5));
 }

--- a/crates/anodized/tests/method_call_invariant.rs
+++ b/crates/anodized/tests/method_call_invariant.rs
@@ -23,8 +23,7 @@ impl Validator {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    self.is_valid()")]
+#[should_panic(expected = "postcondition failed")]
 fn violates_post_invariant() {
     let mut v = Validator { valid: true };
     // This will violate the invariant on exit.
@@ -33,8 +32,7 @@ fn violates_post_invariant() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    self.is_valid()")]
+#[should_panic(expected = "precondition failed")]
 fn violates_pre_invariant() {
     let mut v = Validator { valid: false };
     // This violates the invariant on entry.

--- a/crates/anodized/tests/method_with_invariant.rs
+++ b/crates/anodized/tests/method_with_invariant.rs
@@ -27,8 +27,7 @@ fn increment_success() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    self.count <= self.capacity")]
+#[should_panic(expected = "postcondition failed")]
 fn increment_violates_invariant() {
     let mut c = Counter {
         count: 10,
@@ -40,8 +39,7 @@ fn increment_violates_invariant() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    self.count <= self.capacity")]
+#[should_panic(expected = "precondition failed")]
 fn increment_violates_pre_invariant() {
     let mut c = Counter {
         count: 11,

--- a/crates/anodized/tests/multiple_conditions.rs
+++ b/crates/anodized/tests/multiple_conditions.rs
@@ -34,8 +34,7 @@ fn get_element_success() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    ! self.locked")]
+#[should_panic(expected = "precondition failed")]
 fn get_element_panics_when_locked() {
     let buffer = SafeBuffer {
         items: vec![10, 20, 30],
@@ -47,8 +46,7 @@ fn get_element_panics_when_locked() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    index < self.items.len()")]
+#[should_panic(expected = "precondition failed")]
 fn get_element_panics_on_out_of_bounds() {
     let buffer = SafeBuffer {
         items: vec![10, 20, 30],

--- a/crates/anodized/tests/rename_return_value.rs
+++ b/crates/anodized/tests/rename_return_value.rs
@@ -34,8 +34,7 @@ fn calculate_odd_result(output: i32) -> i32 {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    result % 2 == 0")]
+#[should_panic(expected = "postcondition failed")]
 fn rename_panics_if_not_even() {
     // Returns 5, violating the postcondition.
     calculate_odd_result(4);

--- a/crates/anodized/tests/trait_narrowing.rs
+++ b/crates/anodized/tests/trait_narrowing.rs
@@ -97,8 +97,7 @@ fn runtime_allows_valid_narrowing() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "precondition failed:\
-\n    input.is_sorted()")]
+#[should_panic(expected = "precondition failed")]
 fn runtime_rejects_stronger_impl_precondition() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
     let seq = [5, -42, 3];
@@ -107,8 +106,7 @@ fn runtime_rejects_stronger_impl_precondition() {
 
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
-#[should_panic(expected = "postcondition failed:\
-\n    input.iter().any(| item | output == item) || input.is_empty()")]
+#[should_panic(expected = "postcondition failed")]
 fn runtime_rejects_weaker_impl_postcondition() {
     // NOTE: The trait's runtime checks are active even when the concrete type is statically known.
     let seq = [5, 42, 3];

--- a/examples/bin-search/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/examples/bin-search/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -17,9 +17,7 @@ fuzz_target!(|inputs: Inputs<i32>| -> Corpus {
         Err(PreError) => Corpus::Reject,
         // When postconditions are violated, panic to signal a counter-example.
         Err(PostError(output)) => {
-            eprintln!("inputs:");
-            dbg!(inputs.seq);
-            dbg!(inputs.value);
+            dbg!(inputs);
             dbg!(output);
             panic!("postcondition failed");
         }

--- a/examples/bin-search/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/examples/bin-search/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -14,14 +14,14 @@ fuzz_target!(|inputs: Inputs<i32>| -> Corpus {
         // Successful call.
         Ok(_) => Corpus::Keep,
         // When preconditions are violated, reject the input.
-        Err(PreError(_)) => Corpus::Reject,
+        Err(PreError) => Corpus::Reject,
         // When postconditions are violated, panic to signal a counter-example.
-        Err(PostError(output, errors)) => {
+        Err(PostError(output)) => {
             eprintln!("inputs:");
             dbg!(inputs.seq);
             dbg!(inputs.value);
             dbg!(output);
-            panic!("postcondition failed:{errors}");
+            panic!("postcondition failed");
         }
     }
 });

--- a/examples/bin-search/tests/proptest.rs
+++ b/examples/bin-search/tests/proptest.rs
@@ -1,4 +1,4 @@
-use anodized::result::{PostError, PreError, try_call};
+use anodized::result::{try_call, PostError, PreError};
 
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -17,14 +17,14 @@ proptest! {
             // Successful call.
             Ok(_) => {},
             // When preconditions are violated, reject the input.
-            Err(PreError(_)) => prop_assume!(false),
+            Err(PreError) => prop_assume!(false),
             // When postconditions are violated, panic to signal a counter-example.
-            Err(PostError(output, errors)) => {
+            Err(PostError(output)) => {
                 eprintln!("inputs:");
                 dbg!(inputs.seq);
                 dbg!(inputs.value);
                 dbg!(output);
-                panic!("postcondition failed:{errors}");
+                panic!("postcondition failed");
             }
         }
     }

--- a/examples/bin-search/tests/proptest.rs
+++ b/examples/bin-search/tests/proptest.rs
@@ -1,4 +1,4 @@
-use anodized::result::{try_call, PostError, PreError};
+use anodized::result::{PostError, PreError, try_call};
 
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;

--- a/examples/bin-search/tests/proptest.rs
+++ b/examples/bin-search/tests/proptest.rs
@@ -1,4 +1,4 @@
-use anodized::result::{PostError, PreError, try_call};
+use anodized::result::{try_call, PostError, PreError};
 
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -20,9 +20,7 @@ proptest! {
             Err(PreError) => prop_assume!(false),
             // When postconditions are violated, panic to signal a counter-example.
             Err(PostError(output)) => {
-                eprintln!("inputs:");
-                dbg!(inputs.seq);
-                dbg!(inputs.value);
+                dbg!(inputs);
                 dbg!(output);
                 panic!("postcondition failed");
             }

--- a/examples/bin-search/tests/quickcheck.rs
+++ b/examples/bin-search/tests/quickcheck.rs
@@ -1,4 +1,4 @@
-use anodized::result::{PostError, PreError, try_call};
+use anodized::result::{try_call, PostError, PreError};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 
@@ -22,9 +22,7 @@ fn test_spec_property(inputs: Inputs<i32>) -> TestResult {
         Err(PreError) => TestResult::discard(),
         // When postconditions are violated, fail to signal a counter-example.
         Err(PostError(output)) => {
-            eprintln!("inputs:");
-            dbg!(inputs.seq);
-            dbg!(inputs.value);
+            dbg!(inputs);
             dbg!(output);
             TestResult::error("postcondition failed")
         }

--- a/examples/bin-search/tests/quickcheck.rs
+++ b/examples/bin-search/tests/quickcheck.rs
@@ -1,4 +1,4 @@
-use anodized::result::{try_call, PostError, PreError};
+use anodized::result::{PostError, PreError, try_call};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 

--- a/examples/bin-search/tests/quickcheck.rs
+++ b/examples/bin-search/tests/quickcheck.rs
@@ -1,4 +1,4 @@
-use anodized::result::{PostError, PreError, try_call};
+use anodized::result::{try_call, PostError, PreError};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 
@@ -19,14 +19,14 @@ fn test_spec_property(inputs: Inputs<i32>) -> TestResult {
         // Successful call.
         Ok(_) => TestResult::passed(),
         // When preconditions are violated, reject the input.
-        Err(PreError(_)) => TestResult::discard(),
+        Err(PreError) => TestResult::discard(),
         // When postconditions are violated, fail to signal a counter-example.
-        Err(PostError(output, errors)) => {
+        Err(PostError(output)) => {
             eprintln!("inputs:");
             dbg!(inputs.seq);
             dbg!(inputs.value);
             dbg!(output);
-            TestResult::error(format!("postcondition failed:{errors}"))
+            TestResult::error("postcondition failed")
         }
     }
 }


### PR DESCRIPTION
- Refactor `fn` instrumentation to rely on `anodized::__::eval()`.
- Print messages directly instead of collecting into `String`.
- Remove `Messages` payload from the `Result` of a `try_call!`.
- Update tests and examples.