### PR TITLE
[anodized-core] feat: guarantee that captures are mutation-free

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
 
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -161,11 +161,9 @@ impl Mode {
 
         {
             let patterns = captures.iter().map(|capture| &capture.pat);
-            let values = captures.iter().map(|capture| -> Expr {
-                let expr = &capture.expr;
-                // Wrap in closure to guard against `return`.
-                parse_quote! { (|| #expr)() }
-            });
+            let values = captures
+                .iter()
+                .map(|capture| build_capture_eval(&capture.expr));
             statements.push(parse_quote! { let (#(#patterns),*) = (#(#values),*); });
         }
 
@@ -227,19 +225,15 @@ impl CheckSettings {
             .map(|cb| &cb.pat)
             .chain(std::iter::once(&output_ident));
 
-        let body_expr = if is_async {
-            quote! { (async || #return_type #original_body)().await }
+        let body_expr: Expr = if is_async {
+            parse_quote! { (async || #return_type #original_body)().await }
         } else {
-            quote! { (|| #return_type #original_body)() }
+            parse_quote! { (|| #return_type #original_body)() }
         };
         let values = spec
             .captures
             .iter()
-            .map(|cb| {
-                let expr = &cb.expr;
-                // Evaluate expression in a closure to prevent early return.
-                quote! { (|| #expr)() }
-            })
+            .map(|cb| build_capture_eval(&cb.expr))
             .chain(std::iter::once(body_expr));
 
         let captures_and_output = quote! {
@@ -343,6 +337,10 @@ impl CheckSettings {
 
 fn build_cond_eval(expr: &Expr) -> Expr {
     parse_quote! { ::anodized::__::eval::<bool>(|| #expr) }
+}
+
+fn build_capture_eval(expr: &Expr) -> Expr {
+    parse_quote! { ::anodized::__::eval(|| #expr) }
 }
 
 pub(crate) fn make_try_fn_ident(ident: &Ident) -> Ident {

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -59,7 +59,10 @@ fn embed_spec_item_fn() {
             let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_4);
             let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_5);
             let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| COND_6);
-            let (ALIAS_1, (ALIAS_2, ALIAS_3)) = ((|| EXPR_1)(), (|| EXPR_2)());
+            let (ALIAS_1, (ALIAS_2, ALIAS_3)) = (
+                ::anodized::__::eval(|| EXPR_1),
+                ::anodized::__::eval(|| EXPR_2),
+            );
             let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
             let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
             let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
@@ -100,8 +103,8 @@ fn default_instrument_item_fn() {
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
-                (|| EXPR_1)(),
-                (|| EXPR_2)(),
+                ::anodized::__::eval(|| EXPR_1),
+                ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
             if false {
@@ -168,8 +171,8 @@ fn emit_try_fn_instrument_item_fn() {
                 }
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
-                (|| EXPR_1)(),
-                (|| EXPR_2)(),
+                ::anodized::__::eval(|| EXPR_1),
+                ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
             if true {
@@ -920,7 +923,11 @@ fn captures() {
                     panic!("precondition failed");
                 }
             }
-            let (ALIAS_1, ALIAS_2, __anodized_output) = ((|| EXPR_1) (), (|| EXPR_2) (), (|| #ret_type #body)());
+            let (ALIAS_1, ALIAS_2, __anodized_output) = (
+                ::anodized::__::eval(|| EXPR_1),
+                ::anodized::__::eval(|| EXPR_2),
+                (|| #ret_type #body)(),
+            );
             if true {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)

--- a/crates/anodized/tests/compile_fail/captures_mutation.rs
+++ b/crates/anodized/tests/compile_fail/captures_mutation.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use anodized::spec;
+
+// This test verifies that capture expressions are mutation-free.
+
+#[spec(
+    captures: first = input.pop(),
+    ensures: |output| output == first,
+)]
+fn head(input: &mut Vec<i32>) -> Option<i32> {
+    todo!()
+}

--- a/crates/anodized/tests/compile_fail/captures_mutation.stderr
+++ b/crates/anodized/tests/compile_fail/captures_mutation.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow value as mutable, as it is a captured variable in a `Fn` closure
+  --> tests/compile_fail/captures_mutation.rs:8:23
+   |
+ 7 | / #[spec(
+ 8 | |     captures: first = input.pop(),
+   | |                       ^^^^^ cannot borrow as mutable
+ 9 | |     ensures: |output| output == first,
+10 | | )]
+   | |__- in this closure
+11 |   fn head(input: &mut Vec<i32>) -> Option<i32> {
+   |           ----- `*input` declared here, outside the closure

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
- Apply the same technique to evaluating capture expressions as to conditions.
- Add a new test to confirm expected behavior.
- Update unit tests in `anodized-core`.
- Pin the Rust toolchain for reproducibility.