### PR TITLE
[anodized-core] fix: honor a condition's `cfg` without printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **[anodized-core] `#[cfg]` on a condition is honored in every check mode** - The guard was
+  emitted only alongside the printing path, so a condition gated off by its `#[cfg]` was still
+  checked under `--cfg anodized_panic` without `--cfg anodized_print`.
+
 ## 0.6.0 (2026 Aug 08)
 
 ### Breaking Changes

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -315,20 +315,21 @@ impl CheckSettings {
     }
 
     fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        // The guard belongs to the condition, not to reporting: without it here, a
-        // `#[cfg]`-gated condition would still be checked whenever printing is disabled.
         let cfg_guard = match cfg {
             Some(meta) => quote! { !cfg!(#meta) || },
             None => quote!(),
         };
-        if self.does_print {
-            parse_quote! {
-                ( #cfg_guard #expr || eprintln!(#msg, #repr) != () )
-            }
-        } else if cfg.is_some() {
-            parse_quote! { ( #cfg_guard #expr ) }
+        let report_expr = if self.does_print {
+            quote! { || eprintln!(#msg, #repr) != () }
         } else {
+            quote!()
+        };
+        if cfg_guard.is_empty() && report_expr.is_empty() {
             expr.clone()
+        } else {
+            parse_quote! {
+                ( #cfg_guard #expr #report_expr )
+            }
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -315,14 +315,18 @@ impl CheckSettings {
     }
 
     fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
+        // The guard belongs to the condition, not to reporting: without it here, a
+        // `#[cfg]`-gated condition would still be checked whenever printing is disabled.
+        let cfg_guard = match cfg {
+            Some(meta) => quote! { !cfg!(#meta) || },
+            None => quote!(),
+        };
         if self.does_print {
-            let cfg_guard = match cfg {
-                Some(meta) => quote! { !cfg!(#meta) || },
-                None => quote!(),
-            };
             parse_quote! {
                 ( #cfg_guard #expr || eprintln!(#msg, #repr) != () )
             }
+        } else if cfg.is_some() {
+            parse_quote! { ( #cfg_guard #expr ) }
         } else {
             expr.clone()
         }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -95,11 +95,11 @@ fn default_instrument_item_fn() {
             if false {
                 let __anodized_pre = true;
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_3);
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2));
+                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3));
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_4);
                 let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_5);
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_6);
+                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
@@ -111,10 +111,10 @@ fn default_instrument_item_fn() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_4);
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_5);
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_6);
+                let __anodized_post = __anodized_post & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
+                let __anodized_post = __anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 }));
+                let __anodized_post = __anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 }));
                 if !__anodized_post {}
             }
             __anodized_output

--- a/crates/anodized/tests/condition_cfg.rs
+++ b/crates/anodized/tests/condition_cfg.rs
@@ -1,0 +1,60 @@
+//! A `#[cfg]` on a condition must gate the check in every build configuration.
+//!
+//! These tests are gated on `anodized_panic` alone, not on `all(anodized_print,
+//! anodized_panic)` as the other panic tests are. That difference is the point: the guard was
+//! once emitted only alongside printing, so a gated-off condition was still checked whenever
+//! printing was disabled, and no test that required both flags could see it.
+
+use anodized::spec;
+
+#[spec(
+    #[cfg(any())]
+    requires: false,
+)]
+fn gated_off_precondition(value: i32) -> i32 {
+    value
+}
+
+#[spec(
+    #[cfg(all())]
+    requires: false,
+)]
+fn gated_on_precondition(value: i32) -> i32 {
+    value
+}
+
+#[spec(
+    #[cfg(any())]
+    ensures: |output| output == value + 1,
+)]
+fn gated_off_postcondition(value: i32) -> i32 {
+    value
+}
+
+#[spec(
+    #[cfg(all())]
+    ensures: |output| output == value + 1,
+)]
+fn gated_on_postcondition(value: i32) -> i32 {
+    value
+}
+
+#[test]
+fn gated_off_conditions_are_never_checked() {
+    assert_eq!(gated_off_precondition(1), 1);
+    assert_eq!(gated_off_postcondition(2), 2);
+}
+
+#[cfg(anodized_panic)]
+#[test]
+#[should_panic(expected = "precondition failed")]
+fn gated_on_precondition_is_checked() {
+    gated_on_precondition(1);
+}
+
+#[cfg(anodized_panic)]
+#[test]
+#[should_panic(expected = "postcondition failed")]
+fn gated_on_postcondition_is_checked() {
+    gated_on_postcondition(1);
+}


### PR DESCRIPTION
- Build the `cfg` guard outside the `does_print` branch, so a condition gated off by its own `#[cfg]` is no longer checked under `--cfg anodized_panic` alone.
- Add a test gated on `anodized_panic` alone, which is the configuration where the bug was reachable. The existing panic tests all require `all(anodized_print, anodized_panic)`, so none of them could see it.
- Update the unit test for the default build configuration, where gated conditions now carry their guard too.
