### PR TITLE
[anodized-core] refactor: regularize `fn` instrumentation

### DIFF
--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -83,7 +83,7 @@ Given an original function like this:
     requires: <PRECONDITION>,
     maintains: <INVARIANT>,
     captures: <ALIAS> = <CAPTURE_EXPR>,
-    ensures: |<PATTERN>| <POSTCONDITION>,
+    ensures: |<OUTPUT_BINDING>| <POSTCONDITION>,
 )]
 fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
     <BODY>
@@ -94,37 +94,56 @@ The macro rewrites the body to be conceptually equivalent to the following:
 
 ```rust,ignore
 fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
-    // 1. Preconditions and invariants are checked
-    check!((|| <PRECONDITION>)(), "precondition failed: <PRECONDITION>");
-    check!((|| <INVARIANT>)(), "pre-invariant failed: <INVARIANT>");
+    // 1. Preconditions and invariants are checked.
+    let __anodized_pre = true;
+    let __anodized_pre = __anodized_pre & check_condition!(
+        <PRECONDITION>,
+        "precondition failed: <PRECONDITION>",
+    );
+    let __anodized_pre = __anodized_pre & check_condition!(
+        <INVARIANT>,
+        "preinvariant failed: <INVARIANT>",
+    );
+    if !__anodized_pre {
+        handle_failure!();
+    }
 
-    // 2. Values are captured and the original function body is executed
-    // Note 1: captures and body execution happen in a single tuple assignment
-    //         to ensure captured values aren't accessible to the function body
-    // Note 2: the body is evaluated in a closure, so returns inside the body
-    //         do not bypass postcondition checks
+    // 2. Values are captured and the original function body is executed.
+    // Note 1: Captures and body execution happen in a single tuple assignment
+    //         to ensure captured values aren't accessible to the function body.
+    // Note 2: The body is evaluated in a closure, so returns inside the body
+    //         do not bypass postcondition checks.
     let (<ALIAS>, __anodized_output): (_, <RETURN_TYPE>) = (
         <CAPTURE_EXPR>,
         (|| { <BODY> })(),
     );
 
-    // 3. Invariants and postconditions are checked
-    // Note 1: Captured values are in scope for postconditions
+    // 3. Invariants and postconditions are checked.
+    // Note 1: Captured values are in scope for postconditions.
     // Note 2: `__anodized_output` is also in scope for postconditions,
-    //         but referring to it is strongly discouraged
-    check!((|| <INVARIANT>)(), "post-invariant failed: <INVARIANT>");
-    // Each postcondition runs against `__anodized_output` through its output pattern.
-    // Borrowing patterns borrow it; move patterns reconstruct it after the check.
-    check_postcondition!(
-        <PATTERN>,
-        __anodized_output,
-        <POSTCONDITION>,
-        "postcondition failed: | <PATTERN> | <POSTCONDITION>",
+    //         but referring to it is strongly discouraged.
+    let __anodized_post = true;
+    let __anodized_post = __anodized_post & check_condition!(
+        <INVARIANT>,
+        "postinvariant failed: <INVARIANT>",
     );
+    // Each postcondition is evaluated with its output bindings in scope.
+    // Note 1: Details of pattern handling are omitted for brevity.
+    let __anodized_post = __anodized_post & check_condition!(
+        { let <OUTPUT_BINDING> = __anodized_output; <POSTCONDITION> },
+        "postcondition failed: | <OUTPUT_BINDING> | <POSTCONDITION>",
+    );
+    if !__anodized_post {
+        handle_failure!();
+    }
+
+    // `check_condition!` represents the generated condition expression. Depending on
+    // enabled settings, it evaluates the condition, prints a diagnostic, or short-circuits
+    // to `true` when no runtime action is enabled.
 
     // 4. The result is returned
     __anodized_output
 }
 ```
 
-When a condition has a `#[cfg(...)]` attribute, the corresponding `check!` is wrapped in an `if cfg!(...)` block. This follows standard Rust `#[cfg]` semantics: the check only runs when the configuration predicate is true. Details of the injected code are determined by `cfg` settings.
+When a condition has a `#[cfg(...)]` attribute, its individual generated condition is guarded with `!cfg!(...) || ...`. This follows standard Rust `#[cfg]` semantics: the condition is evaluated only when the configuration predicate is true. The condition remains type-checked in every build configuration, and details of diagnostics and failure handling are determined by the enabled `anodized_*` settings.

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -146,4 +146,8 @@ fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
 }
 ```
 
-When a condition has a `#[cfg(...)]` attribute, its individual generated condition is guarded with `!cfg!(...) || ...`. This follows standard Rust `#[cfg]` semantics: the condition is evaluated only when the configuration predicate is true. The condition remains type-checked in every build configuration, and details of diagnostics and failure handling are determined by the enabled `anodized_*` settings.
+When a condition has a `#[cfg(...)]` attribute, its generated evaluator is individually guarded
+with `!cfg!(...) || ...`. This follows standard Rust `#[cfg]` semantics: the condition is evaluated
+only when the configuration predicate is true, but the condition remains type-checked in every build
+configuration, with details of diagnostics and failure handling determined by the `anodized_*`
+settings.

--- a/crates/anodized-core/README.md
+++ b/crates/anodized-core/README.md
@@ -103,7 +103,7 @@ fn my_function(<FUNCTION_INPUTS>) -> <RETURN_TYPE> {
     //         to ensure captured values aren't accessible to the function body
     // Note 2: the body is evaluated in a closure, so returns inside the body
     //         do not bypass postcondition checks
-    let (<ALIAS>, mut __anodized_output): (_, <RETURN_TYPE>) = (
+    let (<ALIAS>, __anodized_output): (_, <RETURN_TYPE>) = (
         <CAPTURE_EXPR>,
         (|| { <BODY> })(),
     );

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -208,7 +208,6 @@ impl CheckSettings {
     ) -> Result<Block> {
         // The identifier for the return value binding.
         let output_ident: Pat = parse_quote!(__anodized_output);
-        let output_binder: Pat = parse_quote! { mut #output_ident };
 
         // Generate precondition checks.
         let mut precond_checks: Vec<Stmt> = vec![parse_quote! {
@@ -237,7 +236,7 @@ impl CheckSettings {
             .captures
             .iter()
             .map(|cb| &cb.pat)
-            .chain(std::iter::once(&output_binder));
+            .chain(std::iter::once(&output_ident));
 
         let body_expr: Expr = if is_async {
             parse_quote! { (async || #return_type #original_body)().await }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -257,7 +257,7 @@ impl CheckSettings {
         let mut id_gen = IdentGenerator::new();
         // Generate postcondition checks.
         let mut postcond_checks: Vec<Stmt> = vec![parse_quote! {
-            let mut __anodized_post = true;
+            let __anodized_post = true;
         }];
         for postinvariant in &spec.maintains {
             let check = self.build_postcond_check(
@@ -340,25 +340,24 @@ impl CheckSettings {
                 });
                 let check = self.build_cond_check(msg, cfg, &eval, &repr);
                 parse_quote! {
-                    __anodized_post &= #check;
+                    let __anodized_post = __anodized_post & #check;
                 }
             }
             Some(TamePat::Invertible(inv_pat)) => {
                 let eval = build_cond_eval(expr);
                 let check = self.build_cond_check(msg, cfg, &eval, &repr);
                 parse_quote! {
-                    {
+                    let (__anodized_post, __anodized_output) = {
                         let #inv_pat = __anodized_output;
-                        __anodized_post &= #check;
-                        __anodized_output = #inv_pat;
-                    }
+                        (__anodized_post & #check, #inv_pat)
+                    };
                 }
             }
             None => {
                 let eval = build_cond_eval(expr);
                 let check = self.build_cond_check(msg, cfg, &eval, &repr);
                 parse_quote! {
-                    __anodized_post &= #check;
+                    let __anodized_post = __anodized_post & #check;
                 }
             }
         }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -212,7 +212,7 @@ impl CheckSettings {
 
         // Generate precondition checks.
         let mut precond_checks: Vec<Stmt> = vec![parse_quote! {
-            let mut __anodized_pre = true;
+            let __anodized_pre = true;
         }];
         for precondition in &spec.requires {
             let check = self.build_precond_check(
@@ -321,7 +321,7 @@ impl CheckSettings {
         let eval = build_cond_eval(expr);
         let check = self.build_cond_check(msg, cfg, &eval, &repr);
         parse_quote! {
-            __anodized_pre &= #check;
+            let __anodized_pre = __anodized_pre & #check;
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -212,7 +212,7 @@ impl CheckSettings {
 
         // Generate precondition checks.
         let mut precond_checks: Vec<Stmt> = vec![parse_quote! {
-            let __anodized_pre = true;
+            let mut __anodized_pre = true;
         }];
         for precondition in &spec.requires {
             let check = self.build_precond_check(
@@ -221,7 +221,7 @@ impl CheckSettings {
                 &precondition.expr,
             );
             precond_checks.push(parse_quote! {
-                let __anodized_pre = __anodized_pre & #check;
+                __anodized_pre &= #check;
             });
         }
         for preinvariant in &spec.maintains {
@@ -231,7 +231,7 @@ impl CheckSettings {
                 &preinvariant.expr,
             );
             precond_checks.push(parse_quote! {
-                let __anodized_pre = __anodized_pre & #check;
+                __anodized_pre &= #check;
             });
         }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -283,8 +283,6 @@ impl CheckSettings {
             postcond_checks.push(check);
         }
 
-        let do_run_checks = self.does_print || self.does_panic.is_some();
-
         let (output_expr, precond_fail_action, postcond_fail_action) =
             if let Some(ref panic_settings) = self.does_panic
                 && panic_settings.has_try_fn
@@ -304,18 +302,14 @@ impl CheckSettings {
 
         Ok(parse_quote! {
             {
-                if #do_run_checks {
-                    #(#precond_checks)*
-                    if !__anodized_pre {
-                        #precond_fail_action
-                    }
+                #(#precond_checks)*
+                if !__anodized_pre {
+                    #precond_fail_action
                 }
                 #captures_and_output
-                if #do_run_checks {
-                    #(#postcond_checks)*
-                    if !__anodized_post {
-                        #postcond_fail_action
-                    }
+                #(#postcond_checks)*
+                if !__anodized_post {
+                    #postcond_fail_action
                 }
                 #output_expr
             }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -220,9 +220,7 @@ impl CheckSettings {
                 &precondition.cfg,
                 &precondition.expr,
             );
-            precond_checks.push(parse_quote! {
-                __anodized_pre &= #check;
-            });
+            precond_checks.push(check);
         }
         for preinvariant in &spec.maintains {
             let check = self.build_precond_check(
@@ -230,9 +228,7 @@ impl CheckSettings {
                 &preinvariant.cfg,
                 &preinvariant.expr,
             );
-            precond_checks.push(parse_quote! {
-                __anodized_pre &= #check;
-            });
+            precond_checks.push(check);
         }
 
         // Bind capture values and function output in a single tuple assignment.
@@ -326,10 +322,13 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr) -> Expr {
+    fn build_precond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr) -> Stmt {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        self.build_cond_check(msg, cfg, &eval, &repr)
+        let check = self.build_cond_check(msg, cfg, &eval, &repr);
+        parse_quote! {
+            __anodized_pre &= #check;
+        }
     }
 
     fn build_postcond_check(

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -370,22 +370,29 @@ impl CheckSettings {
         }
     }
 
-    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr, repr: &str) -> Expr {
-        let cfg_guard = match cfg {
-            Some(meta) => quote! { !cfg!(#meta) || },
-            None => quote!(),
-        };
-        let report_expr = if self.does_print {
-            quote! { || eprintln!(#msg, #repr) != () }
+    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
+        let guard: Option<Expr> = if self.does_print || self.does_panic.is_some() {
+            cfg.as_ref().map(|meta| parse_quote! { !cfg!(#meta) })
         } else {
-            quote!()
+            Some(parse_quote! { true })
         };
-        if cfg_guard.is_empty() && report_expr.is_empty() {
+
+        let printer: Option<Expr> = if self.does_print {
+            Some(parse_quote! { eprintln!(#msg, #repr) != () })
+        } else {
+            None
+        };
+
+        let exprs: Vec<Expr> = guard
+            .into_iter()
+            .chain(std::iter::once(cond.clone()))
+            .chain(printer)
+            .collect();
+
+        if let [expr] = exprs.as_slice() {
             expr.clone()
         } else {
-            parse_quote! {
-                ( #cfg_guard #expr #report_expr )
-            }
+            parse_quote! { ( #(#exprs)||* ) }
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -318,7 +318,7 @@ impl CheckSettings {
     fn build_precond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr) -> Stmt {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        let check = self.build_cond_check(msg, cfg, &eval, &repr);
+        let check = self.build_cond_check(msg, cfg, eval, &repr);
         parse_quote! {
             let __anodized_pre = __anodized_pre & #check;
         }
@@ -337,14 +337,14 @@ impl CheckSettings {
                 let eval = build_cond_eval(&parse_quote! {
                     { let #brw_pat = __anodized_output; #expr }
                 });
-                let check = self.build_cond_check(msg, cfg, &eval, &repr);
+                let check = self.build_cond_check(msg, cfg, eval, &repr);
                 parse_quote! {
                     let __anodized_post = __anodized_post & #check;
                 }
             }
             Some(TamePat::Invertible(inv_pat)) => {
                 let eval = build_cond_eval(expr);
-                let check = self.build_cond_check(msg, cfg, &eval, &repr);
+                let check = self.build_cond_check(msg, cfg, eval, &repr);
                 parse_quote! {
                     let (__anodized_post, __anodized_output) = {
                         let #inv_pat = __anodized_output;
@@ -354,7 +354,7 @@ impl CheckSettings {
             }
             None => {
                 let eval = build_cond_eval(expr);
-                let check = self.build_cond_check(msg, cfg, &eval, &repr);
+                let check = self.build_cond_check(msg, cfg, eval, &repr);
                 parse_quote! {
                     let __anodized_post = __anodized_post & #check;
                 }
@@ -362,7 +362,7 @@ impl CheckSettings {
         }
     }
 
-    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
+    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: Expr, repr: &str) -> Expr {
         let guard: Option<Expr> = if self.does_print || self.does_panic.is_some() {
             cfg.as_ref().map(|meta| parse_quote! { !cfg!(#meta) })
         } else {
@@ -375,16 +375,13 @@ impl CheckSettings {
             None
         };
 
-        let exprs: Vec<Expr> = guard
-            .into_iter()
-            .chain(std::iter::once(cond.clone()))
-            .chain(printer)
-            .collect();
+        let maybe_exprs = [guard, Some(cond), printer];
+        let exprs = maybe_exprs.iter().flatten();
 
-        if let [expr] = exprs.as_slice() {
-            expr.clone()
-        } else {
+        if exprs.clone().count() > 1 {
             parse_quote! { ( #(#exprs)||* ) }
+        } else {
+            parse_quote! { #(#exprs)||* }
         }
     }
 

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -93,13 +93,13 @@ fn default_instrument_item_fn() {
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2));
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3));
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_4);
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_5);
-                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
+                let mut __anodized_pre = true;
+                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
+                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2));
+                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3));
+                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_4);
+                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_5);
+                __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
@@ -165,19 +165,19 @@ fn emit_try_fn_instrument_item_fn() {
             -> ::anodized::result::Result<RET_TYPE>
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
-                        || eprintln!("precondition failed: {}", "COND_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
-                        || eprintln!("precondition failed: {}", "COND_2") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
-                        || eprintln!("precondition failed: {}", "COND_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_4)
-                        || eprintln!("preinvariant failed: {}", "COND_4") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_5)
-                        || eprintln!("preinvariant failed: {}", "COND_5") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
-                        || eprintln!("preinvariant failed: {}", "COND_6") != ());
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                    || eprintln!("precondition failed: {}", "COND_1") != ());
+                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
+                    || eprintln!("precondition failed: {}", "COND_2") != ());
+                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
+                    || eprintln!("precondition failed: {}", "COND_3") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_4)
+                    || eprintln!("preinvariant failed: {}", "COND_4") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_5)
+                    || eprintln!("preinvariant failed: {}", "COND_5") != ());
+                __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
+                    || eprintln!("preinvariant failed: {}", "COND_6") != ());
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
                 }
@@ -251,8 +251,8 @@ fn simple_requires() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -290,8 +290,8 @@ fn requires_disable_runtime_checks() {
     let expected: Block = parse_quote! {
         {
             if false {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| CONDITION_1);
+                let mut __anodized_pre = true;
+                __anodized_pre &= ::anodized::__::eval::<bool>(|| CONDITION_1);
                 if !__anodized_pre {}
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
@@ -317,8 +317,8 @@ fn requires_no_panic_runtime() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {}
             }
@@ -349,8 +349,8 @@ fn simple_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -387,7 +387,7 @@ fn simple_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
+                let mut __anodized_pre = true;
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -424,11 +424,11 @@ fn simple_requires_and_maintains() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -465,8 +465,8 @@ fn simple_requires_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -504,8 +504,8 @@ fn simple_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
@@ -546,11 +546,11 @@ fn simple_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -590,11 +590,11 @@ fn simple_async_requires_maintains_and_ensures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -634,15 +634,15 @@ fn multiple_conditions_in_clauses() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -684,7 +684,7 @@ fn postcond_closure_form() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
+                let mut __anodized_pre = true;
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -729,7 +729,7 @@ fn ensures_with_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
+                let mut __anodized_pre = true;
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -776,11 +776,11 @@ fn cfg_attributes() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -822,13 +822,13 @@ fn cfg_on_single_and_list_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -878,19 +878,19 @@ fn complex_mixed_conditions() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_5)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_5") != ());
-                let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
-                        || eprintln!("preinvariant failed: {}", "CONDITION_6") != ());
+                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("precondition failed: {}", "CONDITION_3") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_5") != ());
+                __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
+                    || eprintln!("preinvariant failed: {}", "CONDITION_6") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
@@ -944,8 +944,8 @@ fn captures() {
     let expected: Block = parse_quote! {
         {
             if true {
-                let __anodized_pre = true;
-                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
                     || eprintln!("precondition failed: {}", "CONDITION_1") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -94,12 +94,12 @@ fn default_instrument_item_fn() {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             if false {
                 let mut __anodized_pre = true;
-                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
-                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2));
-                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3));
-                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_4);
-                __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_5);
-                __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_3));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_4));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_5));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_6));
                 if !__anodized_pre {}
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
@@ -109,22 +109,22 @@ fn default_instrument_item_fn() {
             );
             if false {
                 let mut __anodized_post = true;
-                __anodized_post &= ::anodized::__::eval::<bool>(|| COND_4);
-                __anodized_post &= ::anodized::__::eval::<bool>(|| COND_5);
-                __anodized_post &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6));
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_4));
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_5));
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_6));
                 {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= ::anodized::__::eval::<bool>(|| COND_7);
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_7));
                     __anodized_output = PAT_1;
                 }
                 {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_8));
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_8));
                     __anodized_output = PAT_1;
                 }
                 {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_9));
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_9));
                     __anodized_output = PAT_1;
                 }
                 if !__anodized_post {}
@@ -291,7 +291,7 @@ fn requires_disable_runtime_checks() {
         {
             if false {
                 let mut __anodized_pre = true;
-                __anodized_pre &= ::anodized::__::eval::<bool>(|| CONDITION_1);
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
                 if !__anodized_pre {}
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -105,25 +105,22 @@ fn default_instrument_item_fn() {
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
-            let mut __anodized_post = true;
-            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_4));
-            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_5));
-            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_6));
-            {
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_4));
+            let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_5));
+            let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_6));
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_7));
-                __anodized_output = PAT_1;
-            }
-            {
+                (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_7)), PAT_1)
+            };
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_8));
-                __anodized_output = PAT_1;
-            }
-            {
+                (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_8)), PAT_1)
+            };
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_9));
-                __anodized_output = PAT_1;
-            }
+                (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_9)), PAT_1)
+            };
             if !__anodized_post {}
             __anodized_output
         }
@@ -181,31 +178,28 @@ fn emit_try_fn_instrument_item_fn() {
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| COND_4)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_4)
                     || eprintln!("postinvariant failed: {}", "COND_4") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| COND_5)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_5)
                     || eprintln!("postinvariant failed: {}", "COND_5") != ());
-            __anodized_post &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
+            let __anodized_post = __anodized_post & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
                     || eprintln!("postinvariant failed: {}", "COND_6") != ());
-            {
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_7)
-                        || eprintln!("postcondition failed: {}", "COND_7") != ());
-                __anodized_output = PAT_1;
-            }
-            {
+                (__anodized_post & (::anodized::__::eval::<bool>(|| COND_7)
+                        || eprintln!("postcondition failed: {}", "COND_7") != ()), PAT_1)
+            };
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_8)
-                        || eprintln!("postcondition failed: {}", "COND_8") != ());
-                __anodized_output = PAT_1;
-            }
-            {
+                (__anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_8)
+                        || eprintln!("postcondition failed: {}", "COND_8") != ()), PAT_1)
+            };
+            let (__anodized_post, __anodized_output) = {
                 let PAT_1 = __anodized_output;
-                __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_9)
-                        || eprintln!("postcondition failed: {}", "COND_9") != ());
-                __anodized_output = PAT_1;
-            }
+                (__anodized_post & (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_9)
+                        || eprintln!("postcondition failed: {}", "COND_9") != ()), PAT_1)
+            };
             if !__anodized_post {
                 return ::anodized::result::post_err(__anodized_output);
             }
@@ -249,7 +243,7 @@ fn simple_requires() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
+            let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
             }
@@ -281,7 +275,7 @@ fn requires_disable_runtime_checks() {
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
+            let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
         }
@@ -305,7 +299,7 @@ fn requires_no_panic_runtime() {
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
+            let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
         }
@@ -335,8 +329,8 @@ fn simple_maintains() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -367,8 +361,8 @@ fn simple_ensures() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -404,8 +398,8 @@ fn simple_requires_and_maintains() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -439,8 +433,8 @@ fn simple_requires_and_ensures() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -474,10 +468,10 @@ fn simple_maintains_and_ensures() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -514,10 +508,10 @@ fn simple_requires_maintains_and_ensures() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -554,10 +548,10 @@ fn simple_async_requires_maintains_and_ensures() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((async || #ret_type #body)().await);
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -598,14 +592,14 @@ fn multiple_conditions_in_clauses() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                     || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_5)
                     || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_6)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_6)
                     || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -636,13 +630,12 @@ fn postcond_closure_form() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            {
+            let __anodized_post = true;
+            let (__anodized_post, __anodized_output) = {
                 let OUTPUT_PATTERN = __anodized_output;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                __anodized_output = OUTPUT_PATTERN;
-            }
+                (__anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ()), OUTPUT_PATTERN)
+            };
             if !__anodized_post {
                 panic!("postcondition failed");
             }
@@ -677,14 +670,14 @@ fn ensures_with_mixed_conditions() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                     || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                     || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -724,10 +717,10 @@ fn cfg_attributes() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -768,14 +761,14 @@ fn cfg_on_single_and_list_conditions() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
-            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_4)
                     || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_5)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_5)
                     || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -826,18 +819,18 @@ fn complex_mixed_conditions() {
                 panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_5)
                     || eprintln!("postinvariant failed: {}", "CONDITION_5") != ());
-            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
                     || eprintln!("postinvariant failed: {}", "CONDITION_6") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_7)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_7)
                     || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
-            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_8)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_8)
                     || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
-            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_9)
+            let __anodized_post = __anodized_post & (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_9)
                     || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -882,10 +875,10 @@ fn captures() {
                 ::anodized::__::eval(|| EXPR_2),
                 (|| #ret_type #body)(),
             );
-            let mut __anodized_post = true;
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_post = true;
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                     || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
             if !__anodized_post {
                 panic!("postcondition failed");

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -100,7 +100,7 @@ fn default_instrument_item_fn() {
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_5));
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_6));
             if !__anodized_pre {}
-            let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
+            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
@@ -173,7 +173,7 @@ fn emit_try_fn_instrument_item_fn() {
             if !__anodized_pre {
                 return ::anodized::result::pre_err();
             }
-            let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
+            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
@@ -242,7 +242,7 @@ fn simple_requires() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -274,7 +274,7 @@ fn requires_disable_runtime_checks() {
             let __anodized_pre = true;
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -298,7 +298,7 @@ fn requires_no_panic_runtime() {
             let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -328,7 +328,7 @@ fn simple_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -360,7 +360,7 @@ fn simple_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -397,7 +397,7 @@ fn simple_requires_and_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -432,7 +432,7 @@ fn simple_requires_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -467,7 +467,7 @@ fn simple_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -507,7 +507,7 @@ fn simple_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -547,7 +547,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((async || #ret_type #body)().await);
+            let (__anodized_output) = ((async || #ret_type #body)().await);
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -591,7 +591,7 @@ fn multiple_conditions_in_clauses() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
@@ -629,7 +629,7 @@ fn postcond_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = {
                 let OUTPUT_PATTERN = __anodized_output;
@@ -669,7 +669,7 @@ fn ensures_with_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -716,7 +716,7 @@ fn cfg_attributes() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -760,7 +760,7 @@ fn cfg_on_single_and_list_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -818,7 +818,7 @@ fn complex_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (mut __anodized_output) = ((|| #ret_type #body)());
+            let (__anodized_output) = ((|| #ret_type #body)());
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
@@ -870,7 +870,7 @@ fn captures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (ALIAS_1, ALIAS_2, mut __anodized_output) = (
+            let (ALIAS_1, ALIAS_2, __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| #ret_type #body)(),

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -92,43 +92,39 @@ fn default_instrument_item_fn() {
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            if false {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_4));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_5));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_6));
-                if !__anodized_pre {}
-            }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_3));
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_4));
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_5));
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_6));
+            if !__anodized_pre {}
             let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
-            if false {
-                let mut __anodized_post = true;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_4));
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_5));
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_6));
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_7));
-                    __anodized_output = PAT_1;
-                }
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_8));
-                    __anodized_output = PAT_1;
-                }
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_9));
-                    __anodized_output = PAT_1;
-                }
-                if !__anodized_post {}
+            let mut __anodized_post = true;
+            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_4));
+            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_5));
+            __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_6));
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_7));
+                __anodized_output = PAT_1;
             }
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_8));
+                __anodized_output = PAT_1;
+            }
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_9));
+                __anodized_output = PAT_1;
+            }
+            if !__anodized_post {}
             __anodized_output
         }
     };
@@ -164,58 +160,54 @@ fn emit_try_fn_instrument_item_fn() {
         fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
             -> ::anodized::result::Result<RET_TYPE>
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
-                    || eprintln!("precondition failed: {}", "COND_1") != ());
-                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
-                    || eprintln!("precondition failed: {}", "COND_2") != ());
-                __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
-                    || eprintln!("precondition failed: {}", "COND_3") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_4)
-                    || eprintln!("preinvariant failed: {}", "COND_4") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_5)
-                    || eprintln!("preinvariant failed: {}", "COND_5") != ());
-                __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
-                    || eprintln!("preinvariant failed: {}", "COND_6") != ());
-                if !__anodized_pre {
-                    return ::anodized::result::pre_err();
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                || eprintln!("precondition failed: {}", "COND_1") != ());
+            __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
+                || eprintln!("precondition failed: {}", "COND_2") != ());
+            __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
+                || eprintln!("precondition failed: {}", "COND_3") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_4)
+                || eprintln!("preinvariant failed: {}", "COND_4") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_5)
+                || eprintln!("preinvariant failed: {}", "COND_5") != ());
+            __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
+                || eprintln!("preinvariant failed: {}", "COND_6") != ());
+            if !__anodized_pre {
+                return ::anodized::result::pre_err();
             }
             let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| -> RET_TYPE { BODY })(),
             );
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_4)
-                        || eprintln!("postinvariant failed: {}", "COND_4") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_5)
-                        || eprintln!("postinvariant failed: {}", "COND_5") != ());
-                __anodized_post &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
-                        || eprintln!("postinvariant failed: {}", "COND_6") != ());
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_7)
-                            || eprintln!("postcondition failed: {}", "COND_7") != ());
-                    __anodized_output = PAT_1;
-                }
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_8)
-                            || eprintln!("postcondition failed: {}", "COND_8") != ());
-                    __anodized_output = PAT_1;
-                }
-                {
-                    let PAT_1 = __anodized_output;
-                    __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_9)
-                            || eprintln!("postcondition failed: {}", "COND_9") != ());
-                    __anodized_output = PAT_1;
-                }
-                if !__anodized_post {
-                    return ::anodized::result::post_err(__anodized_output);
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| COND_4)
+                    || eprintln!("postinvariant failed: {}", "COND_4") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| COND_5)
+                    || eprintln!("postinvariant failed: {}", "COND_5") != ());
+            __anodized_post &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
+                    || eprintln!("postinvariant failed: {}", "COND_6") != ());
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_7)
+                        || eprintln!("postcondition failed: {}", "COND_7") != ());
+                __anodized_output = PAT_1;
+            }
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_8)
+                        || eprintln!("postcondition failed: {}", "COND_8") != ());
+                __anodized_output = PAT_1;
+            }
+            {
+                let PAT_1 = __anodized_output;
+                __anodized_post &= (!cfg!(META_3) || ::anodized::__::eval::<bool>(|| COND_9)
+                        || eprintln!("postcondition failed: {}", "COND_9") != ());
+                __anodized_output = PAT_1;
+            }
+            if !__anodized_post {
+                return ::anodized::result::post_err(__anodized_output);
             }
             Ok(__anodized_output)
         }
@@ -250,20 +242,16 @@ fn simple_requires() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -289,16 +277,12 @@ fn requires_disable_runtime_checks() {
         .unwrap();
     let expected: Block = parse_quote! {
         {
-            if false {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
-                if !__anodized_pre {}
-            }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
+            if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if false {
-                let mut __anodized_post = true;
-                if !__anodized_post {}
-            }
+            let mut __anodized_post = true;
+            if !__anodized_post {}
             __anodized_output
         }
     };
@@ -316,17 +300,13 @@ fn requires_no_panic_runtime() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {}
-            }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                if !__anodized_post {}
-            }
+            let mut __anodized_post = true;
+            if !__anodized_post {}
             __anodized_output
         }
     };
@@ -348,22 +328,18 @@ fn simple_maintains() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -386,20 +362,16 @@ fn simple_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -423,24 +395,20 @@ fn simple_requires_and_maintains() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -464,22 +432,18 @@ fn simple_requires_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -503,24 +467,20 @@ fn simple_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -545,26 +505,22 @@ fn simple_requires_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -589,26 +545,22 @@ fn simple_async_requires_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((async || #ret_type #body)().await);
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -633,34 +585,30 @@ fn multiple_conditions_in_clauses() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
-                        || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
-                        || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_6)
-                        || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                    || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+                    || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_6)
+                    || eprintln!("postcondition failed: {}", "CONDITION_6") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -683,24 +631,20 @@ fn postcond_closure_form() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                {
-                    let OUTPUT_PATTERN = __anodized_output;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                        || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                    __anodized_output = OUTPUT_PATTERN;
-                }
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            {
+                let OUTPUT_PATTERN = __anodized_output;
+                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+                __anodized_output = OUTPUT_PATTERN;
+            }
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -728,26 +672,22 @@ fn ensures_with_mixed_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                        || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
-                        || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                    || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -775,26 +715,22 @@ fn cfg_attributes() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -821,32 +757,28 @@ fn cfg_on_single_and_list_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
-                __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_4)
-                        || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
-                __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_5)
-                        || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
+            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_4)
+                    || eprintln!("postcondition failed: {}", "CONDITION_4") != ());
+            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_5)
+                    || eprintln!("postcondition failed: {}", "CONDITION_5") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -877,42 +809,38 @@ fn complex_mixed_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-                __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
-                    || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_5)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_5") != ());
-                __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
-                    || eprintln!("preinvariant failed: {}", "CONDITION_6") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("precondition failed: {}", "CONDITION_2") != ());
+            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
+                || eprintln!("precondition failed: {}", "CONDITION_3") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+                || eprintln!("preinvariant failed: {}", "CONDITION_5") != ());
+            __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
+                || eprintln!("preinvariant failed: {}", "CONDITION_6") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (mut __anodized_output) = ((|| #ret_type #body)());
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
-                    || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
-                        || eprintln!("postinvariant failed: {}", "CONDITION_5") != ());
-                __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
-                        || eprintln!("postinvariant failed: {}", "CONDITION_6") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_7)
-                        || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
-                __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_8)
-                        || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
-                __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_9)
-                        || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+                || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+                    || eprintln!("postinvariant failed: {}", "CONDITION_5") != ());
+            __anodized_post &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
+                    || eprintln!("postinvariant failed: {}", "CONDITION_6") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_7)
+                    || eprintln!("postcondition failed: {}", "CONDITION_7") != ());
+            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_8)
+                    || eprintln!("postcondition failed: {}", "CONDITION_8") != ());
+            __anodized_post &= (!cfg!(SETTING_3) || ::anodized::__::eval::<bool>(|| CONDITION_9)
+                    || eprintln!("postcondition failed: {}", "CONDITION_9") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }
@@ -943,28 +871,24 @@ fn captures() {
 
     let expected: Block = parse_quote! {
         {
-            if true {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
-                    || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-                if !__anodized_pre {
-                    panic!("precondition failed");
-                }
+            let mut __anodized_pre = true;
+            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+                || eprintln!("precondition failed: {}", "CONDITION_1") != ());
+            if !__anodized_pre {
+                panic!("precondition failed");
             }
             let (ALIAS_1, ALIAS_2, mut __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
                 (|| #ret_type #body)(),
             );
-            if true {
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
-                    || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
-                __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
-                        || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
-                if !__anodized_post {
-                    panic!("postcondition failed");
-                }
+            let mut __anodized_post = true;
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+                || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
+            __anodized_post &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+                    || eprintln!("postcondition failed: {}", "CONDITION_3") != ());
+            if !__anodized_post {
+                panic!("postcondition failed");
             }
             __anodized_output
         }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -92,13 +92,13 @@ fn default_instrument_item_fn() {
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_4));
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_5));
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_6));
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_3));
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_4));
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_5));
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_6));
             if !__anodized_pre {}
             let (ALIAS_1, (ALIAS_2, ALIAS_3), mut __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
@@ -160,18 +160,18 @@ fn emit_try_fn_instrument_item_fn() {
         fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
             -> ::anodized::result::Result<RET_TYPE>
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                 || eprintln!("precondition failed: {}", "COND_1") != ());
-            __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
+            let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_2)
                 || eprintln!("precondition failed: {}", "COND_2") != ());
-            __anodized_pre &= (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
+            let __anodized_pre = __anodized_pre & (!cfg!(META_1) || ::anodized::__::eval::<bool>(|| COND_3)
                 || eprintln!("precondition failed: {}", "COND_3") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_4)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_4)
                 || eprintln!("preinvariant failed: {}", "COND_4") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_5)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_5)
                 || eprintln!("preinvariant failed: {}", "COND_5") != ());
-            __anodized_pre &= (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
+            let __anodized_pre = __anodized_pre & (!cfg!(META_2) || ::anodized::__::eval::<bool>(|| COND_6)
                 || eprintln!("preinvariant failed: {}", "COND_6") != ());
             if !__anodized_pre {
                 return ::anodized::result::pre_err();
@@ -242,8 +242,8 @@ fn simple_requires() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -277,8 +277,8 @@ fn requires_disable_runtime_checks() {
         .unwrap();
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
             let mut __anodized_post = true;
@@ -300,8 +300,8 @@ fn requires_no_panic_runtime() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
             let (mut __anodized_output) = ((|| #ret_type #body)());
@@ -328,8 +328,8 @@ fn simple_maintains() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -362,7 +362,7 @@ fn simple_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
+            let __anodized_pre = true;
             if !__anodized_pre {
                 panic!("precondition failed");
             }
@@ -395,10 +395,10 @@ fn simple_requires_and_maintains() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -432,8 +432,8 @@ fn simple_requires_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -467,8 +467,8 @@ fn simple_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("preinvariant failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -505,10 +505,10 @@ fn simple_requires_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -545,10 +545,10 @@ fn simple_async_requires_maintains_and_ensures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -585,14 +585,14 @@ fn multiple_conditions_in_clauses() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -631,7 +631,7 @@ fn postcond_closure_form() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
+            let __anodized_pre = true;
             if !__anodized_pre {
                 panic!("precondition failed");
             }
@@ -672,7 +672,7 @@ fn ensures_with_mixed_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
+            let __anodized_pre = true;
             if !__anodized_pre {
                 panic!("precondition failed");
             }
@@ -715,10 +715,10 @@ fn cfg_attributes() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -757,12 +757,12 @@ fn cfg_on_single_and_list_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("preinvariant failed: {}", "CONDITION_2") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("preinvariant failed: {}", "CONDITION_3") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -809,18 +809,18 @@ fn complex_mixed_conditions() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
-            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("precondition failed: {}", "CONDITION_2") != ());
-            __anodized_pre &= (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_1) || ::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("precondition failed: {}", "CONDITION_3") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_4)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("preinvariant failed: {}", "CONDITION_4") != ());
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_5)
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_5)
                 || eprintln!("preinvariant failed: {}", "CONDITION_5") != ());
-            __anodized_pre &= (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
+            let __anodized_pre = __anodized_pre & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_6)
                 || eprintln!("preinvariant failed: {}", "CONDITION_6") != ());
             if !__anodized_pre {
                 panic!("precondition failed");
@@ -871,8 +871,8 @@ fn captures() {
 
     let expected: Block = parse_quote! {
         {
-            let mut __anodized_pre = true;
-            __anodized_pre &= (::anodized::__::eval::<bool>(|| CONDITION_1)
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {
                 panic!("precondition failed");

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -77,17 +77,17 @@ fn default_instrument_item_impl() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let mut __anodized_pre = true;
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let mut __anodized_post = true;
-                    __anodized_post &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     {
                         let PAT_1 = __anodized_output;
-                        __anodized_post &= ::anodized::__::eval::<bool>(|| COND_3);
+                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
                         __anodized_output = PAT_1;
                     }
                     if !__anodized_post {}

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -80,13 +80,12 @@ fn default_instrument_item_impl() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                let mut __anodized_post = true;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_3)), PAT_1)
+                };
                 if !__anodized_post {}
                 __anodized_output
             }
@@ -144,15 +143,14 @@ fn emit_try_fn_instrument_item_impl() {
                     return ::anodized::result::pre_err();
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                {
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                        || eprintln!("postcondition failed: {}", "COND_3") != ());
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ()), PAT_1)
+                };
                 if !__anodized_post {
                     return ::anodized::result::post_err(__anodized_output);
                 }

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -75,23 +75,19 @@ fn default_instrument_item_impl() {
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                if false {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    if !__anodized_pre {}
-                }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                if false {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {}
+                let mut __anodized_post = true;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
+                    __anodized_output = PAT_1;
                 }
+                if !__anodized_post {}
                 __anodized_output
             }
         }
@@ -139,30 +135,26 @@ fn emit_try_fn_instrument_item_impl() {
             fn __anodized_fn_try_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::anodized::result::Result<RET_TYPE>
             {
-                if true {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
-                        || eprintln!("precondition failed: {}", "COND_1") != ());
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
-                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
-                    if !__anodized_pre {
-                        return ::anodized::result::pre_err();
-                    }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                    || eprintln!("precondition failed: {}", "COND_1") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                    || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                if !__anodized_pre {
+                    return ::anodized::result::pre_err();
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                if true {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                            || eprintln!("postcondition failed: {}", "COND_3") != ());
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {
-                        return ::anodized::result::post_err(__anodized_output);
-                    }
+                let mut __anodized_post = true;
+                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("postinvariant failed: {}", "COND_2") != ());
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ());
+                    __anodized_output = PAT_1;
+                }
+                if !__anodized_post {
+                    return ::anodized::result::post_err(__anodized_output);
                 }
                 Ok(__anodized_output)
             }

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -75,9 +75,9 @@ fn default_instrument_item_impl() {
     let expected: TokenStream = parse_quote! {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let mut __anodized_post = true;
@@ -135,10 +135,10 @@ fn emit_try_fn_instrument_item_impl() {
             fn __anodized_fn_try_FUNC(PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::anodized::result::Result<RET_TYPE>
             {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                     || eprintln!("precondition failed: {}", "COND_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                     || eprintln!("preinvariant failed: {}", "COND_2") != ());
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -79,7 +79,7 @@ fn default_instrument_item_impl() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
+                let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = {
@@ -142,7 +142,7 @@ fn emit_try_fn_instrument_item_impl() {
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
                 }
-                let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
+                let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -76,9 +76,9 @@ fn default_instrument_item_impl() {
         impl IMPL_TYPE {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
@@ -140,11 +140,11 @@ fn emit_try_fn_instrument_item_impl() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
-                            || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                        || eprintln!("precondition failed: {}", "COND_1") != ());
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         return ::anodized::result::pre_err();
                     }

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -95,17 +95,17 @@ fn default_instrument_item_trait() {
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
                     let mut __anodized_pre = true;
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 if false {
                     let mut __anodized_post = true;
-                    __anodized_post &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     {
                         let PAT_1 = __anodized_output;
-                        __anodized_post &= ::anodized::__::eval::<bool>(|| COND_3);
+                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
                         __anodized_output = PAT_1;
                     }
                     if !__anodized_post {}
@@ -293,17 +293,17 @@ fn default_instrument_item_impl_trait() {
                 };
                 if false {
                     let mut __anodized_pre = true;
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
-                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
                 if false {
                     let mut __anodized_post = true;
-                    __anodized_post &= ::anodized::__::eval::<bool>(|| COND_2);
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
                     {
                         let PAT_1 = __anodized_output;
-                        __anodized_post &= ::anodized::__::eval::<bool>(|| COND_3);
+                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
                         __anodized_output = PAT_1;
                     }
                     if !__anodized_post {}

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -93,9 +93,9 @@ fn default_instrument_item_trait() {
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 let mut __anodized_post = true;
@@ -166,10 +166,10 @@ fn emit_try_fn_instrument_item_trait() {
             fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::anodized::result::Result<RET_TYPE>
             {
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                     || eprintln!("precondition failed: {}", "COND_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                     || eprintln!("preinvariant failed: {}", "COND_2") != ());
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
@@ -283,9 +283,9 @@ fn default_instrument_item_impl_trait() {
                         "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
                     );
                 };
-                let mut __anodized_pre = true;
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
+                let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let mut __anodized_post = true;
@@ -340,10 +340,10 @@ fn emit_try_fn_instrument_item_impl_trait() {
                         "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
                     );
                 };
-                let mut __anodized_pre = true;
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
                     || eprintln!("precondition failed: {}", "COND_1") != ());
-                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
                     || eprintln!("preinvariant failed: {}", "COND_2") != ());
                 if !__anodized_pre {
                     panic!("precondition failed");

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -97,7 +97,7 @@ fn default_instrument_item_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
+                let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = {
@@ -173,7 +173,7 @@ fn emit_try_fn_instrument_item_trait() {
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
                 }
-                let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
+                let (__anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());
@@ -285,7 +285,7 @@ fn default_instrument_item_impl_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
+                let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = {
@@ -345,7 +345,7 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
-                let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
+                let (__anodized_output) = ((|| -> RET_TYPE { BODY })());
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -98,13 +98,12 @@ fn default_instrument_item_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
-                let mut __anodized_post = true;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_3)), PAT_1)
+                };
                 if !__anodized_post {}
                 __anodized_output
             }
@@ -175,15 +174,14 @@ fn emit_try_fn_instrument_item_trait() {
                     return ::anodized::result::pre_err();
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                {
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                        || eprintln!("postcondition failed: {}", "COND_3") != ());
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ()), PAT_1)
+                };
                 if !__anodized_post {
                     return ::anodized::result::post_err(__anodized_output);
                 }
@@ -288,13 +286,12 @@ fn default_instrument_item_impl_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                let mut __anodized_post = true;
-                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                {
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_3)), PAT_1)
+                };
                 if !__anodized_post {}
                 __anodized_output
             }
@@ -349,15 +346,14 @@ fn emit_try_fn_instrument_item_impl_trait() {
                     panic!("precondition failed");
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                let mut __anodized_post = true;
-                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                let __anodized_post = true;
+                let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                {
+                let (__anodized_post, __anodized_output) = {
                     let PAT_1 = __anodized_output;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                        || eprintln!("postcondition failed: {}", "COND_3") != ());
-                    __anodized_output = PAT_1;
-                }
+                    (__anodized_post & (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ()), PAT_1)
+                };
                 if !__anodized_post {
                     panic!("postcondition failed");
                 }

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -94,9 +94,9 @@ fn default_instrument_item_trait() {
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
                 if false {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
@@ -171,11 +171,11 @@ fn emit_try_fn_instrument_item_trait() {
                 -> ::anodized::result::Result<RET_TYPE>
             {
                 if true {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
-                            || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                        || eprintln!("precondition failed: {}", "COND_1") != ());
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         return ::anodized::result::pre_err();
                     }
@@ -292,9 +292,9 @@ fn default_instrument_item_impl_trait() {
                     );
                 };
                 if false {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
-                    let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_1);
+                    __anodized_pre &= ::anodized::__::eval::<bool>(|| COND_2);
                     if !__anodized_pre {}
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
@@ -353,11 +353,11 @@ fn emit_try_fn_instrument_item_impl_trait() {
                     );
                 };
                 if true {
-                    let __anodized_pre = true;
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_1)
-                            || eprintln!("precondition failed: {}", "COND_1") != ());
-                    let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                    let mut __anodized_pre = true;
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                        || eprintln!("precondition failed: {}", "COND_1") != ());
+                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
                     if !__anodized_pre {
                         panic!("precondition failed");
                     }

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -93,23 +93,19 @@ fn default_instrument_item_trait() {
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-                if false {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    if !__anodized_pre {}
-                }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
-                if false {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {}
+                let mut __anodized_post = true;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
+                    __anodized_output = PAT_1;
                 }
+                if !__anodized_post {}
                 __anodized_output
             }
         }
@@ -170,30 +166,26 @@ fn emit_try_fn_instrument_item_trait() {
             fn __anodized_fn_try_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2)
                 -> ::anodized::result::Result<RET_TYPE>
             {
-                if true {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
-                        || eprintln!("precondition failed: {}", "COND_1") != ());
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
-                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
-                    if !__anodized_pre {
-                        return ::anodized::result::pre_err();
-                    }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                    || eprintln!("precondition failed: {}", "COND_1") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                    || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                if !__anodized_pre {
+                    return ::anodized::result::pre_err();
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) })());
-                if true {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                            || eprintln!("postcondition failed: {}", "COND_3") != ());
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {
-                        return ::anodized::result::post_err(__anodized_output);
-                    }
+                let mut __anodized_post = true;
+                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("postinvariant failed: {}", "COND_2") != ());
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ());
+                    __anodized_output = PAT_1;
+                }
+                if !__anodized_post {
+                    return ::anodized::result::post_err(__anodized_output);
                 }
                 Ok(__anodized_output)
             }
@@ -291,23 +283,19 @@ fn default_instrument_item_impl_trait() {
                         "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
                     );
                 };
-                if false {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
-                    __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    if !__anodized_pre {}
-                }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_1));
+                __anodized_pre &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                if !__anodized_pre {}
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                if false {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {}
+                let mut __anodized_post = true;
+                __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_2));
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (true || ::anodized::__::eval::<bool>(|| COND_3));
+                    __anodized_output = PAT_1;
                 }
+                if !__anodized_post {}
                 __anodized_output
             }
         }
@@ -352,30 +340,26 @@ fn emit_try_fn_instrument_item_impl_trait() {
                         "the qualifiers on the impl `IMPL_TYPE::FUNC` cannot be weaker than the qualifiers on the trait `TRAIT::FUNC`",
                     );
                 };
-                if true {
-                    let mut __anodized_pre = true;
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
-                        || eprintln!("precondition failed: {}", "COND_1") != ());
-                    __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
-                        || eprintln!("preinvariant failed: {}", "COND_2") != ());
-                    if !__anodized_pre {
-                        panic!("precondition failed");
-                    }
+                let mut __anodized_pre = true;
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_1)
+                    || eprintln!("precondition failed: {}", "COND_1") != ());
+                __anodized_pre &= (::anodized::__::eval::<bool>(|| COND_2)
+                    || eprintln!("preinvariant failed: {}", "COND_2") != ());
+                if !__anodized_pre {
+                    panic!("precondition failed");
                 }
                 let (mut __anodized_output) = ((|| -> RET_TYPE { BODY })());
-                if true {
-                    let mut __anodized_post = true;
-                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
-                            || eprintln!("postinvariant failed: {}", "COND_2") != ());
-                    {
-                        let PAT_1 = __anodized_output;
-                        __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
-                            || eprintln!("postcondition failed: {}", "COND_3") != ());
-                        __anodized_output = PAT_1;
-                    }
-                    if !__anodized_post {
-                        panic!("postcondition failed");
-                    }
+                let mut __anodized_post = true;
+                __anodized_post &= (::anodized::__::eval::<bool>(|| COND_2)
+                        || eprintln!("postinvariant failed: {}", "COND_2") != ());
+                {
+                    let PAT_1 = __anodized_output;
+                    __anodized_post &= (::anodized::__::eval::<bool>(|| COND_3)
+                        || eprintln!("postcondition failed: {}", "COND_3") != ());
+                    __anodized_output = PAT_1;
+                }
+                if !__anodized_post {
+                    panic!("postcondition failed");
                 }
                 __anodized_output
             }


### PR DESCRIPTION
- Make pre/postcondition handling uniform.
- Remove the need for the top-level execution guards.
- Remove the need for `mut` on internal `__anodized_*` bindings.
- Update unit tests and documentation.